### PR TITLE
Polo refactoring (+ fix rounding)

### DIFF
--- a/ExchangeSharp/API/APIException.cs
+++ b/ExchangeSharp/API/APIException.cs
@@ -1,0 +1,23 @@
+﻿namespace ExchangeSharp
+{
+    using System;
+
+    /// <summary>
+    /// Exception class for API calls
+    /// </summary>
+    public class APIException : Exception
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">Message</param>
+        public APIException(string message) : base(message) { }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException">Inner exception</param>
+        public APIException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -151,7 +151,12 @@ namespace ExchangeSharp
         private decimal lastNonce;
 
         // Helper for making the API calls
-        private IRequestHelper requestHelper;
+        public IRequestHelper RequestHelper { get; set; }
+
+        public BaseAPI()
+        {
+            this.RequestHelper = new RequestHelper(this);
+        }
 
         /// <summary>
         /// Static constructor
@@ -172,16 +177,6 @@ namespace ExchangeSharp
             {
 
             }
-        }
-
-        public BaseAPI()
-        {
-            this.requestHelper = new RequestHelper(this);
-        }
-
-        public BaseAPI(IRequestHelper requestHelper)
-        {
-            this.requestHelper = requestHelper;
         }
 
         /// <summary>
@@ -285,7 +280,7 @@ namespace ExchangeSharp
         /// The encoding of payload is API dependant but is typically json.</param>
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.requestHelper.MakeRequest(url, baseUrl, payload, method));
+        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.RequestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: method));
 
         /// <summary>
         /// Make a JSON request to an API end point
@@ -298,7 +293,7 @@ namespace ExchangeSharp
         /// <returns>Result decoded from JSON response</returns>
         public T MakeJsonRequest<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
         {
-            string response = this.requestHelper.MakeRequest(url, baseUrl, payload, requestMethod);
+            string response = this.RequestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
             return JsonConvert.DeserializeObject<T>(response);
         }
 

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -151,12 +151,7 @@ namespace ExchangeSharp
         private decimal lastNonce;
 
         // Helper for making the API calls
-        public IRequestHelper RequestHelper { get; set; }
-
-        public BaseAPI()
-        {
-            this.RequestHelper = new RequestHelper(this);
-        }
+        protected IRequestHelper requestHelper;
 
         /// <summary>
         /// Static constructor
@@ -280,7 +275,7 @@ namespace ExchangeSharp
         /// The encoding of payload is API dependant but is typically json.</param>
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.RequestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: method));
+        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.requestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: method));
 
         /// <summary>
         /// Make a JSON request to an API end point
@@ -293,7 +288,7 @@ namespace ExchangeSharp
         /// <returns>Result decoded from JSON response</returns>
         public T MakeJsonRequest<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
         {
-            string response = this.RequestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
+            string response = this.requestHelper.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
             return JsonConvert.DeserializeObject<T>(response);
         }
 

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -27,8 +27,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     /// <summary>
     /// Type of nonce styles
     /// </summary>

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -27,6 +27,8 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     /// <summary>
     /// Type of nonce styles
     /// </summary>
@@ -148,6 +150,9 @@ namespace ExchangeSharp
 
         private decimal lastNonce;
 
+        // Helper for making the API calls
+        private IRequestHelper requestHelper;
+
         /// <summary>
         /// Static constructor
         /// </summary>
@@ -167,6 +172,16 @@ namespace ExchangeSharp
             {
 
             }
+        }
+
+        public BaseAPI()
+        {
+            this.requestHelper = new RequestHelper(this);
+        }
+
+        public BaseAPI(IRequestHelper requestHelper)
+        {
+            this.requestHelper = requestHelper;
         }
 
         /// <summary>
@@ -262,69 +277,6 @@ namespace ExchangeSharp
         }
 
         /// <summary>
-        /// Make a request to a path on the API
-        /// </summary>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// The encoding of payload is API dependant but is typically json.</param>
-        /// <param name="method">Request method or null for default</param>
-        /// <returns>Raw response</returns>
-        public string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
-        {
-            RateLimit.WaitToProceed();
-            if (string.IsNullOrWhiteSpace(url))
-            {
-                return null;
-            }
-            else if (url[0] != '/')
-            {
-                url = "/" + url;
-            }
-
-            string fullUrl = (baseUrl ?? BaseUrl) + url;
-            Uri uri = ProcessRequestUrl(new UriBuilder(fullUrl), payload);
-            HttpWebRequest request = HttpWebRequest.CreateHttp(uri);
-            request.Headers["Accept-Language"] = "en-us; q=1.0;";
-            request.Method = method ?? RequestMethod;
-            request.ContentType = RequestContentType;
-            request.UserAgent = RequestUserAgent;
-            request.CachePolicy = CachePolicy;
-            request.Timeout = request.ReadWriteTimeout = request.ContinueTimeout = (int)RequestTimeout.TotalMilliseconds;
-            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-            ProcessRequest(request, payload);
-            HttpWebResponse response;
-            try
-            {
-                response = request.GetResponse() as HttpWebResponse;
-                if (response == null)
-                {
-                    throw new APIException("Unknown response from server");
-                }
-            }
-            catch (WebException we)
-            {
-                response = we.Response as HttpWebResponse;
-                if (response == null)
-                {
-                    throw new APIException(we.Message ?? "Unknown response from server");
-                }
-            }
-            string responseString = null;
-            using (Stream responseStream = response.GetResponseStream())
-            {
-                responseString = new StreamReader(responseStream).ReadToEnd();
-                if (response.StatusCode != HttpStatusCode.OK)
-                {
-                    throw new APIException(responseString);
-                }
-                ProcessResponse(response);
-            }
-            response.Dispose();
-            return responseString;
-        }
-
-        /// <summary>
         /// ASYNC - Make a request to a path on the API
         /// </summary>
         /// <param name="url">Path and query</param>
@@ -333,7 +285,7 @@ namespace ExchangeSharp
         /// The encoding of payload is API dependant but is typically json.</param>
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => MakeRequest(url, baseUrl, payload, method));
+        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.requestHelper.MakeRequest(url, baseUrl, payload, method));
 
         /// <summary>
         /// Make a JSON request to an API end point
@@ -346,7 +298,7 @@ namespace ExchangeSharp
         /// <returns>Result decoded from JSON response</returns>
         public T MakeJsonRequest<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
         {
-            string response = MakeRequest(url, baseUrl, payload, requestMethod);
+            string response = this.requestHelper.MakeRequest(url, baseUrl, payload, requestMethod);
             return JsonConvert.DeserializeObject<T>(response);
         }
 
@@ -385,22 +337,11 @@ namespace ExchangeSharp
         }
 
         /// <summary>
-        /// Process a request url
-        /// </summary>
-        /// <param name="url">Url</param>
-        /// <param name="payload">Payload</param>
-        /// <returns>Updated url</returns>
-        protected virtual Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
-        {
-            return url.Uri;
-        }
-
-        /// <summary>
         /// Additional handling for request
         /// </summary>
         /// <param name="request">Request</param>
         /// <param name="payload">Payload</param>
