### PR TITLE
Collect more market and currency metadata

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -80,6 +80,17 @@ namespace ExchangeSharp
             return symbol?.Replace("_", "-").Replace("/", "-").ToLowerInvariant();
         }
 
+        /// <summary>Gets currencies and related data such as IsEnabled and TxFee (if available)</summary>
+        /// <returns>Collection of Currencies</returns>
+        public IEnumerable<string> GetCurrencies()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>ASYNC - Gets currencies and related data such as IsEnabled and TxFee (if available)</summary>
+        /// <returns>Collection of Currencies</returns>
+        public Task<IEnumerable<string>> GetCurrenciesAsync() => Task.Factory.StartNew(() => GetCurrencies());
+
         /// <summary>
         /// Get exchange symbols
         /// </summary>

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -93,6 +93,18 @@ namespace ExchangeSharp
         public Task<IEnumerable<string>> GetSymbolsAsync() => Task.Factory.StartNew(() => GetSymbols());
 
         /// <summary>
+        /// Get exchange symbols including available metadata such as min trade size and whether the market is active
+        /// </summary>
+        /// <returns>Collection of ExchangeMarkets</returns>
+        public virtual IEnumerable<ExchangeMarket> GetSymbolsMetadata() { throw new NotImplementedException(); }
+
+        /// <summary>
+        /// ASYNC - Get exchange symbols including available metadata such as min trade size and whether the market is active
+        /// </summary>
+        /// <returns>Collection of ExchangeMarkets</returns>
+        public Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync() => Task.Factory.StartNew(() => GetSymbolsMetadata());
+
+        /// <summary>
         /// Get exchange ticker
         /// </summary>
         /// <param name="symbol">Symbol to get ticker for</param>

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -82,14 +82,14 @@ namespace ExchangeSharp
 
         /// <summary>Gets currencies and related data such as IsEnabled and TxFee (if available)</summary>
         /// <returns>Collection of Currencies</returns>
-        public IEnumerable<string> GetCurrencies()
+        public virtual IEnumerable<ExchangeCurrency> GetCurrencies()
         {
             throw new NotImplementedException();
         }
 
         /// <summary>ASYNC - Gets currencies and related data such as IsEnabled and TxFee (if available)</summary>
         /// <returns>Collection of Currencies</returns>
-        public Task<IEnumerable<string>> GetCurrenciesAsync() => Task.Factory.StartNew(() => GetCurrencies());
+        public virtual Task<IEnumerable<ExchangeCurrency>> GetCurrenciesAsync() => Task.Factory.StartNew(() => GetCurrencies());
 
         /// <summary>
         /// Get exchange symbols

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -89,7 +89,7 @@ namespace ExchangeSharp
 
         /// <summary>ASYNC - Gets currencies and related data such as IsEnabled and TxFee (if available)</summary>
         /// <returns>Collection of Currencies</returns>
-        public virtual Task<IEnumerable<ExchangeCurrency>> GetCurrenciesAsync() => Task.Factory.StartNew(() => GetCurrencies());
+        public Task<IEnumerable<ExchangeCurrency>> GetCurrenciesAsync() => Task.Factory.StartNew(this.GetCurrencies);
 
         /// <summary>
         /// Get exchange symbols
@@ -113,7 +113,7 @@ namespace ExchangeSharp
         /// ASYNC - Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
         /// <returns>Collection of ExchangeMarkets</returns>
-        public Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync() => Task.Factory.StartNew(() => GetSymbolsMetadata());
+        public Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync() => Task.Factory.StartNew(this.GetSymbolsMetadata);
 
         /// <summary>
         /// Get exchange ticker

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -135,6 +135,12 @@ namespace ExchangeSharp
             return markets;
         }
 
+        public override IEnumerable<ExchangeCurrency> GetCurrencies()
+        {
+            Console.WriteLine("Binance does not provide data about its currencies via the API.");
+            return new ExchangeCurrency[0];
+        }
+
         public override ExchangeTicker GetTicker(string symbol)
         {
             symbol = NormalizeSymbol(symbol);

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -535,10 +535,10 @@ namespace ExchangeSharp
                     case "POST_TRADING":
                         isActive = true;
                         break;
-                    /* case "END_OF_DAY":
-                        case "HALT":
-                        case "AUCTION_MATCH":
-                        case "BREAK": */
+                        /* case "END_OF_DAY":
+                            case "HALT":
+                            case "AUCTION_MATCH":
+                            case "BREAK": */
                 }
             }
 
