### PR TITLE
Implementing GetOpenOrderDetails for Kraken

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -531,7 +531,8 @@ namespace ExchangeSharp
             {
                 Amount = token["origQty"].ConvertInvariant<decimal>(),
                 AmountFilled = token["executedQty"].ConvertInvariant<decimal>(),
-                AveragePrice = token["price"].ConvertInvariant<decimal>(),
+                Price = token["price"].ConvertInvariant<decimal>(),
+                // TODO: AveragePrice should be calculated by 'fills'
                 IsBuy = token["side"].ToStringInvariant() == "BUY",
                 OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(token["time"].ConvertInvariant<long>(token["transactTime"].ConvertInvariant<long>())),
                 OrderId = token["orderId"].ToStringInvariant(),

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -532,10 +532,12 @@ namespace ExchangeSharp
         {
             decimal amount = order["original_amount"].ConvertInvariant<decimal>();
             decimal amountFilled = order["executed_amount"].ConvertInvariant<decimal>();
+            decimal price = order["price"].ConvertInvariant<decimal>();
             return new ExchangeOrderResult
             {
                 Amount = amount,
                 AmountFilled = amountFilled,
+                Price = price,
                 AveragePrice = order["avg_execution_price"].ConvertInvariant<decimal>(order["price"].ConvertInvariant<decimal>()),
                 Message = string.Empty,
                 OrderId = order["id"].ToStringInvariant(),
@@ -570,6 +572,7 @@ namespace ExchangeSharp
             {
                 Amount = amount,
                 AmountFilled = amount,
+                Price = order[6].ConvertInvariant<decimal>(),
                 AveragePrice = order[7].ConvertInvariant<decimal>(),
                 IsBuy = (amount > 0m),
                 OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(order[8].ConvertInvariant<long>()),
@@ -605,6 +608,7 @@ namespace ExchangeSharp
                 {
                     ExchangeOrderResult append = new ExchangeOrderResult { Symbol = kv.Key, OrderId = trade[3].ToStringInvariant() };
                     append.Amount = append.AmountFilled = Math.Abs(trade[4].ConvertInvariant<decimal>());
+                    append.Price = trade[7].ConvertInvariant<decimal>();
                     append.AveragePrice = trade[5].ConvertInvariant<decimal>();
                     append.IsBuy = trade[4].ConvertInvariant<decimal>() >= 0m;
                     append.OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(trade[2].ConvertInvariant<long>());

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -74,6 +74,7 @@ namespace ExchangeSharp
             decimal amountFilled = amount - remaining;
             order.Amount = amount;
             order.AmountFilled = amountFilled;
+            order.Price = token["Price"].ConvertInvariant<decimal>();
             order.AveragePrice = token["PricePerUnit"].ConvertInvariant<decimal>(token["Price"].ConvertInvariant<decimal>());
             order.Message = string.Empty;
             order.OrderId = token["OrderUuid"].ToStringInvariant();

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -39,11 +39,13 @@ namespace ExchangeSharp
             decimal executedValue = result["executed_value"].ConvertInvariant<decimal>();
             decimal amountFilled = result["filled_size"].ConvertInvariant<decimal>();
             decimal amount = result["size"].ConvertInvariant<decimal>(amountFilled);
+            decimal price = result["price"].ConvertInvariant<decimal>();
             decimal averagePrice = (executedValue <= 0m ? 0m : executedValue / amountFilled);
             ExchangeOrderResult order = new ExchangeOrderResult
             {
                 Amount = amount,
                 AmountFilled = amountFilled,
+                Price = price,
                 AveragePrice = averagePrice,
                 IsBuy = (result["side"].ToStringInvariant() == "buy"),
                 OrderDate = result["created_at"].ConvertInvariant<DateTime>(),

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -40,7 +40,7 @@ namespace ExchangeSharp
             decimal amountFilled = result["filled_size"].ConvertInvariant<decimal>();
             decimal amount = result["size"].ConvertInvariant<decimal>(amountFilled);
             decimal price = result["price"].ConvertInvariant<decimal>();
-            decimal averagePrice = (executedValue <= 0m ? 0m : executedValue / amountFilled);
+            decimal averagePrice = (amountFilled <= 0m ? 0m : executedValue / amountFilled);
             ExchangeOrderResult order = new ExchangeOrderResult
             {
                 Amount = amount,

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -51,7 +51,8 @@ namespace ExchangeSharp
             {
                 Amount = amount,
                 AmountFilled = amountFilled,
-                AveragePrice = result["price"].ConvertInvariant<decimal>(),
+                Price = result["price"].ConvertInvariant<decimal>(),
+                AveragePrice = result["avg_execution_price"].ConvertInvariant<decimal>(),
                 Message = string.Empty,
                 OrderId = result["id"].ToStringInvariant(),
                 Result = (amountFilled == amount ? ExchangeAPIOrderResult.Filled : (amountFilled == 0 ? ExchangeAPIOrderResult.Pending : ExchangeAPIOrderResult.FilledPartially)),

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -81,7 +81,8 @@ namespace ExchangeSharp
                     {
                         order.Amount += token["amount"].ConvertInvariant<decimal>();
                         order.AmountFilled = order.Amount;
-                        order.AveragePrice += token["rate"].ConvertInvariant<decimal>();
+                        order.Price += token["rate"].ConvertInvariant<decimal>();
+                        // TODO: implement AveragePrice - should be calculated from resultingTrades?
                         if (token["type"].ToStringInvariant() == "buy")
                         {
                             order.IsBuy = true;
@@ -98,7 +99,7 @@ namespace ExchangeSharp
             {
                 if (result["rate"] != null)
                 {
-                    order.AveragePrice = result["rate"].ConvertInvariant<decimal>();
+                    order.Price = result["rate"].ConvertInvariant<decimal>();
                 }
                 if (result["startingAmount"] != null)
                 {

--- a/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -85,6 +85,11 @@ namespace ExchangeSharp
         public decimal AmountFilled { get; set; }
 
         /// <summary>
+        /// Price
+        /// </summary>
+        public decimal Price { get; set; }
+
+        /// <summary>
         /// Average price
         /// </summary>
         public decimal AveragePrice { get; set; }


### PR DESCRIPTION
Implementing GetOpenOrderDetails for Kraken.

Also added Price property to ExchangeOrderResult. I'm not sure where the requested price of an order would be located? .. please let me know if there's already a field for it somewhere that I've just missed.. but it seems like the only price field is the AveragePrice which is what is calculated when an order is filled.