-        protected virtual void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public virtual void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
 
         }
@@ -409,9 +350,20 @@ namespace ExchangeSharp
         /// Additional handling for response
         /// </summary>
         /// <param name="response">Response</param>
-        protected virtual void ProcessResponse(HttpWebResponse response)
+        public virtual void ProcessResponse(HttpWebResponse response)
         {
 
+        }
+
+        /// <summary>
+        /// Process a request url
+        /// </summary>
+        /// <param name="url">Url</param>
+        /// <param name="payload">Payload</param>
+        /// <returns>Updated url</returns>
+        public virtual Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
+        {
+            return url.Uri;
         }
 
         /// <summary>

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -28,25 +28,6 @@ using Newtonsoft.Json.Linq;
 namespace ExchangeSharp
 {
     /// <summary>
-    /// Exception class for API calls
-    /// </summary>
-    public class APIException : Exception
-    {
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="message">Message</param>
-        public APIException(string message) : base(message) { }
-
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="innerException">Inner exception</param>
-        public APIException(string message, Exception innerException) : base(message, innerException) { }
-    }
-
-    /// <summary>
     /// Type of nonce styles
     /// </summary>
     public enum NonceStyle

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -17,6 +17,8 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     /// <summary>
     /// Base class for all exchange API
     /// </summary>
@@ -36,6 +38,15 @@ namespace ExchangeSharp
                 ExchangeAPI api = Activator.CreateInstance(type) as ExchangeAPI;
                 apis[api.Name] = api;
             }
+        }
+
+        protected ExchangeAPI() : this(null)
+        {
+        }
+
+        protected ExchangeAPI(IRequestHelper helper)
+        {
+            this.requestHelper = helper ?? new RequestHelper(this);
         }
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -17,8 +17,7 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
+    /// <summary>
     /// <summary>
     /// Base class for all exchange API
     /// </summary>

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -22,8 +22,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeBinanceAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.binance.com/api/v1";

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -778,7 +778,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {
@@ -786,7 +786,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
+        public override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -22,6 +22,8 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeBinanceAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.binance.com/api/v1";
@@ -40,6 +42,12 @@ namespace ExchangeSharp
         }
 
         public ExchangeBinanceAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeBinanceAPI(IRequestHelper requestHelper) 