@@ -633,27 +633,27 @@ namespace ExchangeSharp
             switch (token["status"].ToStringInvariant())
             {
                 case "NEW":
-                result.Result = ExchangeAPIOrderResult.Pending;
-                break;
+                    result.Result = ExchangeAPIOrderResult.Pending;
+                    break;
 
                 case "PARTIALLY_FILLED":
-                result.Result = ExchangeAPIOrderResult.FilledPartially;
-                break;
+                    result.Result = ExchangeAPIOrderResult.FilledPartially;
+                    break;
 
                 case "FILLED":
-                result.Result = ExchangeAPIOrderResult.Filled;
-                break;
+                    result.Result = ExchangeAPIOrderResult.Filled;
+                    break;
 
                 case "CANCELED":
                 case "PENDING_CANCEL":
                 case "EXPIRED":
                 case "REJECTED":
-                result.Result = ExchangeAPIOrderResult.Canceled;
-                break;
+                    result.Result = ExchangeAPIOrderResult.Canceled;
+                    break;
 
                 default:
-                result.Result = ExchangeAPIOrderResult.Error;
-                break;
+                    result.Result = ExchangeAPIOrderResult.Error;
+                    break;
             }
             return result;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -70,6 +70,71 @@ namespace ExchangeSharp
             return symbols;
         }
 
+        public override IEnumerable<ExchangeMarket> GetSymbolsMetadata()
+        {
+            /*
+             *         {
+            "symbol": "QTUMETH",
+            "status": "TRADING",
+            "baseAsset": "QTUM",
+            "baseAssetPrecision": 8,
+            "quoteAsset": "ETH",
+            "quotePrecision": 8,
+            "orderTypes": [
+                "LIMIT",
+                "LIMIT_MAKER",
+                "MARKET",
+                "STOP_LOSS_LIMIT",
+                "TAKE_PROFIT_LIMIT"
+            ],
+            "icebergAllowed": true,
+            "filters": [
+                {
+                    "filterType": "PRICE_FILTER",
+                    "minPrice": "0.00000100",
+                    "maxPrice": "100000.00000000",
+                    "tickSize": "0.00000100"
+                },
+                {
+                    "filterType": "LOT_SIZE",
+                    "minQty": "0.01000000",
+                    "maxQty": "90000000.00000000",
+                    "stepSize": "0.01000000"
+                },
+                {
+                    "filterType": "MIN_NOTIONAL",
+                    "minNotional": "0.01000000"
+                }
+            ]
+        },
+             */
+
+            var markets = new List<ExchangeMarket>();
+            JToken obj = MakeJsonRequest<JToken>("/exchangeInfo");
+            CheckError(obj);
+            JToken allSymbols = obj["symbols"];
+            foreach (JToken symbol in allSymbols)
+            {
+                var market = new ExchangeMarket();
+                market.MarketName = symbol["symbol"].ToStringUpperInvariant();
+                market.IsActive = this.ParseMarketStatus(symbol["status"].ToStringUpperInvariant());
+                market.BaseCurrency = symbol["quoteAsset"].ToStringUpperInvariant();
+                market.MarketCurrency = symbol["baseAsset"].ToStringUpperInvariant();
+
+                // "LOT_SIZE"
+                JToken filters = symbol["filters"];
+                JToken lotSizeFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "LOT_SIZE"));
+                if (lotSizeFilter != null)
+                {
+                    market.MinTradeSize = lotSizeFilter["minQty"].ConvertInvariant<decimal>();
+                }
+
+                markets.Add(market);
+            }
+
+            return markets;
+        }
+
         public override ExchangeTicker GetTicker(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
@@ -324,9 +389,9 @@ namespace ExchangeSharp
         {
             Dictionary<string, object> payload = GetNoncePayload();
             if (!string.IsNullOrWhiteSpace(symbol))
-	        {
+            {
                 payload["symbol"] = NormalizeSymbol(symbol);
-	        }
+            }
             JToken token = MakeJsonRequest<JToken>("/openOrders", BaseUrlPrivate, payload);
             CheckError(token);
             foreach (JToken order in token)
@@ -417,7 +482,6 @@ namespace ExchangeSharp
             CheckError(token);
         }
 
-
         public override ExchangeWithdrawalResponse Withdraw(ExchangeWithdrawalRequest withdrawalRequest)
         {
             Dictionary<string, object> payload = GetNoncePayload();
@@ -451,6 +515,28 @@ namespace ExchangeSharp
             }
 
             return withdrawalResponse;
+        }
+
+        private bool ParseMarketStatus(string status)
+        {
+            bool isActive = false;
+            if (!string.IsNullOrWhiteSpace(status))
+            {
+                switch (status)
+                {
+                    case "TRADING":
+                    case "PRE_TRADING":
+                    case "POST_TRADING":
+                        isActive = true;
+                        break;
+                    /* case "END_OF_DAY":
+                        case "HALT":
+                        case "AUCTION_MATCH":
+                        case "BREAK": */
+                }
+            }
+
+            return isActive;
         }
 
         private void CheckError(JToken result)
