### PR TITLE
Add option to load API Keys from string (useful for testing)

### DIFF
--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -120,6 +120,17 @@ namespace ExchangeSharp
         }
 
         /// <summary>
+        /// Load API keys from unsecure strings
+        /// </summary>
+        /// <param name="publicApiKey">Public Api Key</param>
+        /// <param name="privateApiKey">Private Api Key</param>
+        public virtual void LoadAPIKeysUnsecure(string publicApiKey, string privateApiKey)
+        {
+            PublicApiKey = publicApiKey.ToSecureString();
+            PrivateApiKey = privateApiKey.ToSecureString();
+        }
+
+        /// <summary>
         /// Make a request to a path on the API
         /// </summary>
         /// <param name="url">Path and query</param>


### PR DESCRIPTION
I think this is a really useful option for development or if alterative encryption method is used

Sample:

```
ExchangeBinanceAPI binanceApi = new ExchangeBinanceAPI();
binanceApi.LoadAPIKeysUnsecure("PUBLICAPIKEY", "PRIVATEAPIKEY");
Console.WriteLine(binanceApi.GetAmounts().Keys);
```