+            : base(requestHelper)
         {
             // give binance plenty of room to accept requests
             RequestWindow = TimeSpan.FromMinutes(15.0);

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -695,7 +695,7 @@ namespace ExchangeSharp
             return resp;
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -23,6 +23,8 @@ namespace ExchangeSharp
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
+    using ExchangeSharp.API.Services;
+
     public class ExchangeBitfinexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.bitfinex.com/v2";
@@ -34,6 +36,12 @@ namespace ExchangeSharp
         public string BaseUrlV1 { get; set; } = "https://api.bitfinex.com/v1";
 
         public ExchangeBitfinexAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeBitfinexAPI(IRequestHelper requestHelper) 
+            : base(requestHelper)
         {
             NonceStyle = NonceStyle.UnixMillisecondsString;
             RateLimit = new RateGate(1, TimeSpan.FromSeconds(6.0));

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -23,8 +23,6 @@ namespace ExchangeSharp
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
-    using ExchangeSharp.API.Services;
-
     public class ExchangeBitfinexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.bitfinex.com/v2";

--- a/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
@@ -17,8 +17,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeBithumbAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.bithumb.com";

--- a/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
@@ -17,12 +17,24 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeBithumbAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.bithumb.com";
         public override string Name => ExchangeName.Bithumb;
 
         private static readonly char[] normalizeSeps = new char[] { '-', '_' };
+
+        public ExchangeBithumbAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeBithumbAPI(IRequestHelper requestHelper)
+            : base(requestHelper)
+        {
+        }
 
         public override string NormalizeSymbol(string symbol)
         {

--- a/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
@@ -19,6 +19,8 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeBitstampAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://www.bitstamp.net/api/v2";
@@ -33,11 +35,17 @@ namespace ExchangeSharp
             set { Passphrase = value.ToSecureString(); }
         }
 
+        public ExchangeBitstampAPI() 
+            : this((IRequestHelper)null)
+        {
+        }
+
         /// <summary>
         /// In order to use private functions of the API, you must set CustomerId by calling constructor with parameter,
         /// or setting it later in the ExchangeBitstampAPI object.
         /// </summary>
-        public ExchangeBitstampAPI()
+        public ExchangeBitstampAPI(IRequestHelper requestHelper) 
+            : base(requestHelper)
         {
             RequestContentType = "application/x-www-form-urlencoded";
             NonceStyle = NonceStyle.UnixMilliseconds;

--- a/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
@@ -19,8 +19,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeBitstampAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://www.bitstamp.net/api/v2";

--- a/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
@@ -53,7 +53,7 @@ namespace ExchangeSharp
             CustomerId = customerId;
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -154,7 +154,7 @@ namespace ExchangeSharp
             return url.Uri;
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -22,8 +22,6 @@ namespace ExchangeSharp
     using System.Threading.Tasks;
     using System.Web;
 
-    using ExchangeSharp.API.Services;
-
     public class ExchangeBittrexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://bittrex.com/api/v1.1";

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -22,6 +22,8 @@ namespace ExchangeSharp
     using System.Threading.Tasks;
     using System.Web;
 
+    using ExchangeSharp.API.Services;
+
     public class ExchangeBittrexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://bittrex.com/api/v1.1";
@@ -37,6 +39,12 @@ namespace ExchangeSharp
         public HashSet<string> OneFieldDepositCoinTypes { get; }
 
         public ExchangeBittrexAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeBittrexAPI(IRequestHelper requestHelper = null) 
+            : base(requestHelper)
         {
             this.TwoFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -143,7 +143,7 @@ namespace ExchangeSharp
             return order;
         }
 
-        protected override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
+        public override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -118,7 +118,7 @@ namespace ExchangeSharp
             WriteFormToRequest(request, form);
         }
 
-        protected override void ProcessResponse(HttpWebResponse response)
+        public override void ProcessResponse(HttpWebResponse response)
         {
             base.ProcessResponse(response);
             cursorAfter = response.Headers["cb-after"];

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -95,7 +95,7 @@ namespace ExchangeSharp
             return base.CanMakeAuthenticatedRequest(payload) && Passphrase != null;
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (!CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -21,8 +21,6 @@ namespace ExchangeSharp
 {
     using System.Linq;
 
-    using ExchangeSharp.API.Services;
-
     public class ExchangeGdaxAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.gdax.com";

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -21,6 +21,8 @@ namespace ExchangeSharp
 {
     using System.Linq;
 
+    using ExchangeSharp.API.Services;
+
     public class ExchangeGdaxAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.gdax.com";
@@ -126,6 +128,12 @@ namespace ExchangeSharp
         }
 
         public ExchangeGdaxAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeGdaxAPI(IRequestHelper requestHelper) 
+            : base(requestHelper)
         {
             RequestContentType = "application/json";
             NonceStyle = NonceStyle.UnixSeconds;

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -22,10 +22,22 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeGeminiAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.gemini.com/v1";
         public override string Name => ExchangeName.Gemini;
+
+        public ExchangeGeminiAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeGeminiAPI(IRequestHelper requestHelper)
+            : base(requestHelper)
+        {
+        }
 
         private ExchangeVolume ParseVolume(JToken token)
         {

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -22,8 +22,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeGeminiAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.gemini.com/v1";

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -70,7 +70,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -174,7 +174,7 @@ namespace ExchangeSharp
             }
         }
 
-        public ExchangeKrakenAPI() : base()
+        public ExchangeKrakenAPI()
         {
             RequestMethod = "POST";
             RequestContentType = "application/x-www-form-urlencoded";

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -22,8 +22,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeKrakenAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.kraken.com";

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -175,6 +175,12 @@ namespace ExchangeSharp
         }
 
         public ExchangeKrakenAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeKrakenAPI(IRequestHelper requestHelper)
+            : base(requestHelper)
         {
             RequestMethod = "POST";
             RequestContentType = "application/x-www-form-urlencoded";

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -22,6 +22,8 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeKrakenAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://api.kraken.com";
@@ -139,7 +141,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (payload == null || PrivateApiKey == null || PublicApiKey == null || !payload.ContainsKey("nonce"))
             {
@@ -172,7 +174,7 @@ namespace ExchangeSharp
             }
         }
 
-        public ExchangeKrakenAPI()
+        public ExchangeKrakenAPI() : base()
         {
             RequestMethod = "POST";
             RequestContentType = "application/x-www-form-urlencoded";

--- a/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
@@ -17,8 +17,6 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.API.Services;
-
     public class ExchangeOkexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://www.okex.com/api/v1";

--- a/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
@@ -17,12 +17,20 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.API.Services;
+
     public class ExchangeOkexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://www.okex.com/api/v1";
         public override string Name => ExchangeName.Okex;
 
         public ExchangeOkexAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangeOkexAPI(IRequestHelper requestHelper)
+            : base(requestHelper)
         {
             RequestContentType = "application/x-www-form-urlencoded";
         }

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -23,8 +23,6 @@ namespace ExchangeSharp
     using System.IO;
     using System.Reflection;
 
-    using ExchangeSharp.API.Services;
-
     public class ExchangePoloniexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://poloniex.com";
@@ -313,11 +311,12 @@ namespace ExchangeSharp
 
             var markets = new List<ExchangeMarket>();
             Dictionary<string, JToken> lookup = MakeJsonRequest<Dictionary<string, JToken>>("/public?command=returnOrderBook&currencyPair=all&depth=0");
+            // StepSize is 8 decimal places for both price and amount on everything at Polo
+            const decimal StepSize = 0.00000001m;
+            const decimal minTradeSize = 0.0001m;
+
             foreach (var kvp in lookup)
             {
-                // StepSize is 8 decimal places for both price and amount on everything at Polo
-                const decimal StepSize = 0.00000001m;
-                const decimal minTradeSize = 0.0001m;
                 var market = new ExchangeMarket { MarketName = kvp.Key, IsActive = false };
 
                 string isFrozen = kvp.Value["isFrozen"].ToStringInvariant();

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -321,6 +321,9 @@ namespace ExchangeSharp
             Dictionary<string, JToken> lookup = MakeJsonRequest<Dictionary<string, JToken>>("/public?command=returnOrderBook&currencyPair=all&depth=0");
             foreach (var kvp in lookup)
             {
+                // StepSize is 8 decimal places for both price and amount on everything at Polo
+                const decimal StepSize = 0.00000001m;
+                const decimal minTradeSize = 0.0001m;
                 var market = new ExchangeMarket { MarketName = kvp.Key, IsActive = false };
 
                 string isFrozen = kvp.Value["isFrozen"].ToStringInvariant();
@@ -334,9 +337,12 @@ namespace ExchangeSharp
                 {
                     market.BaseCurrency = pairs[0];
                     market.MarketCurrency = pairs[1];
+                    market.PriceStepSize = StepSize;
+                    market.QuantityStepSize = StepSize;
+                    market.MinPrice = StepSize;
+                    market.MinTradeSize = minTradeSize;
                 }
 
-                // TODO: Not sure how to find min order amount
                 markets.Add(market);
             }
 

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -117,7 +117,7 @@ namespace ExchangeSharp
 
                 order.Price = result["rate"].ConvertInvariant<decimal>();
                 order.Amount = result["startingAmount"].ConvertInvariant<decimal>();
-                order.AmountFilled = amount - order.Amount; // Is this right?
+                order.AmountFilled = amount - order.Amount;
                 order.OrderDate = result["date"].ConvertInvariant<DateTime>();
                 order.IsBuy = result["type"].ToStringLowerInvariant() != "sell";
 

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -23,6 +23,8 @@ namespace ExchangeSharp
     using System.IO;
     using System.Reflection;
 
+    using ExchangeSharp.API.Services;
+
     public class ExchangePoloniexAPI : ExchangeAPI
     {
         public override string BaseUrl { get; set; } = "https://poloniex.com";
@@ -51,6 +53,12 @@ namespace ExchangeSharp
         }
 
         public ExchangePoloniexAPI()
+            : this(null)
+        {
+        }
+
+        public ExchangePoloniexAPI(IRequestHelper requestHelper) 
+            : base(requestHelper)
         {
             RequestContentType = "application/x-www-form-urlencoded";
         }

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -607,11 +607,15 @@ namespace ExchangeSharp
             }
 
             string symbol = NormalizeSymbol(order.Symbol);
+
+            decimal orderAmount = this.ClampOrderQuantity(symbol, order.Amount);
+            decimal orderPrice = this.ClampOrderPrice(symbol, order.Price);
+
             List<object> orderParams = new List<object>
             {
                 "currencyPair", symbol,
-                "rate", order.Price.ToStringInvariant(),
-                "amount", order.RoundAmount().ToStringInvariant()
+                "rate", orderPrice.ToStringInvariant(),
+                "amount", orderAmount.ToStringInvariant()
             };
             foreach (KeyValuePair<string, object> kv in order.ExtraParameters)
             {

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -242,7 +242,7 @@ namespace ExchangeSharp
             };
         }
 
-        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        public override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
             if (CanMakeAuthenticatedRequest(payload))
             {

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -105,7 +105,7 @@ namespace ExchangeSharp
             return this.MakeJsonRequest<JToken>("/tradingApi", null, payload);
         }
 
-        public ExchangeOrderResult ParseActiveOrder(JToken result)
+        public ExchangeOrderResult ParsePlacedOrder(JToken result)
         {
             ExchangeOrderResult order = new ExchangeOrderResult
             {
@@ -121,7 +121,10 @@ namespace ExchangeSharp
             return order;
         }
 
-        public ExchangeOrderResult ParseOpenOrders(JToken result)
+        /// <summary>Parses an order which has not been filled.</summary>
+        /// <param name="result">The JToken to parse.</param>
+        /// <returns>ExchangeOrderResult with the open order and how much is remaining to fill</returns>
+        public ExchangeOrderResult ParseOpenOrder(JToken result)
         {
             ExchangeOrderResult order = new ExchangeOrderResult
             {
@@ -616,7 +619,7 @@ namespace ExchangeSharp
 
             JToken result = MakePrivateAPIRequest(order.IsBuy ? "buy" : "sell", orderParams);
             CheckError(result);
-            ExchangeOrderResult exchangeOrderResult = this.ParseActiveOrder(result);
+            ExchangeOrderResult exchangeOrderResult = this.ParsePlacedOrder(result);
             exchangeOrderResult.Symbol = symbol;
             exchangeOrderResult.FeesCurrency = ParseFeesCurrency(order.IsBuy, symbol);
             return exchangeOrderResult;
@@ -653,7 +656,7 @@ namespace ExchangeSharp
                     {
                         foreach (JToken token in array)
                         {
-                            yield return this.ParseActiveOrder(token);
+                            yield return this.ParseOpenOrder(token);
                         }
                     }
                 }
@@ -662,7 +665,7 @@ namespace ExchangeSharp
             {
                 foreach (JToken token in array)
                 {
-                    yield return this.ParseActiveOrder(token);
+                    yield return this.ParseOpenOrder(token);
                 }
             }
         }

--- a/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
@@ -98,28 +98,6 @@ namespace ExchangeSharp
         object GenerateNonce();
 
         /// <summary>
-        /// Make a raw request to a path on the API
-        /// </summary>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// The encoding of payload is exchange dependant but is typically json.</param>
-        /// <param name="method">Request method or null for default</param>
-        /// <returns>Raw response</returns>
-        string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null);
-
-        /// <summary>
-        /// ASYNC - Make a raw request to a path on the API
-        /// </summary>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// The encoding of payload is exchange dependant but is typically json.</param>
-        /// <param name="method">Request method or null for default</param>
-        /// <returns>Raw response</returns>
-        Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null);
-
-        /// <summary>
         /// Make a JSON request to an API end point
         /// </summary>
         /// <typeparam name="T">Type of object to parse JSON as</typeparam>

--- a/ExchangeSharp/API/IRequestHelper.cs
+++ b/ExchangeSharp/API/IRequestHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace ExchangeSharp.API.Services
+﻿namespace ExchangeSharp
 {
     using System.Collections.Generic;
 

--- a/ExchangeSharp/API/IRequestHelper.cs
+++ b/ExchangeSharp/API/IRequestHelper.cs
@@ -1,0 +1,18 @@
+﻿namespace ExchangeSharp.API.Services
+{
+    using System.Collections.Generic;
+
+    public interface IRequestHelper
+    {
+        /// <summary>
+        /// Make a request to a path on the API
+        /// </summary>
+        /// <param name="url">Path and query</param>
+        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+        /// The encoding of payload is API dependant but is typically json.</param>
+        /// <param name="method">Request method or null for default</param>
+        /// <returns>Raw response</returns>
+        string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null);
+    }
+}

--- a/ExchangeSharp/API/RequestHelper.cs
+++ b/ExchangeSharp/API/RequestHelper.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExchangeSharp.API.Services
+{
+    using System.IO;
+    using System.Net;
+
+    class RequestHelper : IRequestHelper
+    {
+        private BaseAPI api;
+
+        public RequestHelper(BaseAPI api)
+        {
+            this.api = api;
+        }
+
+        /// <summary>
+        /// Make a request to a path on the API
+        /// </summary>
+        /// <param name="url">Path and query</param>
+        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+        /// The encoding of payload is API dependant but is typically json.</param>
+        /// <param name="method">Request method or null for default</param>
+        /// <returns>Raw response</returns>
+        public string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
+        {
+            this.api.RateLimit.WaitToProceed();
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return null;
+            }
+            else if (url[0] != '/')
+            {
+                url = "/" + url;
+            }
+
+            string fullUrl = (baseUrl ?? this.api.BaseUrl) + url;
+            Uri uri = this.api.ProcessRequestUrl(new UriBuilder(fullUrl), payload);
+            HttpWebRequest request = HttpWebRequest.CreateHttp(uri);
+            request.Headers["Accept-Language"] = "en-us; q=1.0;";
+            request.Method = method ?? this.api.RequestMethod;
+            request.ContentType = this.api.RequestContentType;
+            request.UserAgent = BaseAPI.RequestUserAgent;
+            request.CachePolicy = this.api.CachePolicy;
+            request.Timeout = request.ReadWriteTimeout = request.ContinueTimeout = (int)this.api.RequestTimeout.TotalMilliseconds;
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            api.ProcessRequest(request, payload);
+            HttpWebResponse response;
+            try
+            {
+                response = request.GetResponse() as HttpWebResponse;
+                if (response == null)
+                {
+                    throw new APIException("Unknown response from server");
+                }
+            }
+            catch (WebException we)
+            {
+                response = we.Response as HttpWebResponse;
+                if (response == null)
+                {
+                    throw new APIException(we.Message ?? "Unknown response from server");
+                }
+            }
+            string responseString = null;
+            using (Stream responseStream = response.GetResponseStream())
+            {
+                responseString = new StreamReader(responseStream).ReadToEnd();
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new APIException(responseString);
+                }
+                api.ProcessResponse(response);
+            }
+            response.Dispose();
+            return responseString;
+        }
+    }
+}

--- a/ExchangeSharp/API/RequestHelper.cs
+++ b/ExchangeSharp/API/RequestHelper.cs
@@ -2,12 +2,16 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace ExchangeSharp.API.Services
+namespace ExchangeSharp
 {
     using System.IO;
     using System.Net;
 
-    class RequestHelper : IRequestHelper
+    /// <summary>
+    /// Handles all the logic for making API calls.
+    /// </summary>
+    /// <seealso cref="ExchangeSharp.API.Services.IRequestHelper" />
+    public class RequestHelper : IRequestHelper
     {
         private BaseAPI api;
 

--- a/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -14,6 +14,8 @@ namespace ExchangeSharp
 {
     using System;
 
+    using Newtonsoft.Json.Linq;
+
     /// <summary>Result of an exchange order</summary>
     public class ExchangeOrderResult
     {

--- a/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -14,8 +14,6 @@ namespace ExchangeSharp
 {
     using System;
 
-    using Newtonsoft.Json.Linq;
-
     /// <summary>Result of an exchange order</summary>
     public class ExchangeOrderResult
     {

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using ExchangeSharp;
     using ExchangeSharp.API.Services;
@@ -18,6 +19,8 @@
     [TestClass]
     public class ExchangePoloniexAPITests
     {
+        private static Action Invoking(Action action) => action;
+
         private const string SingleMarketTradeHistory = @"[{
     ""globalTradeID"": 25129732,
     ""tradeID"": ""6325758"",
@@ -314,6 +317,319 @@
 
         #endregion
 
+        #region GetCompletedOrderDetails_AllGas
+
+        private const string ReturnOrderTrades_AllGas = @"[{
+    ""globalTradeID"": 359099213,
+    ""tradeID"": ""130931"",
+    ""date"": ""2018-04-04 01:31:41"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.09270548"",
+    ""total"": ""0.00382224"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359099165,
+    ""tradeID"": ""130930"",
+    ""date"": ""2018-04-04 01:31:33"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.49122807"",
+    ""total"": ""0.02025333"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359099125,
+    ""tradeID"": ""130929"",
+    ""date"": ""2018-04-04 01:31:24"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098971,
+    ""tradeID"": ""130928"",
+    ""date"": ""2018-04-04 01:30:59"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098909,
+    ""tradeID"": ""130927"",
+    ""date"": ""2018-04-04 01:30:50"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098836,
+    ""tradeID"": ""130926"",
+    ""date"": ""2018-04-04 01:30:41"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098805,
+    ""tradeID"": ""130925"",
+    ""date"": ""2018-04-04 01:30:34"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098661,
+    ""tradeID"": ""130924"",
+    ""date"": ""2018-04-04 01:30:10"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098505,
+    ""tradeID"": ""130923"",
+    ""date"": ""2018-04-04 01:29:46"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098451,
+    ""tradeID"": ""130922"",
+    ""date"": ""2018-04-04 01:29:39"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.26835036"",
+    ""total"": ""0.01106408"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359098353,
+    ""tradeID"": ""130920"",
+    ""date"": ""2018-04-04 01:29:11"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359097358,
+    ""tradeID"": ""130919"",
+    ""date"": ""2018-04-04 01:25:56"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.30075188"",
+    ""total"": ""0.01240000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359097294,
+    ""tradeID"": ""130918"",
+    ""date"": ""2018-04-04 01:25:44"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.49122807"",
+    ""total"": ""0.02025333"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359097028,
+    ""tradeID"": ""130917"",
+    ""date"": ""2018-04-04 01:25:05"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""0.40853799"",
+    ""total"": ""0.01684402"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359094184,
+    ""tradeID"": ""130914"",
+    ""date"": ""2018-04-04 01:11:45"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""1.61598982"",
+    ""total"": ""0.06662726"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 359078956,
+    ""tradeID"": ""130910"",
+    ""date"": ""2018-04-04 00:02:42"",
+    ""rate"": ""0.04123000"",
+    ""amount"": ""3.63812757"",
+    ""total"": ""0.14999999"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17565886729"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358351885,
+    ""tradeID"": ""130147"",
+    ""date"": ""2018-04-01 02:43:03"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.17821893"",
+    ""total"": ""0.00707885"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358351682,
+    ""tradeID"": ""130146"",
+    ""date"": ""2018-04-01 02:41:03"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""4.39606430"",
+    ""total"": ""0.17461167"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358351475,
+    ""tradeID"": ""130145"",
+    ""date"": ""2018-04-01 02:40:32"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""2.78493409"",
+    ""total"": ""0.11061758"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358350781,
+    ""tradeID"": ""130144"",
+    ""date"": ""2018-04-01 02:34:58"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358350765,
+    ""tradeID"": ""130143"",
+    ""date"": ""2018-04-01 02:34:46"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358350760,
+    ""tradeID"": ""130142"",
+    ""date"": ""2018-04-01 02:34:41"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358350720,
+    ""tradeID"": ""130141"",
+    ""date"": ""2018-04-01 02:34:03"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.50949000"",
+    ""total"": ""0.02023694"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358350626,
+    ""tradeID"": ""130140"",
+    ""date"": ""2018-04-01 02:33:23"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.43261515"",
+    ""total"": ""0.01718347"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358329457,
+    ""tradeID"": ""130133"",
+    ""date"": ""2018-03-31 22:49:19"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.48059203"",
+    ""total"": ""0.01908911"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358316481,
+    ""tradeID"": ""130128"",
+    ""date"": ""2018-03-31 21:05:15"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.00923445"",
+    ""total"": ""0.00036679"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358284828,
+    ""tradeID"": ""130127"",
+    ""date"": ""2018-03-31 17:09:24"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.00730656"",
+    ""total"": ""0.00029021"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 358284727,
+    ""tradeID"": ""130126"",
+    ""date"": ""2018-03-31 17:08:09"",
+    ""rate"": ""0.03971998"",
+    ""amount"": ""8.27247449"",
+    ""total"": ""0.32858252"",
+    ""fee"": ""0.00250000"",
+    ""orderNumber"": ""17518581082"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}]";
+#endregion
+
         [TestMethod]
         public void ParseBuyOrder_SingleTrade_HappyPath()
         {
@@ -331,7 +647,7 @@
 
             var singleOrder = JsonConvert.DeserializeObject<JToken>(BuyOrder);
             var polo = new ExchangePoloniexAPI();
-            ExchangeOrderResult order = polo.ParseOrder(singleOrder);
+            ExchangeOrderResult order = polo.ParseActiveOrder(singleOrder);
             order.OrderId.Should().Be("31226040");
             order.IsBuy.Should().BeTrue();
             order.Amount.Should().Be(338.8732m);
@@ -359,7 +675,7 @@
 
             var singleOrder = JsonConvert.DeserializeObject<JToken>(SellOrder);
             var polo = new ExchangePoloniexAPI();
-            ExchangeOrderResult order = polo.ParseOrder(singleOrder);
+            ExchangeOrderResult order = polo.ParseActiveOrder(singleOrder);
             order.OrderId.Should().Be("31226040");
             order.IsBuy.Should().BeFalse();
             order.Amount.Should().Be(338.8732m);
@@ -375,7 +691,8 @@
         {
             var order = new ExchangeOrderResult();
             var orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTradesSell);
-            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            var polo = new ExchangePoloniexAPI();
+            polo.ParseOrderTrades(orderWithMultipleTrades, order);
             order.Amount.Should().Be(143.14m);
             order.AmountFilled.Should().Be(order.Amount);
             order.Fees.Should().Be(0.00006141m);
@@ -392,7 +709,8 @@
         {
             var order = new ExchangeOrderResult();
             var orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTrades_SimpleBuy);
-            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            var polo = new ExchangePoloniexAPI();
+            polo.ParseOrderTrades(orderWithMultipleTrades, order);
             order.OrderId.Should().BeNullOrEmpty();
             order.Amount.Should().Be(19096.46996880m);
             order.AmountFilled.Should().Be(order.Amount);
@@ -409,7 +727,8 @@
         {
             var order = new ExchangeOrderResult();
             var orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTrades_GasBuy);
-            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            var polo = new ExchangePoloniexAPI();
+            polo.ParseOrderTrades(orderWithMultipleTrades, order);
             order.AveragePrice.Should().Be(0.0397199908083616777777777778m);
             order.IsBuy.Should().BeTrue();
         }
@@ -439,24 +758,14 @@
             {
                 foreach (JToken token in array)
                 {
-                    orders.Add(polo.ParseOrder(token));
+                    orders.Add(polo.ParseOpenOrders(token));
                 }
             }
 
             orders[0].OrderId.Should().Be("120466");
             orders[0].IsBuy.Should().BeFalse();
             orders[0].Price.Should().Be(0.025m);
-//            orders[0].Amount.Should().Be(100);
-
-        }
-
-        [TestMethod]
-        public void GetOrderdetails_happyPath()
-        {
-            var requestHelper = Substitute.For<IRequestHelper>();
-            requestHelper.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_SimpleBuy);
-            var polo = new ExchangePoloniexAPI(requestHelper);
-            var response = polo.GetOrderDetails("1");
+            //            orders[0].Amount.Should().Be(100);
         }
 
         [TestMethod]
@@ -475,7 +784,7 @@
 
             var polo = new ExchangePoloniexAPI();
             JToken marketOrders = JsonConvert.DeserializeObject<JToken>(unfilled);
-            ExchangeOrderResult order = polo.ParseOrder(marketOrders[0]);
+            ExchangeOrderResult order = polo.ParseOpenOrders(marketOrders[0]);
             order.OrderId.Should().Be("35329211614");
             order.IsBuy.Should().BeTrue();
             order.AmountFilled.Should().Be(0);
@@ -483,6 +792,66 @@
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
+        }
+
+        [TestMethod]
+        public void GetOrderDetails_HappyPath()
+        {
+            var requestHelper = Substitute.For<IRequestHelper>();
+            requestHelper.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_SimpleBuy);
+            var polo = new ExchangePoloniexAPI(requestHelper);
+            ExchangeOrderResult order = polo.GetOrderDetails("1");
+
+            order.OrderId.Should().Be("1");
+            order.Amount.Should().Be(19096.46996880m);
+            order.AmountFilled.Should().Be(order.Amount);
+            order.IsBuy.Should().BeTrue();
+            order.Fees.Should().Be(28.64470495m);
+            order.FeesCurrency.Should().Be("XEM");
+            order.Symbol.Should().Be("BTC_XEM");
+            order.Price.Should().Be(0.00005128m);
+            order.AveragePrice.Should().Be(0.00005128m);
+        }
+
+        [TestMethod]
+        public void GetOrderDetails_OrderNotFound_DoesNotThrow()
+        {
+            var requestHelper = Substitute.For<IRequestHelper>();
+            requestHelper.MakeRequest(null).ReturnsForAnyArgs(@"{""error"":""Order not found, or you are not the person who placed it.""}");
+            var polo = new ExchangePoloniexAPI(requestHelper);
+            polo.GetOrderDetails("1").Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetOrderDetails_OtherErrors_ThrowAPIException()
+        {
+            var requestHelper = Substitute.For<IRequestHelper>();
+            requestHelper.MakeRequest(null).ReturnsForAnyArgs(@"{""error"":""Big scary error.""}");
+            var polo = new ExchangePoloniexAPI(requestHelper);
+
+            void a() => polo.GetOrderDetails("1");
+            Invoking(a).Should().Throw<APIException>();
+        }
+
+        [TestMethod]
+        public void GetCompletedOrderDetails_MultipleOrders()
+        {
+            var requestHelper = Substitute.For<IRequestHelper>();
+            requestHelper.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_AllGas);
+            var polo = new ExchangePoloniexAPI(requestHelper);
+            IEnumerable<ExchangeOrderResult> orders = polo.GetCompletedOrderDetails("ETH_GAS");
+            orders.Should().HaveCount(2);
+            var sellorder = orders.Single(x => !x.IsBuy);
+            sellorder.AveragePrice.Should().Be(0.04123m);
+            sellorder.AmountFilled.Should().Be(9.71293428m);
+            sellorder.FeesCurrency.Should().Be("ETH");
+            sellorder.Fees.Should().Be(0.0006007m);
+
+            var buyOrder = orders.Single(x => x.IsBuy);
+            buyOrder.AveragePrice.Should().Be(0.0397199908083616777777777778m);
+            buyOrder.AmountFilled.Should().Be(18);
+            buyOrder.FeesCurrency.Should().Be("GAS");
+            buyOrder.Fees.Should().Be(0.0352725m);
         }
     }
 }

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
 
     using ExchangeSharp;
+    using ExchangeSharp.API.Services;
 
     using FluentAssertions;
 
@@ -11,6 +12,8 @@
 
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+
+    using NSubstitute;
 
     [TestClass]
     public class ExchangePoloniexAPITests
@@ -414,19 +417,19 @@
         [TestMethod]
         public void ReturnOpenOrders_SingleMarket_Parses()
         {
-            string marketOrdersJson = @"[{
-    ""orderNumber"": ""120466"",
-    ""type"": ""sell"",
-    ""rate"": ""0.025"",
-    ""amount"": ""100"",
-    ""total"": ""2.5""
-}, {
-    ""orderNumber"": ""120467"",
-    ""type"": ""sell"",
-    ""rate"": ""0.04"",
-    ""amount"": ""100"",
-    ""total"": ""4""
-}]";
+        string marketOrdersJson = @"[{
+            ""orderNumber"": ""120466"",
+            ""type"": ""sell"",
+            ""rate"": ""0.025"",
+            ""amount"": ""100"",
+            ""total"": ""2.5""
+        }, {
+            ""orderNumber"": ""120467"",
+            ""type"": ""sell"",
+            ""rate"": ""0.04"",
+            ""amount"": ""100"",
+            ""total"": ""4""
+        }]";
             var polo = new ExchangePoloniexAPI();
             JToken marketOrders = JsonConvert.DeserializeObject<JToken>(marketOrdersJson);
 