@@ -541,27 +627,27 @@ namespace ExchangeSharp
             switch (token["status"].ToStringInvariant())
             {
                 case "NEW":
-                    result.Result = ExchangeAPIOrderResult.Pending;
-                    break;
+                result.Result = ExchangeAPIOrderResult.Pending;
+                break;
 
                 case "PARTIALLY_FILLED":
-                    result.Result = ExchangeAPIOrderResult.FilledPartially;
-                    break;
+                result.Result = ExchangeAPIOrderResult.FilledPartially;
+                break;
 
                 case "FILLED":
-                    result.Result = ExchangeAPIOrderResult.Filled;
-                    break;
+                result.Result = ExchangeAPIOrderResult.Filled;
+                break;
 
                 case "CANCELED":
                 case "PENDING_CANCEL":
                 case "EXPIRED":
                 case "REJECTED":
-                    result.Result = ExchangeAPIOrderResult.Canceled;
-                    break;
+                result.Result = ExchangeAPIOrderResult.Canceled;
+                break;
 
                 default:
-                    result.Result = ExchangeAPIOrderResult.Error;
-                    break;
+                result.Result = ExchangeAPIOrderResult.Error;
+                break;
             }
             return result;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -124,6 +124,12 @@ namespace ExchangeSharp
             return markets;
         }
 
+        public override IEnumerable<ExchangeCurrency> GetCurrencies()
+        {
+            Console.WriteLine("Bitfinex does not provide data about its currencies via the API.");
+            return new ExchangeCurrency[0];
+        }
+
         public override ExchangeTicker GetTicker(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
@@ -606,7 +612,7 @@ namespace ExchangeSharp
                 OrderId = order[0].ToStringInvariant(),
                 Result = ExchangeAPIOrderResult.Filled,
                 Symbol = order[1].ToStringInvariant()
-            };               
+            };
         }
 
         private IEnumerable<ExchangeOrderResult> ParseOrderV2(Dictionary<string, List<JToken>> trades)

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -407,15 +407,15 @@ namespace ExchangeSharp
                 case 259200: periodString = "threeDay"; break;
                 case 604800: periodString = "week"; break;
                 default:
-                if (periodSeconds > 604800)
-                {
-                    periodString = "month";
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("Period seconds must be 60,300,1800,3600,86400, 259200 or 604800");
-                }
-                break;
+                    if (periodSeconds > 604800)
+                    {
+                        periodString = "month";
+                    }
+                    else
+                    {
+                        throw new ArgumentOutOfRangeException("Period seconds must be 60,300,1800,3600,86400, 259200 or 604800");
+                    }
+                    break;
             }
             symbol = NormalizeSymbol(symbol);
             endDate = endDate ?? DateTime.UtcNow;

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -121,7 +121,7 @@ namespace ExchangeSharp
         public override IEnumerable<ExchangeCurrency> GetCurrencies()
         {
             var currencies = new List<ExchangeCurrency>();
-            JObject obj = MakeJsonRequest<JObject>("/public/getmarkets");
+            JObject obj = MakeJsonRequest<JObject>("/public/getcurrencies");
             JToken result = CheckError(obj);
             if (result is JArray array)
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -118,6 +118,30 @@ namespace ExchangeSharp
             return symbol?.ToUpperInvariant();
         }
 
