### PR TITLE
RSACryptoServiceProvider does not support CspParameters on Linux

### DIFF
--- a/ExchangeSharp/Utility/ManagedProtection.cs
+++ b/ExchangeSharp/Utility/ManagedProtection.cs
@@ -279,9 +279,16 @@ namespace ExchangeSharp
                     {
                         lock (user_lock)
                         {
-                            // CspParameters csp = new CspParameters();
-                            // csp.KeyContainerName = "DAPI";
-                            user = new RSACryptoServiceProvider(1536);
+                            if (CryptoUtility.IsMono)
+                            {
+                                CspParameters csp = new CspParameters();
+                                csp.KeyContainerName = "DAPI";
+                                user = new RSACryptoServiceProvider(1536, csp);
+                            }
+                            else
+                            {
+                                user = new RSACryptoServiceProvider(1536);
+                            }
                         }
                     }
                     return user;
@@ -290,10 +297,17 @@ namespace ExchangeSharp
                     {
                         lock (machine_lock)
                         {
-                            CspParameters csp = new CspParameters();
-                            csp.KeyContainerName = "DAPI";
-                            csp.Flags = CspProviderFlags.UseMachineKeyStore;
-                            machine = new RSACryptoServiceProvider(1536, csp);
+                            if (CryptoUtility.IsMono)
+                            {
+                                CspParameters csp = new CspParameters();
+                                csp.KeyContainerName = "DAPI";
+                                csp.Flags = CspProviderFlags.UseMachineKeyStore;
+                                machine = new RSACryptoServiceProvider(1536, csp);
+                            }
+                            else
+                            {
+                                machine = new RSACryptoServiceProvider(1536);
+                            }
                         }
                     }
                     return machine;

--- a/ExchangeSharp/Utility/ManagedProtection.cs
+++ b/ExchangeSharp/Utility/ManagedProtection.cs
@@ -279,9 +279,9 @@ namespace ExchangeSharp
                     {
                         lock (user_lock)
                         {
-                            CspParameters csp = new CspParameters();
-                            csp.KeyContainerName = "DAPI";
-                            user = new RSACryptoServiceProvider(1536, csp);
+                            // CspParameters csp = new CspParameters();
+                            // csp.KeyContainerName = "DAPI";
+                            user = new RSACryptoServiceProvider(1536);
                         }
                     }
                     return user;


### PR DESCRIPTION
This should be tested on Windows before merging!

How I found this issue:

cd Console
dotnet run test

Fatal error: System.PlatformNotSupportedException: 'CspParameters' requires Windows Cryptographic API (CAPI), which is not available on this platform.
   at System.Security.Cryptography.RSACryptoServiceProvider..ctor(Int32 dwKeySize, CspParameters parameters)
   at ExchangeSharp.ManagedProtection.GetKey(DataProtectionScope scope) in .../ExchangeSharp-netcore/ExchangeSharp/Utility/ManagedProtection.cs:line 284
   at ExchangeSharp.ManagedProtection.Protect(Byte[] userData, Byte[] optionalEntropy, DataProtectionScope scope) in .../ExchangeSharp-netcore/ExchangeSharp/Utility/ManagedProtection.cs:line 108
   at ExchangeSharp.DataProtector.Protect(Byte[] data) in .../ExchangeSharp-netcore/ExchangeSharp/Utility/DataProtector.cs:line 131
   at ExchangeSharpConsoleApp.ExchangeSharpConsole.TestEncryption() in .../ExchangeSharp-netcore/Console/ExchangeSharpConsole_Tests.cs:line 103
   at ExchangeSharpConsoleApp.ExchangeSharpConsole.RunPerformTests(Dictionary`2 dict) in .../ExchangeSharp-netcore/Console/ExchangeSharpConsole_Tests.cs:line 171
   at ExchangeSharpConsoleApp.ExchangeSharpConsole.ConsoleMain(String[] args) in .../ExchangeSharp-netcore/Console/ExchangeSharpConsole.cs:line 67