@@ -443,8 +446,17 @@
             orders[0].OrderId.Should().Be("120466");
             orders[0].IsBuy.Should().BeFalse();
             orders[0].Price.Should().Be(0.025m);
-            orders[0].Amount.Should().Be(100);
+//            orders[0].Amount.Should().Be(100);
 
+        }
+
+        [TestMethod]
+        public void GetOrderdetails_happyPath()
+        {
+            var requestHelper = Substitute.For<IRequestHelper>();
+            requestHelper.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_SimpleBuy);
+            var polo = new ExchangePoloniexAPI(requestHelper);
+            var response = polo.GetOrderDetails("1");
         }
 
         [TestMethod]

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -1,0 +1,422 @@
+﻿namespace ExchangeSharpTests
+{
+    using System;
+    using System.Threading;
+
+    using ExchangeSharp;
+
+    using FluentAssertions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class ExchangePoloniexAPITests
+    {
+        private const string SingleMarketTradeHistory =
+            @"[{
+    ""globalTradeID"": 25129732,
+    ""tradeID"": ""6325758"",
+    ""date"": ""2016-04-05 08:08:40"",
+    ""rate"": ""0.02565498"",
+    ""amount"": ""0.10000000"",
+    ""total"": ""0.00256549"",
+    ""fee"": ""0.00200000"",
+    ""orderNumber"": ""34225313575"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 25129628,
+    ""tradeID"": ""6325741"",
+    ""date"": ""2016-04-05 08:07:55"",
+    ""rate"": ""0.02565499"",
+    ""amount"": ""0.10000000"",
+    ""total"": ""0.00256549"",
+    ""fee"": ""0.00200000"",
+    ""orderNumber"": ""34225195693"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}]";
+
+        #region AllMarketTradeHistory
+
+        private const string AllMarketTradeHistory =
+            @"{
+    ""BTC_MAID"": [{
+        ""globalTradeID"": 29251512,
+        ""tradeID"": ""1385888"",
+        ""date"": ""2016-05-03 01:29:55"",
+        ""rate"": ""0.00014243"",
+        ""amount"": ""353.74692925"",
+        ""total"": ""0.05038417"",
+        ""fee"": ""0.00200000"",
+        ""orderNumber"": ""12603322113"",
+        ""type"": ""buy"",
+        ""category"": ""settlement""
+    }, {
+        ""globalTradeID"": 29251511,
+        ""tradeID"": ""1385887"",
+        ""date"": ""2016-05-03 01:29:55"",
+        ""rate"": ""0.00014111"",
+        ""amount"": ""311.24262497"",
+        ""total"": ""0.04391944"",
+        ""fee"": ""0.00200000"",
+        ""orderNumber"": ""12603319116"",
+        ""type"": ""sell"",
+        ""category"": ""marginTrade""
+    }, ...],
+    ""BTC_LTC"": [...]...
+}";
+        #endregion
+
+        #region CompletedOrderDetails
+
+        private const string CompletedOrderDetails = @"[{
+    ""globalTradeID"": 345739440,
+    ""tradeID"": ""6238142"",
+    ""date"": ""2018-02-16 19:55:15"",
+    ""rate"": ""0.00005100"",
+    ""amount"": ""7579.24108267"",
+    ""total"": ""0.38654129"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""47874850339"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 345739439,
+    ""tradeID"": ""6238141"",
+    ""date"": ""2018-02-16 19:55:14"",
+    ""rate"": ""0.00005100"",
+    ""amount"": ""2.28017336"",
+    ""total"": ""0.00011628"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""47874850339"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 345737315,
+    ""tradeID"": ""6238069"",
+    ""date"": ""2018-02-16 19:46:43"",
+    ""rate"": ""0.00005115"",
+    ""amount"": ""11486.30400782"",
+    ""total"": ""0.58752444"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""47874023167"",
+    ""type"": ""sell"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 345736206,
+    ""tradeID"": ""6238021"",
+    ""date"": ""2018-02-16 19:39:23"",
+    ""rate"": ""0.00005128"",
+    ""amount"": ""9096.46996880"",
+    ""total"": ""0.46646698"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""47873217973"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}, {
+    ""globalTradeID"": 345736149,
+    ""tradeID"": ""6238020"",
+    ""date"": ""2018-02-16 19:39:06"",
+    ""rate"": ""0.00005128"",
+    ""amount"": ""10000.00000000"",
+    ""total"": ""0.51280000"",
+    ""fee"": ""0.00150000"",
+    ""orderNumber"": ""47873217973"",
+    ""type"": ""buy"",
+    ""category"": ""exchange""
+}]";
+#endregion
+
+        [TestMethod]
+        public void ParseBuyOrder_SingleTrade_HappyPath()
+        {
+            const string BuyOrder = @"{
+    ""orderNumber"": 31226040,
+    ""resultingTrades"": [{
+        ""amount"": ""338.8732"",
+        ""date"": ""2014-10-18 23:03:21"",
+        ""rate"": ""0.00000173"",
+        ""total"": ""0.00058625"",
+        ""tradeID"": ""16164"",
+        ""type"": ""buy""
+    }]
+}";
+
+            JToken singleOrder = JsonConvert.DeserializeObject<JToken>(BuyOrder);
+            var polo = new ExchangePoloniexAPI();
+            ExchangeOrderResult order = polo.ParseOrder(singleOrder);
+            order.OrderId.Should().Be("31226040");
+            order.IsBuy.Should().BeTrue();
+            order.Amount.Should().Be(338.8732m);
+            order.OrderDate.Should().Be(new DateTime(2014, 10, 18, 23, 03, 21));
+            order.AveragePrice.Should().Be(0.00000173m);
+            order.AmountFilled.Should().Be(338.8732m);
+            order.FeesCurrency.Should().BeNullOrEmpty();
+            order.Fees.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ParseSellOrder_SingleTrade_HappyPath()
+        {
+            const string SellOrder = @"{
+    ""orderNumber"": 31226040,
+    ""resultingTrades"": [{
+        ""amount"": ""338.8732"",
+        ""date"": ""2014-10-18 23:03:21"",
+        ""rate"": ""0.00000173"",
+        ""total"": ""0.00058625"",
+        ""tradeID"": ""16164"",
+        ""type"": ""sell""
+    }]
+}";
+
+            JToken singleOrder = JsonConvert.DeserializeObject<JToken>(SellOrder);
+            var polo = new ExchangePoloniexAPI();
+            ExchangeOrderResult order = polo.ParseOrder(singleOrder);
+            order.OrderId.Should().Be("31226040");
+            order.IsBuy.Should().BeFalse();
+            order.Amount.Should().Be(338.8732m);
+            order.OrderDate.Should().Be(new DateTime(2014, 10, 18, 23, 03, 21));
+            order.AveragePrice.Should().Be(0.00000173m);
+            order.AmountFilled.Should().Be(338.8732m);
+            order.FeesCurrency.Should().BeNullOrEmpty();
+            order.Fees.Should().Be(0);
+        }
+
+
+
+        private const string ReturnOrderTradesSell = @"[{
+    ""globalTradeID"": 353843995,
+    ""tradeID"": 1524326,
+    ""currencyPair"": ""BTC_VIA"",
+    ""type"": ""sell"",
+    ""rate"": ""0.00017161"",
+    ""amount"": ""119.83405116"",
+    ""total"": ""0.02056472"",
+    ""fee"": ""0.00250000"",
+    ""date"": ""2018-03-15 02:00:31""
+}, {
+    ""globalTradeID"": 353843994,
+    ""tradeID"": 1524325,
+    ""currencyPair"": ""BTC_VIA"",
+    ""type"": ""sell"",
+    ""rate"": ""0.00017163"",
+    ""amount"": ""11.65297442"",
+    ""total"": ""0.00199999"",
+    ""fee"": ""0.00250000"",
+    ""date"": ""2018-03-15 02:00:31""
+}, {
+    ""globalTradeID"": 353843993,
+    ""tradeID"": 1524324,
+    ""currencyPair"": ""BTC_VIA"",
+    ""type"": ""sell"",
+    ""rate"": ""0.00017163"",
+    ""amount"": ""11.65297442"",
+    ""total"": ""0.00199999"",
+    ""fee"": ""0.00250000"",
+    ""date"": ""2018-03-15 02:00:31""
+}]";
+
+        [TestMethod]
+        public void ReturnOrderTrades_Sell_HasCorrectValues()
+        {
+            ExchangeOrderResult order = new ExchangeOrderResult();
+            JToken orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTradesSell);
+            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            order.Amount.Should().Be(143.14m);
+            order.AmountFilled.Should().Be(order.Amount);
+            order.Fees.Should().Be(0.00006141m);
+            order.FeesCurrency.Should().Be("BTC");
+            order.IsBuy.Should().BeFalse();
+            order.OrderId.Should().BeNullOrEmpty();
+            order.AveragePrice.Should().Be(0.0001716132563851949140701411m);
+            order.Price.Should().Be(order.AveragePrice);
+            order.Symbol.Should().Be("BTC_VIA");
+        }
+
+        private const string ReturnOrderTrades_SimpleBuy = @"[{
+    ""globalTradeID"": 345736206,
+    ""tradeID"": 6238021,
+    ""currencyPair"": ""BTC_XEM"",
+    ""type"": ""buy"",
+    ""rate"": ""0.00005128"",
+    ""amount"": ""9096.46996880"",
+    ""total"": ""0.46646698"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-02-16 19:39:23""
+}, {
+    ""globalTradeID"": 345736149,
+    ""tradeID"": 6238020,
+    ""currencyPair"": ""BTC_XEM"",
+    ""type"": ""buy"",
+    ""rate"": ""0.00005128"",
+    ""amount"": ""10000.00000000"",
+    ""total"": ""0.51280000"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-02-16 19:39:06""
+}]";
+
+        [TestMethod]
+        public void ReturnOrderTrades_Buy_HasCorrectValues()
+        {
+            ExchangeOrderResult order = new ExchangeOrderResult();
+            JToken orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTrades_SimpleBuy);
+            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            order.OrderId.Should().BeNullOrEmpty();
+            order.Amount.Should().Be(19096.46996880m);
+            order.AmountFilled.Should().Be(order.Amount);
+            order.IsBuy.Should().BeTrue();
+            order.Fees.Should().Be(28.64470495m);
+            order.FeesCurrency.Should().Be("XEM");
+            order.Symbol.Should().Be("BTC_XEM");
+            order.Price.Should().Be(0.00005128m);
+            order.AveragePrice.Should().Be(0.00005128m);
+        }
+
+        #region ReturnOrderTrades_GasBuy
+
+        private const string ReturnOrderTrades_GasBuy = @"[{
+    ""globalTradeID"": 358351885,
+    ""tradeID"": 130147,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.17821893"",
+    ""total"": ""0.00707885"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:43:03""
+}, {
+    ""globalTradeID"": 358351682,
+    ""tradeID"": 130146,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""4.39606430"",
+    ""total"": ""0.17461167"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:41:03""
+}, {
+    ""globalTradeID"": 358351475,
+    ""tradeID"": 130145,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""2.78493409"",
+    ""total"": ""0.11061758"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:40:32""
+}, {
+    ""globalTradeID"": 358350781,
+    ""tradeID"": 130144,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:34:58""
+}, {
+    ""globalTradeID"": 358350765,
+    ""tradeID"": 130143,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:34:46""
+}, {
+    ""globalTradeID"": 358350760,
+    ""tradeID"": 130142,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.30969000"",
+    ""total"": ""0.01230088"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:34:41""
+}, {
+    ""globalTradeID"": 358350720,
+    ""tradeID"": 130141,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.50949000"",
+    ""total"": ""0.02023694"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:34:03""
+}, {
+    ""globalTradeID"": 358350626,
+    ""tradeID"": 130140,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.43261515"",
+    ""total"": ""0.01718347"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-04-01 02:33:23""
+}, {
+    ""globalTradeID"": 358329457,
+    ""tradeID"": 130133,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.48059203"",
+    ""total"": ""0.01908911"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-03-31 22:49:19""
+}, {
+    ""globalTradeID"": 358316481,
+    ""tradeID"": 130128,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.00923445"",
+    ""total"": ""0.00036679"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-03-31 21:05:15""
+}, {
+    ""globalTradeID"": 358284828,
+    ""tradeID"": 130127,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03972000"",
+    ""amount"": ""0.00730656"",
+    ""total"": ""0.00029021"",
+    ""fee"": ""0.00150000"",
+    ""date"": ""2018-03-31 17:09:24""
+}, {
+    ""globalTradeID"": 358284727,
+    ""tradeID"": 130126,
+    ""currencyPair"": ""ETH_GAS"",
+    ""type"": ""buy"",
+    ""rate"": ""0.03971998"",
+    ""amount"": ""8.27247449"",
+    ""total"": ""0.32858252"",
+    ""fee"": ""0.00250000"",
+    ""date"": ""2018-03-31 17:08:09""
+}]";
+
+#endregion
+
+        [TestMethod]
+        public void ReturnOrderTrades_BuyComplicatedPriceAvg_IsCorrect()
+        {
+            ExchangeOrderResult order = new ExchangeOrderResult();
+            JToken orderWithMultipleTrades = JsonConvert.DeserializeObject<JToken>(ReturnOrderTrades_GasBuy);
+            ExchangePoloniexAPI.ParseOrderTrades(orderWithMultipleTrades, order);
+            order.AveragePrice.Should().Be(0.0397199908083616777777777778m);
+            order.IsBuy.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ReturnOrderTrades_Null_DoesNotThrow()
+        {
+
+        }
+    }
+}

--- a/ExchangeSharpTests/ExchangeSharpTests.csproj
+++ b/ExchangeSharpTests/ExchangeSharpTests.csproj
@@ -11,10 +11,17 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ExchangeSharp\ExchangeSharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="NSubstitute">
+      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 ExchangePoloniexAPI is getting too complicated to edit safely. Begin refactoring to bring it under test.

Pulled out MakeRequest into a RequestHelper to make it easier to mock during unit testing. The helper is now initialized during the api constructor or passed in.

Also refactored parse order details in Polo. Lots of duplicate code removed. Added code coverage for everything that was refactored.