### PR TITLE
Added clamping of Binance quantity and prices

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -383,8 +383,17 @@ namespace ExchangeSharp
             outputPrice = order.Price;
 
             // Get the exchange markets if we haven't gotten them yet.
+
             if (_exchangeMarkets == null)
-                _exchangeMarkets = GetSymbolsMetadata();
+            {
+                lock (this)
+                {
+                    if (_exchangeMarkets == null)
+                    {
+                        _exchangeMarkets = GetSymbolsMetadata();
+                    }
+                }
+            }
 
             // Check if the current market is in our definitions.
             ExchangeMarket market = _exchangeMarkets.FirstOrDefault(x => x.MarketName == symbol);

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -139,8 +139,8 @@ namespace ExchangeSharp
                 JToken priceFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "PRICE_FILTER"));
                 if (priceFilter != null)
                 {
-                    market.MaxPrice = lotSizeFilter["maxPrice"].ConvertInvariant<decimal>();
-                    market.MinPrice = lotSizeFilter["minPrice"].ConvertInvariant<decimal>();
+                    market.MaxPrice = priceFilter["maxPrice"].ConvertInvariant<decimal>();
+                    market.MinPrice = priceFilter["minPrice"].ConvertInvariant<decimal>();
                     market.PriceStepSize = priceFilter["tickSize"].ConvertInvariant<decimal>();
                 }
                 markets.Add(market);

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -30,6 +30,8 @@ namespace ExchangeSharp
         public string WithdrawalUrlPrivate { get; set; } = "https://api.binance.com/wapi/v3";
         public override string Name => ExchangeName.Binance;
 
+        private IEnumerable<ExchangeMarket> _exchangeMarkets;
+
         public override string NormalizeSymbol(string symbol)
         {
             if (symbol != null)
@@ -128,6 +130,7 @@ namespace ExchangeSharp
                 JToken lotSizeFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "LOT_SIZE"));
                 if (lotSizeFilter != null)
                 {
+                    market.MaxTradeSize = lotSizeFilter["maxQty"].ConvertInvariant<decimal>();
                     market.MinTradeSize = lotSizeFilter["minQty"].ConvertInvariant<decimal>();
                     market.QuantityStepSize = lotSizeFilter["stepSize"].ConvertInvariant<decimal>();
                 }
@@ -136,6 +139,8 @@ namespace ExchangeSharp
                 JToken priceFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "PRICE_FILTER"));
                 if (priceFilter != null)
                 {
+                    market.MaxPrice = lotSizeFilter["maxPrice"].ConvertInvariant<decimal>();
+                    market.MinPrice = lotSizeFilter["minPrice"].ConvertInvariant<decimal>();
                     market.PriceStepSize = priceFilter["tickSize"].ConvertInvariant<decimal>();
                 }
                 markets.Add(market);
