### PR TITLE
Use decimal type in MovingAverageCalculator

### DIFF
--- a/ExchangeSharp/Traders/MovingAverageCalculator.cs
+++ b/ExchangeSharp/Traders/MovingAverageCalculator.cs
@@ -24,19 +24,19 @@ namespace ExchangeSharp
     public sealed class MovingAverageCalculator
     {
         private int _windowSize;
-        private double[] _values;
+        private decimal[] _values;
         private int _nextValueIndex;
-        private double _sum;
+        private decimal _sum;
         private int _valuesIn;
 
-        private double _weightingMultiplier;
-        private double _previousMovingAverage;
-        private double _previousExponentialMovingAverage;
+        private decimal _weightingMultiplier;
+        private decimal _previousMovingAverage;
+        private decimal _previousExponentialMovingAverage;
 
-        public double MovingAverage { get; private set; }
-        public double Slope { get; private set; }
-        public double ExponentialMovingAverage { get; private set; }
-        public double ExponentialSlope { get; private set; }
+        public decimal MovingAverage { get; private set; }
+        public decimal Slope { get; private set; }
+        public decimal ExponentialMovingAverage { get; private set; }
+        public decimal ExponentialSlope { get; private set; }
 
         public override string ToString()
         {
@@ -63,7 +63,7 @@ namespace ExchangeSharp
         /// moving average.
         /// </summary>
         /// <param name="nextValue">The next value to be considered within the moving average.</param>
-        public void NextValue(double nextValue)
+        public void NextValue(decimal nextValue)
         {
             // add new value to the sum
             _sum += nextValue;
@@ -93,7 +93,7 @@ namespace ExchangeSharp
             _previousMovingAverage = MovingAverage;
 
             // exponential moving average
-            if (_previousExponentialMovingAverage != double.MinValue)
+            if (_previousExponentialMovingAverage != decimal.MinValue)
             {
                 ExponentialMovingAverage = ((nextValue - _previousExponentialMovingAverage) * _weightingMultiplier) + _previousExponentialMovingAverage;
                 ExponentialSlope = ExponentialMovingAverage - _previousExponentialMovingAverage;
@@ -104,7 +104,7 @@ namespace ExchangeSharp
             else
             {
                 ExponentialMovingAverage = nextValue;
-                ExponentialSlope = 0.0f;
+                ExponentialSlope = 0;
                 _previousExponentialMovingAverage = ExponentialMovingAverage;
             }
         }
@@ -128,12 +128,12 @@ namespace ExchangeSharp
         public void Reset(int windowSize)
         {
             _windowSize = windowSize;
-            _values = new double[_windowSize];
-            _weightingMultiplier = 2.0 / (_values.Length + 1);
+            _values = new decimal[_windowSize];
+            _weightingMultiplier = 2.0m / (_values.Length + 1);
             _nextValueIndex = 0;
             _sum = 0;
             _valuesIn = 0;
-            _previousExponentialMovingAverage = double.MinValue;
+            _previousExponentialMovingAverage = decimal.MinValue;
         }
     }
 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Tests.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Tests.cs
@@ -251,14 +251,14 @@ namespace ExchangeSharpConsoleApp
             var ma1 = new MovingAverageCalculator(len1);
             for (int i=0; i<len1*2; i++)
 	    {
-                ma1.NextValue(5.0);
+                ma1.NextValue(5.0m);
                 Assert((i < len1-1) != ma1.IsMature);
-                Assert(ma1.MovingAverage == 5.0);
+                Assert(ma1.MovingAverage == 5.0m);
             }
             Assert(ma1.IsMature);
-            Assert(ma1.MovingAverage == 5.0);
+            Assert(ma1.MovingAverage == 5.0m);
             Assert(ma1.Slope == 0);
-            Assert(ma1.ExponentialMovingAverage == 5.0);
+            Assert(ma1.ExponentialMovingAverage == 5.0m);
             Assert(ma1.ExponentialSlope == 0);
 
             // constant rise
@@ -267,19 +267,19 @@ namespace ExchangeSharpConsoleApp
             for (int i = 0; i < len2; i++)
 	    {
                 ma2.NextValue(i);
-                Assert(ma2.MovingAverage == i/2.0);
+                Assert(ma2.MovingAverage == i/2.0m);
                 Assert((i<len2-1) != ma2.IsMature);
             }
             Assert(ma2.IsMature);
-            Assert(ma2.MovingAverage == 4.5);
-            Assert(ma2.Slope == 0.5);
-            Assert(ma2.ExponentialMovingAverage == 5.2393684801212155);
-            Assert(ma2.ExponentialSlope == 0.83569589330639626);
+            Assert(ma2.MovingAverage == 4.5m);
+            Assert(ma2.Slope == 0.5m);
+            Assert(ma2.ExponentialMovingAverage == 5.2393684801212157169944615194m);
+            Assert(ma2.ExponentialSlope == 0.8356958933063965073345641067m);
 
             for (int i = len2; i < len2 * 2; i++)
 	    {
                 ma2.NextValue(i);
-                Assert(ma2.MovingAverage == i - 4.5);
+                Assert(ma2.MovingAverage == i - 4.5m);
             }
 
             // step function
@@ -287,24 +287,24 @@ namespace ExchangeSharpConsoleApp
             var ma3 = new MovingAverageCalculator(len3);
             for (int i = 0; i < len3; i++)
 	    {
-                ma3.NextValue(i < 5 ? 0 : 1.0);
+                ma3.NextValue(i < 5 ? 0 : 1.0m);
             }
-            Assert(ma3.MovingAverage == 0.5);
-            Assert(ma3.Slope == 0.05555555555555558);
-            Assert(ma3.ExponentialMovingAverage == 0.63335216794679949);
-            Assert(ma3.ExponentialSlope == 0.081477296011822409);
+            Assert(ma3.MovingAverage == 0.5m);
+            Assert(ma3.Slope == 0.0555555555555555555555555556m);
+            Assert(ma3.ExponentialMovingAverage == 0.6333521679467994610402915846m);
+            Assert(ma3.ExponentialSlope == 0.0814772960118223419910463145m);
 
             // inverse step function
             const int len4 = 10;
             var ma4 = new MovingAverageCalculator(len4);
             for(int i = 0; i < len4; i++)
 	    {
-                ma4.NextValue(i < 5 ? 1.0 : 0);
+                ma4.NextValue(i < 5 ? 1.0m : 0);
             }
-            Assert(ma4.MovingAverage == 0.5);
-            Assert(ma4.Slope == -0.05555555555555558);
-            Assert(ma4.ExponentialMovingAverage == 0.36664783205320051);
-            Assert(ma4.ExponentialSlope == -0.081477296011822353);
+            Assert(ma4.MovingAverage == 0.5m);
+            Assert(ma4.Slope == -0.0555555555555555555555555556m);
+            Assert(ma4.ExponentialMovingAverage == 0.3666478320532005389597084154m);
+            Assert(ma4.ExponentialSlope == -0.0814772960118223419910463145m);
 
             Console.WriteLine("TestMovingAverageCalculator OK");
         }


### PR DESCRIPTION
This one depends on the previous PR #53.

Again, this changes the exact values computed by MovingAverageCalculator.
What was your initial intention/concern using double instead? Was it performance?