### PR TITLE
Set order states (filled/pending) for Poloniex. Fix trailing zeroes bug in ClampDecimal

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -10,18 +10,15 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-
-using Newtonsoft.Json.Linq;
-
 namespace ExchangeSharp
 {
+    using Newtonsoft.Json.Linq;
+    using System;
+    using System.Collections.Generic;
     using System.IO;
-    using System.Reflection;
+    using System.Linq;
+    using System.Net;
+    using System.Threading.Tasks;
 
     public class ExchangePoloniexAPI : ExchangeAPI
     {
@@ -120,11 +117,12 @@ namespace ExchangeSharp
         {
             ExchangeOrderResult order = new ExchangeOrderResult
             {
+                Amount = result["startingAmount"].ConvertInvariant<decimal>(),
+                IsBuy = result["type"].ToStringLowerInvariant() != "sell",
+                OrderDate = result["date"].ConvertInvariant<DateTime>(),
                 OrderId = result["orderNumber"].ToStringInvariant(),
                 Price = result["rate"].ConvertInvariant<decimal>(),
-                Amount = result["startingAmount"].ConvertInvariant<decimal>(),
-                OrderDate = result["date"].ConvertInvariant<DateTime>(),
-                IsBuy = result["type"].ToStringLowerInvariant() != "sell",
+                Result = ExchangeAPIOrderResult.Pending,
             };
 
             decimal amount = result["amount"].ConvertInvariant<decimal>();
@@ -195,6 +193,7 @@ namespace ExchangeSharp
 
                 this.ParseOrderTrades(tradesForOrder, order);
                 order.Price = order.AveragePrice;
+                order.Result = ExchangeAPIOrderResult.Filled;
                 orders.Add(order);
             }
         }

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -167,7 +167,15 @@ namespace ExchangeSharp
                 value -= mod;
             }
 
-            return value;
+            return value.Normalize();
+        }
+
+        /// <summary>Remove trailing zeroes on the decimal.</summary>
+        /// <param name="value">The value to normalize.</param>
+        /// <returns>1.230000 becomes 1.23</returns>
+        public static decimal Normalize(this decimal value)
+        {
+            return value / 1.000000000000000000000000000000000m;
         }
 
         public static DateTime UnixTimeStampToDateTimeSeconds(this double unixTimeStampSeconds)

--- a/ExchangeSharpTests/CryptoUtilityTests.cs
+++ b/ExchangeSharpTests/CryptoUtilityTests.cs
@@ -17,6 +17,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExchangeSharpTests
 {
+    using System.Globalization;
+
     [TestClass]
     public class CryptoUtilityTests
     {
@@ -54,6 +56,14 @@ namespace ExchangeSharpTests
             CryptoUtility.ClampDecimal(0.00000010m, 100000.00000000m, 0.00000010m, 0.00052286m).Should().Be(0.0005228m);
             CryptoUtility.ClampDecimal(0.00001000m, 100000.00000000m, 0.00001000m, 0.02525215m).Should().Be(0.02525m);
             CryptoUtility.ClampDecimal(0.00001000m, 100000.00000000m, null, 0.00401212m).Should().Be(0.00401212m);
+        }
+
+        [TestMethod]
+        public void ClampDecimalTrailingZeroesRemoved()
+        {
+            decimal result = CryptoUtility.ClampDecimal(0, Decimal.MaxValue, 0.01m, 1.23456789m);
+            result.Should().Be(1.23m);
+            result.ToString(CultureInfo.InvariantCulture).Should().NotEndWith("0");
         }
 
         [TestMethod]

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -172,7 +172,7 @@ namespace ExchangeSharpTests
             orders[0].OrderId.Should().Be("120466");
             orders[0].IsBuy.Should().BeFalse();
             orders[0].Price.Should().Be(0.025m);
-            //            orders[0].Amount.Should().Be(100);
+            orders[0].Result.Should().Be(ExchangeAPIOrderResult.Pending);
         }
 
         [TestMethod]
@@ -188,6 +188,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
+            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
         }
 
         [TestMethod]
@@ -205,6 +206,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
+            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
         }
 
         [TestMethod]
@@ -222,6 +224,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
+            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
         }
 
         [TestMethod]
@@ -240,6 +243,7 @@ namespace ExchangeSharpTests
             order.Symbol.Should().Be("BTC_XEM");
             order.Price.Should().Be(0.00005128m);
             order.AveragePrice.Should().Be(0.00005128m);
+            order.Result.Should().Be(ExchangeAPIOrderResult.Filled);
         }
 
         [TestMethod]
@@ -272,12 +276,14 @@ namespace ExchangeSharpTests
             sellorder.AmountFilled.Should().Be(9.71293428m);
             sellorder.FeesCurrency.Should().Be("ETH");
             sellorder.Fees.Should().Be(0.0006007m);
+            sellorder.Result.Should().Be(ExchangeAPIOrderResult.Filled);
 
             ExchangeOrderResult buyOrder = orders.Single(x => x.IsBuy);
             buyOrder.AveragePrice.Should().Be(0.0397199908083616777777777778m);
             buyOrder.AmountFilled.Should().Be(18);
             buyOrder.FeesCurrency.Should().Be("GAS");
             buyOrder.Fees.Should().Be(0.0352725m);
+            buyOrder.Result.Should().Be(ExchangeAPIOrderResult.Filled);
         }
 
         private static Action Invoking(Action action) => action;


### PR DESCRIPTION
Orders in Binance were failing to be placed because the trailing zeroes were not removed.