+        public override IEnumerable<ExchangeCurrency> GetCurrencies()
+        {
+            var currencies = new List<ExchangeCurrency>();
+            JObject obj = MakeJsonRequest<JObject>("/public/getmarkets");
+            JToken result = CheckError(obj);
+            if (result is JArray array)
+            {
+                foreach (JToken token in array)
+                {
+                    var coin = new ExchangeCurrency
+                    {
+                        Name = token["Currency"].ToStringUpperInvariant(),
+                        FullName = token["CurrencyLong"].ToStringInvariant(),
+                        TxFee = token["TxFee"].ConvertInvariant<decimal>(),
+                        IsEnabled = token["IsActive"].ConvertInvariant<bool>(),
+                        Notes = token["Notice"].ToStringInvariant()
+                    };
+                    currencies.Add(coin);
+                }
+            }
+
+            return currencies;
+        }
+
         /// <summary>
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
@@ -145,6 +169,7 @@ namespace ExchangeSharp
 
             return markets;
         }
+
 
         public override IEnumerable<string> GetSymbols()
         {

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -133,9 +133,11 @@ namespace ExchangeSharp
                 {
                     var market = new ExchangeMarket
                     {
-                        MarketName = token["MarketName"].ToStringInvariant(),
+                        MarketName = token["MarketName"].ToStringUpperInvariant(),
                         IsActive = token["IsActive"].ConvertInvariant<bool>(),
-                        MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>()
+                        MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
+                        BaseCurrency = token["BaseCurrency"].ToStringUpperInvariant(),
+                        MarketCurrency = token["MarketCurrency"].ToStringUpperInvariant()
                     };
                     markets.Add(market);
                 }

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -57,34 +57,34 @@ namespace ExchangeSharp
             switch (result["status"].ToStringInvariant())
             {
                 case "pending":
-                order.Result = ExchangeAPIOrderResult.Pending;
-                break;
+                    order.Result = ExchangeAPIOrderResult.Pending;
+                    break;
                 case "active":
                 case "open":
-                if (order.Amount == order.AmountFilled)
-                {
-                    order.Result = ExchangeAPIOrderResult.Filled;
-                }
-                else if (order.AmountFilled > 0.0m)
-                {
-                    order.Result = ExchangeAPIOrderResult.FilledPartially;
-                }
-                else
-                {
-                    order.Result = ExchangeAPIOrderResult.Pending;
-                }
-                break;
+                    if (order.Amount == order.AmountFilled)
+                    {
+                        order.Result = ExchangeAPIOrderResult.Filled;
+                    }
+                    else if (order.AmountFilled > 0.0m)
+                    {
+                        order.Result = ExchangeAPIOrderResult.FilledPartially;
+                    }
+                    else
+                    {
+                        order.Result = ExchangeAPIOrderResult.Pending;
+                    }
+                    break;
                 case "done":
                 case "settled":
-                order.Result = ExchangeAPIOrderResult.Filled;
-                break;
+                    order.Result = ExchangeAPIOrderResult.Filled;
+                    break;
                 case "cancelled":
                 case "canceled":
-                order.Result = ExchangeAPIOrderResult.Canceled;
-                break;
+                    order.Result = ExchangeAPIOrderResult.Canceled;
+                    break;
                 default:
-                order.Result = ExchangeAPIOrderResult.Unknown;
-                break;
+                    order.Result = ExchangeAPIOrderResult.Unknown;
+                    break;
             }
             return order;
         }
@@ -157,6 +157,23 @@ namespace ExchangeSharp
         public override IEnumerable<string> GetSymbols()
         {
             return this.GetSymbolsMetadata().Select(market => market.MarketName);
+        }
+
+        public override IEnumerable<ExchangeCurrency> GetCurrencies()
+        {
+            var currencies = new List<ExchangeCurrency>();
+            JToken products = MakeJsonRequest<JToken>("/currencies");
+            foreach (JToken product in products)
+            {
+                var currency = new ExchangeCurrency();
+                currency.Name = product["id"].ToStringUpperInvariant();
+                currency.FullName = product["name"].ToStringInvariant();
+                currency.IsEnabled = true;
+
+                currencies.Add(currency);
+            }
+
+            return currencies;
         }
 
         public override ExchangeTicker GetTicker(string symbol)

--- a/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
@@ -146,6 +146,18 @@ namespace ExchangeSharp
         Task<IEnumerable<string>> GetSymbolsAsync();
 
         /// <summary>
+        /// Get exchange symbols including available metadata such as min trade size and whether the market is active
+        /// </summary>
+        /// <returns>Collection of ExchangeMarkets</returns>
+        IEnumerable<ExchangeMarket> GetSymbolsMetadata();
+
+        /// <summary>
+        /// ASYNC - Get exchange symbols including available metadata such as min trade size and whether the market is active
+        /// </summary>
+        /// <returns>Collection of ExchangeMarkets</returns>
+        Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync();
+
+        /// <summary>
         /// Get latest ticker
         /// </summary>
         /// <param name="symbol">Symbol</param>