@@ -367,16 +372,39 @@ namespace ExchangeSharp
 
         public override ExchangeOrderResult PlaceOrder(ExchangeOrderRequest order)
         {
+            decimal outputQuantity, outputPrice;
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = GetNoncePayload();
             payload["symbol"] = symbol;
             payload["side"] = (order.IsBuy ? "BUY" : "SELL");
             payload["type"] = order.OrderType.ToString().ToUpperInvariant();
-            payload["quantity"] = order.RoundAmount();
+
+            outputQuantity = order.RoundAmount();
+            outputPrice = order.Price;
+
+            // Get the exchange markets if we haven't gotten them yet.
+            if (_exchangeMarkets == null)
+                _exchangeMarkets = GetSymbolsMetadata();
+
+            // Check if the current market is in our definitions.
+            ExchangeMarket market = _exchangeMarkets.FirstOrDefault(x => x.MarketName == symbol);
+
+            // If a definition is found, we can update the quantity and price to match the rules imposed by Binance.
+            if (market != null)
+            {
+                // Binance has strict rules on which quantities are allowed. They have to match the rules defined in the market definition.
+                outputQuantity = CryptoUtility.ClampQuantity(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, order.RoundAmount());
+
+                // Binance has strict rules on which prices are allowed. They have to match the rules defined in the market definition.
+                outputPrice = CryptoUtility.ClampPrice(market.MinPrice, market.MaxPrice, market.PriceStepSize, order.Price);
+            }
+            
+            payload["quantity"] = outputQuantity;
+
             if (order.OrderType != OrderType.Market)
             {
                 payload["timeInForce"] = "GTC";
-                payload["price"] = order.Price;
+                payload["price"] = outputPrice;
             }
             foreach (var kv in order.ExtraParameters)
             {

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -26,6 +26,11 @@ namespace ExchangeSharp
         /// </summary>
         public decimal MinTradeSize { get; set; }
 
+        /// <summary>
+        /// The maximum size of the trade in the unit of "MarketCurrency".
+        /// </summary>
+        public decimal MaxTradeSize { get; set; }
+
         /// <summary>In a pair like ZRX/BTC, BTC is the base currency.</summary>
         public string BaseCurrency { get; set; }
 
@@ -38,6 +43,16 @@ namespace ExchangeSharp
         /// Null if unknown or not applicable.
         /// </summary>
         public decimal? QuantityStepSize { get; set; }
+
+        /// <summary>
+        /// The minimum price of the pair.
+        /// </summary>
+        public decimal MinPrice { get; set; }
+
+        /// <summary>
+        /// The maximum price of the pair.
+        /// </summary>
+        public decimal MaxPrice { get; set; }
 
         /// <summary>
         /// Defines the intervals that a price can be increased/decreased by. 

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -151,8 +151,14 @@ namespace ExchangeSharp
 
         public static decimal ClampQuantity(decimal minQuantity, decimal maxQuantity, decimal? stepSize, decimal quantity)
         {
+            if(minQuantity < 0) throw new ArgumentOutOfRangeException(nameof(minQuantity));
+            if (maxQuantity < 0) throw new ArgumentOutOfRangeException(nameof(maxQuantity));
+            if (quantity < 0) throw new ArgumentOutOfRangeException(nameof(quantity));
+
             if (stepSize.HasValue)
             {
+                if (stepSize < 0) throw new ArgumentOutOfRangeException(nameof(stepSize));
+
                 quantity = Math.Min(maxQuantity, quantity);
                 quantity = Math.Max(minQuantity, quantity);
                 quantity -= quantity % stepSize.Value;
@@ -164,8 +170,14 @@ namespace ExchangeSharp
 
         public static decimal ClampPrice(decimal minPrice, decimal maxPrice, decimal? tickSize, decimal price)
         {
+            if (minPrice < 0) throw new ArgumentOutOfRangeException(nameof(minPrice));
+            if (maxPrice < 0) throw new ArgumentOutOfRangeException(nameof(maxPrice));
+            if (price < 0) throw new ArgumentOutOfRangeException(nameof(price));
+            
             if (tickSize.HasValue)
             {
+                if (tickSize < 0) throw new ArgumentOutOfRangeException(nameof(tickSize));
+                
                 price = Math.Min(maxPrice, price);
                 price = Math.Max(minPrice, price);
                 price -= price % tickSize.Value;

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -156,8 +156,9 @@ namespace ExchangeSharp
                 quantity = Math.Min(maxQuantity, quantity);
                 quantity = Math.Max(minQuantity, quantity);
                 quantity -= quantity % stepSize.Value;
-                quantity = Floor(quantity);
+                quantity = RoundDown(quantity);
             }
+
             return quantity;
         }
 
@@ -168,14 +169,9 @@ namespace ExchangeSharp
                 price = Math.Min(maxPrice, price);
                 price = Math.Max(minPrice, price);
                 price -= price % tickSize.Value;
-                price = Floor(price);
+                price = RoundDown(price);
             }
             return price;
-        }
-
-        private static decimal Floor(decimal number)
-        {
-            return Math.Floor(number * 100000000) / 100000000;
         }
 
         public static DateTime UnixTimeStampToDateTimeSeconds(this double unixTimeStampSeconds)

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -154,6 +154,7 @@ namespace ExchangeSharp
             if(minQuantity < 0) throw new ArgumentOutOfRangeException(nameof(minQuantity));
             if (maxQuantity < 0) throw new ArgumentOutOfRangeException(nameof(maxQuantity));
             if (quantity < 0) throw new ArgumentOutOfRangeException(nameof(quantity));
+            if (minQuantity > maxQuantity) throw new ArgumentOutOfRangeException(nameof(minQuantity));
 
             if (stepSize.HasValue)
             {
@@ -173,6 +174,7 @@ namespace ExchangeSharp
             if (minPrice < 0) throw new ArgumentOutOfRangeException(nameof(minPrice));
             if (maxPrice < 0) throw new ArgumentOutOfRangeException(nameof(maxPrice));
             if (price < 0) throw new ArgumentOutOfRangeException(nameof(price));
+            if(minPrice > maxPrice) throw new ArgumentOutOfRangeException(nameof(minPrice));
             
             if (tickSize.HasValue)
             {

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -149,6 +149,35 @@ namespace ExchangeSharp
             return secure;
         }
 
+        public static decimal ClampQuantity(decimal minQuantity, decimal maxQuantity, decimal? stepSize, decimal quantity)
+        {
+            if (stepSize.HasValue)
+            {
+                quantity = Math.Min(maxQuantity, quantity);
+                quantity = Math.Max(minQuantity, quantity);
+                quantity -= quantity % stepSize.Value;
+                quantity = Floor(quantity);
+            }
+            return quantity;
+        }
+
+        public static decimal ClampPrice(decimal minPrice, decimal maxPrice, decimal? tickSize, decimal price)
+        {
+            if (tickSize.HasValue)
+            {
+                price = Math.Min(maxPrice, price);
+                price = Math.Max(minPrice, price);
+                price -= price % tickSize.Value;
+                price = Floor(price);
+            }
+            return price;
+        }
+
+        private static decimal Floor(decimal number)
+        {
+            return Math.Floor(number * 100000000) / 100000000;
+        }
+
         public static DateTime UnixTimeStampToDateTimeSeconds(this double unixTimeStampSeconds)
         {
             // Unix timestamp is seconds past epoch

--- a/ExchangeSharpTests/CryptoUtilityTests.cs
+++ b/ExchangeSharpTests/CryptoUtilityTests.cs
@@ -46,12 +46,44 @@
         }
 
         [TestMethod]
+        public void ClampPriceOutOfRange()
+        {
+            Action a = () => CryptoUtility.ClampPrice(-0.00000100m, 100000.00000000m, 0.00000100m, 0.05507632m);
+            a.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action b = () => CryptoUtility.ClampPrice(0.00000100m, -100000.00000000m, 0.00000100m, 0.05507632m);
+            b.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action c = () => CryptoUtility.ClampPrice(0.00000100m, 100000.00000000m, 0.00000100m, -0.05507632m);
+            c.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action d = () => CryptoUtility.ClampPrice(0.00000100m, 100000.00000000m, -0.00000100m, 0.05507632m);
+            d.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [TestMethod]
         public void ClampQuantity()
         {
             CryptoUtility.ClampQuantity(0.01000000m, 90000000.00000000m, 0.01000000m, 34.55215m).Should().Be(34.55m);
             CryptoUtility.ClampQuantity(0.00100000m, 90000000.00000000m, 0.00100000m, 941.4192).Should().Be(941.419m);
             CryptoUtility.ClampQuantity(0.00000100m, 90000000.00000000m, 0.00000100m, 172.94102192m).Should().Be(172.941021m);
             CryptoUtility.ClampQuantity(0.00010000m, 90000000.00000000m, null, 1837.31935m).Should().Be(1837.31935m);
+        }
+
+        [TestMethod]
+        public void ClampQuantityOutOfRange()
+        {
+            Action a = () => CryptoUtility.ClampQuantity(-0.00010000m, 900000.00000000m, 0.00010000m, 33.393832);
+            a.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action b = () => CryptoUtility.ClampQuantity(0.00010000m, -900000.00000000m, 0.00010000m, 33.393832);
+            b.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action c = () => CryptoUtility.ClampQuantity(0.00010000m, 900000.00000000m, 0.00010000m, -33.393832m);
+            c.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action d = () => CryptoUtility.ClampQuantity(0.00010000m, 900000.00000000m, -0.00010000m, 33.393832m);
+            d.Should().Throw<ArgumentOutOfRangeException>();
         }
     }
 }

--- a/ExchangeSharpTests/CryptoUtilityTests.cs
+++ b/ExchangeSharpTests/CryptoUtilityTests.cs
@@ -35,5 +35,23 @@
             Action a = () => CryptoUtility.RoundDown(1.2345m, -1);
             a.Should().Throw<ArgumentOutOfRangeException>();
         }
+
+        [TestMethod]
+        public void ClampPrice()
+        {
+            CryptoUtility.ClampPrice(0.00000100m, 100000.00000000m, 0.00000100m, 0.05507632m).Should().Be(0.055076m);
+            CryptoUtility.ClampPrice(0.00000010m, 100000.00000000m, 0.00000010m, 0.00052286m).Should().Be(0.0005228m);
+            CryptoUtility.ClampPrice(0.00001000m, 100000.00000000m, 0.00001000m, 0.02525215m).Should().Be(0.025252m);
+            CryptoUtility.ClampPrice(0.00001000m, 100000.00000000m, null, 0.00401212m).Should().Be(0.00401212m);
+        }
+
+        [TestMethod]
+        public void ClampQuantity()
+        {
+            CryptoUtility.ClampQuantity(0.01000000m, 90000000.00000000m, 0.01000000m, 34.55215m).Should().Be(34.55m);
+            CryptoUtility.ClampQuantity(0.00100000m, 90000000.00000000m, 0.00100000m, 941.4192).Should().Be(941.419m);
+            CryptoUtility.ClampQuantity(0.00000100m, 90000000.00000000m, 0.00000100m, 172.94102192m).Should().Be(172.941021m);
+            CryptoUtility.ClampQuantity(0.00010000m, 90000000.00000000m, null, 1837.31935m).Should().Be(1837.31935m);
+        }
     }
 }

--- a/ExchangeSharpTests/CryptoUtilityTests.cs
+++ b/ExchangeSharpTests/CryptoUtilityTests.cs
@@ -59,6 +59,9 @@
 
             Action d = () => CryptoUtility.ClampPrice(0.00000100m, 100000.00000000m, -0.00000100m, 0.05507632m);
             d.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action e = () => CryptoUtility.ClampPrice(100000.00000000m, 0.00000100m, -0.00000100m, 0.05507632m);
+            e.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         [TestMethod]
@@ -84,6 +87,9 @@
 
             Action d = () => CryptoUtility.ClampQuantity(0.00010000m, 900000.00000000m, -0.00010000m, 33.393832m);
             d.Should().Throw<ArgumentOutOfRangeException>();
+
+            Action e = () => CryptoUtility.ClampQuantity(900000.00000000m, 0.00010000m, -0.00010000m, 33.393832m);
+            e.Should().Throw<ArgumentOutOfRangeException>();
         }
     }
 }


### PR DESCRIPTION
Binance has limitations on the amount of decimals provided for quantity and price. Each coin has its own settings of how many decimals both can have which are defined in the market metadata. This adds clamping to the quantity and prices if a quantity or price with more decimals than accepted by Binance is provided.