### PR TITLE
 Added QuantityStep and PriceStep to market metadata

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -130,7 +130,7 @@ namespace ExchangeSharp
                     market.QuantityStepSize = lotSizeFilter["stepSize"].ConvertInvariant<decimal>();
                 }
 
-                //PRICE_FILTER
+                // PRICE_FILTER
                 JToken priceFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "PRICE_FILTER"));
                 if (priceFilter != null)
                 {
@@ -750,9 +750,11 @@ namespace ExchangeSharp
                     case 0:
                         transaction.Status = TransactionStatus.Processing;
                         break;
+			
                     case 1:
                         transaction.Status = TransactionStatus.Complete;
                         break;
+			
                     default:
                         // If new states are added, see https://github.com/binance-exchange/binance-official-api-docs/blob/master/wapi-api.md
                         transaction.Status = TransactionStatus.Unknown;

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -623,7 +623,7 @@ namespace ExchangeSharp
                 OrderId = token["orderId"].ToStringInvariant(),
                 Symbol = token["symbol"].ToStringInvariant()
             };
-            result.AveragePrice = (result.AmountFilled <= 0m ? 0m : result.Price / result.AmountFilled);
+            result.AveragePrice = result.Price;
             switch (token["status"].ToStringInvariant())
             {
                 case "NEW":

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -127,8 +127,15 @@ namespace ExchangeSharp
                 if (lotSizeFilter != null)
                 {
                     market.MinTradeSize = lotSizeFilter["minQty"].ConvertInvariant<decimal>();
+                    market.QuantityStepSize = lotSizeFilter["stepSize"].ConvertInvariant<decimal>();
                 }
 
+                //PRICE_FILTER
+                JToken priceFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "PRICE_FILTER"));
+                if (priceFilter != null)
+                {
+                    market.PriceStepSize = priceFilter["tickSize"].ConvertInvariant<decimal>();
+                }
                 markets.Add(market);
             }
 

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -149,6 +149,8 @@ namespace ExchangeSharp
                         throw new System.IO.InvalidDataException("Unexpected market name: " + market.MarketName);
                     }                    
                 }
+                int pricePrecision = pair["price_precision"].ConvertInvariant<int>();
+                market.PriceStepSize = (decimal)Math.Pow(0.1, pricePrecision);
                 markets.Add(market);
             }
 

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -147,7 +147,7 @@ namespace ExchangeSharp
                 market.MarketCurrency = product["base_currency"].ToStringUpperInvariant();
                 market.IsActive = string.Equals(product["status"].ToStringInvariant(), "online", StringComparison.OrdinalIgnoreCase);
                 market.MinTradeSize = product["base_min_size"].ConvertInvariant<decimal>();
-
+                market.PriceStepSize = product["quote_increment"].ConvertInvariant<decimal>();
                 markets.Add(market);
             }
 

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -35,12 +35,14 @@ namespace ExchangeSharp
         /// <summary>
         /// Defines the intervals that a quantity can be increased/decreased by. 
         /// The following must be true for quantity: (Quantity-MinTradeSize) % QuantityStepSize == 0
+        /// Null if unknown or not applicable.
         /// </summary>
         public decimal? QuantityStepSize { get; set; }
 
         /// <summary>
         /// Defines the intervals that a price can be increased/decreased by. 
         /// The following must be true for price: Price % PriceStepSize == 0
+        /// Null if unknown or not applicable.
         /// </summary>
         public decimal? PriceStepSize { get; set; }
 

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -31,6 +31,18 @@ namespace ExchangeSharp
 
         /// <summary>In a pair like ZRX/BTC, ZRX is the market currency.</summary>
         public string MarketCurrency { get; set; }
+        
+        /// <summary>
+        /// Defines the intervals that a quantity can be increased/decreased by. 
+        /// The following must be true for quantity: (Quantity-MinTradeSize) % QuantityStepSize == 0
+        /// </summary>
+        public decimal? QuantityStepSize { get; set; }
+
+        /// <summary>
+        /// Defines the intervals that a price can be increased/decreased by. 
+        /// The following must be true for price: Price % PriceStepSize == 0
+        /// </summary>
+        public decimal? PriceStepSize { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
Added QuantityStepSize and PriceStepSize to ExchangeMarket.
Asigned their values in GetSymbolsMetadata method where possible: Binance, Bitfinex, Gdax