--- a/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
@@ -134,6 +134,18 @@ namespace ExchangeSharp
         Task<T> MakeJsonRequestAsync<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null);
 
         /// <summary>
+        /// Gets currencies and related data such as IsEnabled and TxFee (if available)
+        /// </summary>
+        /// <returns>Collection of Currencies</returns>
+        IEnumerable<ExchangeCurrency> GetCurrencies();
+
+        /// <summary>
+        /// ASYNC - Gets currencies and related data such as IsEnabled and TxFee (if available)
+        /// </summary>
+        /// <returns>Collection of Currencies</returns>
+        Task<IEnumerable<ExchangeCurrency>> GetCurrenciesAsync();
+
+        /// <summary>
         /// Get symbols for the exchange
         /// </summary>
         /// <returns>Symbols</returns>

--- a/ExchangeSharp/Model/ExchangeCurrency.cs
+++ b/ExchangeSharp/Model/ExchangeCurrency.cs
@@ -1,0 +1,16 @@
+﻿namespace ExchangeSharp
+{
+    public class ExchangeCurrency
+    {
+        /// <summary>Short name of the currency. Eg. ETH</summary>
+        public string Name { get; set; }
+
+        /// <summary>Full name of the currency. Eg. Ethereum</summary>
+        public string FullName { get; set; }
+
+        public decimal TxFee { get; set; }
+
+        /// <summary>A value indicating whether the currency is enabled for deposits/withdrawals.</summary>
+        public bool IsEnabled { get; set; }
+    }
+}

--- a/ExchangeSharp/Model/ExchangeCurrency.cs
+++ b/ExchangeSharp/Model/ExchangeCurrency.cs
@@ -8,9 +8,13 @@
         /// <summary>Full name of the currency. Eg. Ethereum</summary>
         public string FullName { get; set; }
 
+        /// <summary>The transaction fee.</summary>
         public decimal TxFee { get; set; }
 
         /// <summary>A value indicating whether the currency is enabled for deposits/withdrawals.</summary>
         public bool IsEnabled { get; set; }
+
+        /// <summary>Extra information from the exchange.</summary>
+        public string Notes { get; set; }
     }
 }

--- a/ExchangeSharp/Model/ExchangeCurrency.cs
+++ b/ExchangeSharp/Model/ExchangeCurrency.cs
@@ -1,4 +1,16 @@
-﻿namespace ExchangeSharp
+﻿/*
+MIT LICENSE
+
+Copyright 2018 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharp
 {
     public class ExchangeCurrency
     {

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -1,0 +1,29 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2018 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharp
+{
+    public class ExchangeMarket
+    {
+        public string MarketName { get; set; }
+
+        public bool IsActive { get; set; }
+
+        public decimal MinTradeSize { get; set; }
+
+        /// <summary>In a pair like ZRX/BTC, BTC is the base currency.</summary>
+        public string BaseCurrency { get; set; }
+
+        /// <summary>In a pair like ZRX/BTC, ZRX is the market currency.</summary>
+        public string MarketCurrency { get; set; }
+    }
+}

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -14,10 +14,16 @@ namespace ExchangeSharp
 {
     public class ExchangeMarket
     {
+        /// <summary>Gets or sets the name of the market.</summary>
         public string MarketName { get; set; }
 
+        /// <summary>A value indicating whether the market is active.</summary>
         public bool IsActive { get; set; }
 
+        /// <summary>
+        /// The minimum size of the trade in the unit of "MarketCurrency".
+        /// For example, in DOGE/BTC the MinTradeSize is currently 423.72881356 DOGE
+        /// </summary>
         public decimal MinTradeSize { get; set; }
 
         /// <summary>In a pair like ZRX/BTC, BTC is the base currency.</summary>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ public static void Main(string[] args)
 ```
 ---
 
-I do cryptocurrency consulting, please don't hesitate to contact me if you have a custom solution you would like me to implement (jjxtra@gmail.com).
+I do cryptocurrency consulting, please don't hesitate to contact me if you have a custom solution you would like me to implement (jeff@digitalruby.com).
 
 If you want help with your project, have questions that need answering or this project has helped you in any way, I accept donations.
 


### PR DESCRIPTION
Some exchanges provide data about whether their currencies or markets are enabled/frozen/delisted. Capture this metadata so trades aren't attempted against blocked markets.