### PR TITLE
Use async methods by default, sync wraps async

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 Pull requests are encouraged and welcome. The more people contributing, the more features and faster this API will grow, serving everyone who uses C# and cryptocurrency.
 
-For JSON parsing and strings, please use the ```CryptoUtility``` extension methods ```ToStringInvariant``` and ```ConvertInvariant``` for all parsing or conversion to other values. This ensures that any locale machine will have no problems parsing and converting data.
+Please follow these guidelines...
+- For JSON parsing and strings, please use the ```CryptoUtility``` extension methods ```ToStringInvariant``` and ```ConvertInvariant``` for all parsing or conversion to other values. This ensures that any locale machine will have no problems parsing and converting data.
+- For new API interface, create a public method in ExchangeAPI and an async version. Follow the pattern of other API methods for handling the synchronization context.
 
 

--- a/ExchangeSharp/API/APIRequestMaker.cs
+++ b/ExchangeSharp/API/APIRequestMaker.cs
@@ -33,7 +33,7 @@ namespace ExchangeSharp
         /// <param name="api">API</param>
         public APIRequestMaker(IAPIRequestHandler api)
         {
-            api = api;
+            this.api = api;
         }
 
         /// <summary>

--- a/ExchangeSharp/API/APIRequestMaker.cs
+++ b/ExchangeSharp/API/APIRequestMaker.cs
@@ -61,7 +61,9 @@ namespace ExchangeSharp
         /// <returns>Raw response</returns>
         public async Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
         {
-            await api.RateLimit.WaitToProceedAsync().ConfigureAwait(false);
+            await new SynchronizationContextRemover();
+
+            await api.RateLimit.WaitToProceedAsync();
             if (string.IsNullOrWhiteSpace(url))
             {
                 return null;

--- a/ExchangeSharp/API/APIRequestMaker.cs
+++ b/ExchangeSharp/API/APIRequestMaker.cs
@@ -33,7 +33,7 @@ namespace ExchangeSharp
         /// <param name="api">API</param>
         public APIRequestMaker(IAPIRequestHandler api)
         {
-            this.api = api;
+            api = api;
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace ExchangeSharp
         /// <returns>Raw response</returns>
         public async Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
         {
-            await this.api.RateLimit.WaitToProceedAsync();
+            await api.RateLimit.WaitToProceedAsync().ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(url))
             {
                 return null;
@@ -71,19 +71,19 @@ namespace ExchangeSharp
                 url = "/" + url;
             }
 
-            string fullUrl = (baseUrl ?? this.api.BaseUrl) + url;
-            Uri uri = this.api.ProcessRequestUrl(new UriBuilder(fullUrl), payload);
+            string fullUrl = (baseUrl ?? api.BaseUrl) + url;
+            Uri uri = api.ProcessRequestUrl(new UriBuilder(fullUrl), payload);
             HttpWebRequest request = HttpWebRequest.CreateHttp(uri);
             request.Headers["Accept-Language"] = "en-us; q=1.0;";
-            request.Method = method ?? this.api.RequestMethod;
-            request.ContentType = this.api.RequestContentType;
+            request.Method = method ?? api.RequestMethod;
+            request.ContentType = api.RequestContentType;
             request.UserAgent = BaseAPI.RequestUserAgent;
-            request.CachePolicy = this.api.RequestCachePolicy;
-            request.Timeout = request.ReadWriteTimeout = (int)this.api.RequestTimeout.TotalMilliseconds;
+            request.CachePolicy = api.RequestCachePolicy;
+            request.Timeout = request.ReadWriteTimeout = (int)api.RequestTimeout.TotalMilliseconds;
             try
             {
                 // not supported on some platforms
-                request.ContinueTimeout = (int)this.api.RequestTimeout.TotalMilliseconds;
+                request.ContinueTimeout = (int)api.RequestTimeout.TotalMilliseconds;
             }
             catch
             {

--- a/ExchangeSharp/API/APIRequestMaker.cs
+++ b/ExchangeSharp/API/APIRequestMaker.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
@@ -46,7 +47,21 @@ namespace ExchangeSharp
         /// <returns>Raw response</returns>
         public string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
         {
-            this.api.RateLimit.WaitToProceed();
+            return MakeRequestAsync(url, baseUrl, payload, method).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// ASYNC - Make a request to a path on the API
+        /// </summary>
+        /// <param name="url">Path and query</param>
+        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+        /// The encoding of payload is API dependant but is typically json.</param>
+        /// <param name="method">Request method or null for default</param>
+        /// <returns>Raw response</returns>
+        public async Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
+        {
+            await this.api.RateLimit.WaitToProceedAsync();
             if (string.IsNullOrWhiteSpace(url))
             {
                 return null;
@@ -79,7 +94,7 @@ namespace ExchangeSharp
             HttpWebResponse response;
             try
             {
-                response = request.GetResponse() as HttpWebResponse;
+                response = await request.GetResponseAsync() as HttpWebResponse;
                 if (response == null)
                 {
                     throw new APIException("Unknown response from server");

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -280,6 +280,20 @@ namespace ExchangeSharp
         }
 
         /// <summary>
+        /// Make a request to a path on the API
+        /// </summary>
+        /// <param name="url">Path and query</param>
+        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+        /// The encoding of payload is API dependant but is typically json.</param>
+        /// <param name="method">Request method or null for default</param>
+        /// <returns>Raw response</returns>
+        public string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
+        {
+            return this.MakeRequestAsync(url, baseUrl, payload, method).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// ASYNC - Make a request to a path on the API
         /// </summary>
         /// <param name="url">Path and query</param>
@@ -288,7 +302,7 @@ namespace ExchangeSharp
         /// The encoding of payload is API dependant but is typically json.</param>
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => Task.Factory.StartNew(() => this.requestMaker.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: method));
+        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => this.requestMaker.MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: method);
 
         /// <summary>
         /// Make a JSON request to an API end point
@@ -301,8 +315,7 @@ namespace ExchangeSharp
         /// <returns>Result decoded from JSON response</returns>
         public T MakeJsonRequest<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
         {
-            string response = this.requestMaker.MakeRequest(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
-            return JsonConvert.DeserializeObject<T>(response);
+            return MakeJsonRequestAsync<T>(url, baseUrl, payload, requestMethod).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -314,7 +327,11 @@ namespace ExchangeSharp
         /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
         /// <param name="requestMethod">Request method or null for default</param>
         /// <returns>Result decoded from JSON response</returns>
-        public Task<T> MakeJsonRequestAsync<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null) => Task.Factory.StartNew(() => MakeJsonRequest<T>(url, baseUrl, payload, requestMethod));
+        public async Task<T> MakeJsonRequestAsync<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
+        {
+            string result = await MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
+            return JsonConvert.DeserializeObject<T>(result);
+        }
 
         /// <summary>
         /// Connect a web socket to a path on the API and start listening, not all exchanges support this

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -329,6 +329,8 @@ namespace ExchangeSharp
         /// <returns>Result decoded from JSON response</returns>
         public async Task<T> MakeJsonRequestAsync<T>(string url, string baseUrl = null, Dictionary<string, object> payload = null, string requestMethod = null)
         {
+            await new SynchronizationContextRemover();
+
             string result = await MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
             return JsonConvert.DeserializeObject<T>(result);
         }

--- a/ExchangeSharp/API/BaseAPI.cs
+++ b/ExchangeSharp/API/BaseAPI.cs
@@ -290,7 +290,7 @@ namespace ExchangeSharp
         /// <returns>Raw response</returns>
         public string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null)
         {
-            return this.MakeRequestAsync(url, baseUrl, payload, method).GetAwaiter().GetResult();
+            return MakeRequestAsync(url, baseUrl, payload, method).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace ExchangeSharp
         /// The encoding of payload is API dependant but is typically json.</param>
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => this.requestMaker.MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: method);
+        public Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null) => requestMaker.MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: method);
 
         /// <summary>
         /// Make a JSON request to an API end point
@@ -520,17 +520,17 @@ namespace ExchangeSharp
 
         void IAPIRequestHandler.ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
         {
-            this.ProcessRequest(request, payload);
+            ProcessRequest(request, payload);
         }
 
         void IAPIRequestHandler.ProcessResponse(HttpWebResponse response)
         {
-            this.ProcessResponse(response);
+            ProcessResponse(response);
         }
 
         Uri IAPIRequestHandler.ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
         {
-            return this.ProcessRequestUrl(url, payload);
+            return ProcessRequestUrl(url, payload);
         }
     }
 }

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -499,7 +499,7 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="symbol">Symbol to get open orders for or null for all</param>
         /// <returns>All open order details</returns>
-        public IEnumerable<ExchangeOrderResult> GetOpenOrderDetails(string symbol = null) => GetOpenOrderDetailsAsync().GetAwaiter().GetResult();
+        public IEnumerable<ExchangeOrderResult> GetOpenOrderDetails(string symbol = null) => GetOpenOrderDetailsAsync(symbol).GetAwaiter().GetResult();
 
         /// <summary>
         /// ASYNC - Get the details of all open orders

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -192,6 +192,20 @@ namespace ExchangeSharp
         }
 
         /// <summary>
+        /// Get all tickers via web socket
+        /// </summary>
+        /// <param name="tickers">Callback</param>
+        /// <returns>Web socket, call Dispose to close</returns>
+        public virtual IDisposable GetTickersWebSocket(System.Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers) => throw new NotImplementedException();
+
+        /// <summary>
+        /// Get the details of all completed orders via web socket
+        /// </summary>
+        /// <param name="callback">Callback</param>
+        /// <returns>Web socket, call Dispose to close</returns>
+        public virtual IDisposable GetCompletedOrderDetailsWebSocket(System.Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
+
+        /// <summary>
         /// Gets currencies and related data such as IsEnabled and TxFee (if available)
         /// </summary>
         /// <returns>Collection of Currencies</returns>
@@ -256,13 +270,6 @@ namespace ExchangeSharp
             await new SynchronizationContextRemover();
             return await OnGetTickerAsync(symbol);
         }
-
-        /// <summary>
-        /// Get all tickers via web socket
-        /// </summary>
-        /// <param name="tickers">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual IDisposable GetTickersWebSocket(System.Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers) => throw new NotImplementedException();
 
         /// <summary>
         /// Get all tickers in one request. If the exchange does not support this, a ticker will be requested for each symbol.
@@ -524,13 +531,6 @@ namespace ExchangeSharp
             await new SynchronizationContextRemover();
             return await OnGetCompletedOrderDetailsAsync(symbol, afterDate);
         }
-
-        /// <summary>
-        /// Get the details of all completed orders via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual IDisposable GetCompletedOrderDetailsWebSocket(System.Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
 
         /// <summary>
         /// Cancel an order, an exception is thrown if error

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -268,18 +268,18 @@ namespace ExchangeSharp
         public virtual Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null) => throw new NotImplementedException();
 
         /// <summary>
-        /// Get recent trades on the exchange - this implementation simply calls GetHistoricalTrades with a null sinceDateTime.
+        /// Get recent trades on the exchange - the default implementation simply calls GetHistoricalTrades with a null sinceDateTime.
         /// </summary>
         /// <param name="symbol">Symbol to get recent trades for</param>
         /// <returns>An enumerator that loops through all recent trades</returns>
         public IEnumerable<ExchangeTrade> GetRecentTrades(string symbol) => GetRecentTradesAsync(symbol).GetAwaiter().GetResult();
 
         /// <summary>
-        /// ASYNC - Get recent trades on the exchange - this implementation simply calls GetHistoricalTrades with a null sinceDateTime.
+        /// ASYNC - Get recent trades on the exchange - the default implementation simply calls GetHistoricalTrades with a null sinceDateTime.
         /// </summary>
         /// <param name="symbol">Symbol to get recent trades for</param>
         /// <returns>An enumerator that loops through all recent trades</returns>
-        public async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol)
+        public virtual async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             await GetHistoricalTradesAsync((e) =>

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -33,8 +33,8 @@ namespace ExchangeSharp
         /// <returns>The ExchangeMarket or null if it doesn't exist</returns>
         protected ExchangeMarket GetExchangeMarket(string symbol)
         {
-            this.PopulateExchangeMarkets();
-            return this.exchangeMarkets.FirstOrDefault(x => x.MarketName == symbol);
+            PopulateExchangeMarkets();
+            return exchangeMarkets.FirstOrDefault(x => x.MarketName == symbol);
         }
 
         /// <summary>
@@ -43,13 +43,13 @@ namespace ExchangeSharp
         private void PopulateExchangeMarkets()
         {
             // Get the exchange markets if we haven't gotten them yet.
-            if (this.exchangeMarkets == null)
+            if (exchangeMarkets == null)
             {
                 lock (this)
                 {
-                    if (this.exchangeMarkets == null)
+                    if (exchangeMarkets == null)
                     {
-                        this.exchangeMarkets = this.GetSymbolsMetadata();
+                        exchangeMarkets = GetSymbolsMetadata();
                     }
                 }
             }
@@ -63,7 +63,7 @@ namespace ExchangeSharp
         /// <returns>Clamped price</returns>
         protected decimal ClampOrderPrice(string symbol, decimal outputPrice)
         {
-            ExchangeMarket market = this.GetExchangeMarket(symbol);
+            ExchangeMarket market = GetExchangeMarket(symbol);
             return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice, market.MaxPrice, market.PriceStepSize, outputPrice);
         }
 
@@ -75,7 +75,7 @@ namespace ExchangeSharp
         /// <returns>Clamped quantity</returns>
         protected decimal ClampOrderQuantity(string symbol, decimal outputQuantity)
         {
-            ExchangeMarket market = this.GetExchangeMarket(symbol);
+            ExchangeMarket market = GetExchangeMarket(symbol);
             return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, outputQuantity);
         }
 

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -47,7 +47,7 @@ namespace ExchangeSharp
             NonceOffset = TimeSpan.FromSeconds(10.0);
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             if (ReadCache("GetSymbols", out List<string> symbols))
             {
@@ -70,7 +70,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
         {
             /*
              *         {
@@ -147,12 +147,12 @@ namespace ExchangeSharp
             return markets;
         }
 
-        public override Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
+        protected override Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
         {
             throw new NotSupportedException("Binance does not provide data about its currencies via the API");
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
             JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr?symbol=" + symbol);
@@ -160,7 +160,7 @@ namespace ExchangeSharp
             return ParseTicker(symbol, obj);
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
             string symbol;
@@ -203,7 +203,7 @@ namespace ExchangeSharp
             });
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
             JToken obj = await MakeJsonRequestAsync<JToken>("/depth?symbol=" + symbol + "&limit=" + maxCount);
@@ -211,7 +211,7 @@ namespace ExchangeSharp
             return ParseOrderBook(obj);
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             /* [ {
             "a": 26129,         // Aggregate tradeId
@@ -286,7 +286,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /* [
             [
@@ -341,7 +341,7 @@ namespace ExchangeSharp
             return candles;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
             CheckError(token);
@@ -357,7 +357,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
             CheckError(token);
@@ -373,7 +373,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = GetNoncePayload();
@@ -403,7 +403,7 @@ namespace ExchangeSharp
             return ParseOrder(token);
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             Dictionary<string, object> payload = GetNoncePayload();
             string[] pieces = orderId.Split(',');
@@ -448,7 +448,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = GetNoncePayload();
@@ -504,7 +504,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             if (string.IsNullOrWhiteSpace(symbol))
@@ -530,7 +530,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             Dictionary<string, object> payload = GetNoncePayload();
             string[] pieces = orderId.Split(',');
@@ -547,7 +547,7 @@ namespace ExchangeSharp
         /// <summary>A withdrawal request. Fee is automatically subtracted from the amount.</summary>
         /// <param name="withdrawalRequest">The withdrawal request.</param>
         /// <returns>Withdrawal response from Binance</returns>
-        public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
             if (string.IsNullOrWhiteSpace(withdrawalRequest.Symbol))
             {
@@ -812,7 +812,7 @@ namespace ExchangeSharp
         /// <returns>
         /// Deposit address details (including tag if applicable, such as XRP)
         /// </returns>
-        public override async Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
         {
             /* 
             * TODO: Binance does not offer a "regenerate" option in the API, but a second IOTA deposit to the same address will not be credited
@@ -839,7 +839,7 @@ namespace ExchangeSharp
         /// <summary>Gets the deposit history for a symbol</summary>
         /// <param name="symbol">The symbol to check. Null for all symbols.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public override async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
         {
             // TODO: API supports searching on status, startTime, endTime
             Dictionary<string, object> payload = GetNoncePayload();

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -47,7 +47,7 @@ namespace ExchangeSharp
             NonceOffset = TimeSpan.FromSeconds(10.0);
         }
 
-        public override IEnumerable<string> GetSymbols()
+        public override async Task<IEnumerable<string>> GetSymbolsAsync()
         {
             if (ReadCache("GetSymbols", out List<string> symbols))
             {
@@ -55,7 +55,7 @@ namespace ExchangeSharp
             }
 
             symbols = new List<string>();
-            JToken obj = MakeJsonRequest<JToken>("/ticker/allPrices");
+            JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/allPrices");
             CheckError(obj);
             foreach (JToken token in obj)
             {
@@ -70,7 +70,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override IEnumerable<ExchangeMarket> GetSymbolsMetadata()
+        public override async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
         {
             /*
              *         {
@@ -110,7 +110,7 @@ namespace ExchangeSharp
              */
 
             var markets = new List<ExchangeMarket>();
-            JToken obj = MakeJsonRequest<JToken>("/exchangeInfo");
+            JToken obj = await MakeJsonRequestAsync<JToken>("/exchangeInfo");
             CheckError(obj);
             JToken allSymbols = obj["symbols"];
             foreach (JToken symbol in allSymbols)
@@ -147,29 +147,31 @@ namespace ExchangeSharp
             return markets;
         }
 
-        public override IReadOnlyDictionary<string, ExchangeCurrency> GetCurrencies()
+        public override Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
         {
             throw new NotSupportedException("Binance does not provide data about its currencies via the API");
         }
 
-        public override ExchangeTicker GetTicker(string symbol)
+        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
-            JToken obj = MakeJsonRequest<JToken>("/ticker/24hr?symbol=" + symbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr?symbol=" + symbol);
             CheckError(obj);
             return ParseTicker(symbol, obj);
         }
 
-        public override IEnumerable<KeyValuePair<string, ExchangeTicker>> GetTickers()
+        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
         {
+            List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
             string symbol;
-            JToken obj = MakeJsonRequest<JToken>("/ticker/24hr");
+            JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr");
             CheckError(obj);
             foreach (JToken child in obj)
             {
                 symbol = child["symbol"].ToStringInvariant();
-                yield return new KeyValuePair<string, ExchangeTicker>(symbol, ParseTicker(symbol, child));
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTicker(symbol, child)));
             }
+            return tickers;
         }
 
         public override IDisposable GetTickersWebSocket(System.Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback)
@@ -201,15 +203,15 @@ namespace ExchangeSharp
             });
         }
 
-        public override ExchangeOrderBook GetOrderBook(string symbol, int maxCount = 100)
+        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
-            JToken obj = MakeJsonRequest<JToken>("/depth?symbol=" + symbol + "&limit=" + maxCount);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/depth?symbol=" + symbol + "&limit=" + maxCount);
             CheckError(obj);
             return ParseOrderBook(obj);
         }
 
-        public override IEnumerable<ExchangeTrade> GetHistoricalTrades(string symbol, DateTime? sinceDateTime = null)
+        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             /* [ {
             "a": 26129,         // Aggregate tradeId
@@ -240,7 +242,7 @@ namespace ExchangeSharp
 
             while (true)
             {
-                JArray obj = MakeJsonRequest<Newtonsoft.Json.Linq.JArray>(url);
+                JArray obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JArray>(url);
                 if (obj == null || obj.Count == 0)
                 {
                     break;
@@ -271,20 +273,20 @@ namespace ExchangeSharp
                     });
                 }
                 trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));
-                foreach (ExchangeTrade t in trades)
+                if (!callback(trades))
                 {
-                    yield return t;
+                    break;
                 }
                 trades.Clear();
                 if (sinceDateTime == null)
                 {
                     break;
                 }
-                Task.Delay(1000).Wait();
+                await Task.Delay(1000);
             }
         }
 
-        public override IEnumerable<MarketCandle> GetCandles(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /* [
             [
@@ -302,6 +304,7 @@ namespace ExchangeSharp
 		    "17928899.62484339" // Can be ignored
 		    ]] */
 
+            List<MarketCandle> candles = new List<MarketCandle>();
             symbol = NormalizeSymbol(symbol);
             string url = "/klines?symbol=" + symbol;
             if (startDate != null)
@@ -315,11 +318,11 @@ namespace ExchangeSharp
             }
             string periodString = CryptoUtility.SecondsToPeriodString(periodSeconds);
             url += "&interval=" + periodString;
-            JToken obj = MakeJsonRequest<JToken>(url);
+            JToken obj = await MakeJsonRequestAsync<JToken>(url);
             CheckError(obj);
             foreach (JArray array in obj)
             {
-                yield return new MarketCandle
+                candles.Add(new MarketCandle
                 {
                     ClosePrice = array[4].ConvertInvariant<decimal>(),
                     ExchangeName = Name,
@@ -332,13 +335,15 @@ namespace ExchangeSharp
                     VolumePrice = array[5].ConvertInvariant<double>(),
                     VolumeQuantity = array[7].ConvertInvariant<double>(),
                     WeightedAverage = 0m
-                };
+                });
             }
+
+            return candles;
         }
 
-        public override Dictionary<string, decimal> GetAmounts()
+        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
         {
-            JToken token = MakeJsonRequest<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
+            JToken token = await MakeJsonRequestAsync<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
             CheckError(token);
             Dictionary<string, decimal> balances = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             foreach (JToken balance in token["balances"])
@@ -352,9 +357,9 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override Dictionary<string, decimal> GetAmountsAvailableToTrade()
+        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
         {
-            JToken token = MakeJsonRequest<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
+            JToken token = await MakeJsonRequestAsync<JToken>("/account", BaseUrlPrivate, GetNoncePayload());
             CheckError(token);
             Dictionary<string, decimal> balances = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             foreach (JToken balance in token["balances"])
@@ -368,7 +373,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override ExchangeOrderResult PlaceOrder(ExchangeOrderRequest order)
+        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = GetNoncePayload();
@@ -393,12 +398,12 @@ namespace ExchangeSharp
                 payload[kv.Key] = kv.Value;
             }
 
-            JToken token = MakeJsonRequest<JToken>("/order", BaseUrlPrivate, payload, "POST");
+            JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrlPrivate, payload, "POST");
             CheckError(token);
             return ParseOrder(token);
         }
 
-        public override ExchangeOrderResult GetOrderDetails(string orderId)
+        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
         {
             Dictionary<string, object> payload = GetNoncePayload();
             string[] pieces = orderId.Split(',');
@@ -415,7 +420,7 @@ namespace ExchangeSharp
             // Add up the fees from each trade in the order
             Dictionary<string, object> feesPayload = GetNoncePayload();
             feesPayload["symbol"] = pieces[0];
-            JToken feesToken = MakeJsonRequest<JToken>("/myTrades", BaseUrlPrivate, feesPayload);
+            JToken feesToken = await MakeJsonRequestAsync<JToken>("/myTrades", BaseUrlPrivate, feesPayload);
             CheckError(feesToken);
             ParseFees(feesToken, result);
 
@@ -443,32 +448,35 @@ namespace ExchangeSharp
             }
         }
 
-        public override IEnumerable<ExchangeOrderResult> GetOpenOrderDetails(string symbol = null)
+        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
         {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = GetNoncePayload();
             if (!string.IsNullOrWhiteSpace(symbol))
             {
                 payload["symbol"] = NormalizeSymbol(symbol);
             }
-            JToken token = MakeJsonRequest<JToken>("/openOrders", BaseUrlPrivate, payload);
+            JToken token = await MakeJsonRequestAsync<JToken>("/openOrders", BaseUrlPrivate, payload);
             CheckError(token);
             foreach (JToken order in token)
             {
-                yield return ParseOrder(order);
+                orders.Add(ParseOrder(order));
             }
+
+            return orders;
         }
 
-        private IEnumerable<ExchangeOrderResult> GetCompletedOrdersForAllSymbols(DateTime? afterDate)
+        private async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrdersForAllSymbolsAsync(DateTime? afterDate)
         {
             // TODO: This is a HACK, Binance API needs to add a single API call to get all orders for all symbols, terrible...
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Exception ex = null;
             string failedSymbol = null;
-            Parallel.ForEach(GetSymbols().Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), (s) =>
+            Parallel.ForEach((await GetSymbolsAsync()).Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), async (s) =>
             {
                 try
                 {
-                    foreach (ExchangeOrderResult order in GetCompletedOrderDetails(s, afterDate))
+                    foreach (ExchangeOrderResult order in (await GetCompletedOrderDetailsAsync(s, afterDate)))
                     {
                         lock (orders)
                         {
@@ -493,20 +501,15 @@ namespace ExchangeSharp
             {
                 return o2.OrderDate.CompareTo(o1.OrderDate);
             });
-            foreach (ExchangeOrderResult order in orders)
-            {
-                yield return order;
-            }
+            return orders;
         }
 
-        public override IEnumerable<ExchangeOrderResult> GetCompletedOrderDetails(string symbol = null, DateTime? afterDate = null)
+        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             if (string.IsNullOrWhiteSpace(symbol))
             {
-                foreach (ExchangeOrderResult order in GetCompletedOrdersForAllSymbols(afterDate))
-                {
-                    yield return order;
-                }
+                orders.AddRange(await GetCompletedOrdersForAllSymbolsAsync(afterDate));
             }
             else
             {
@@ -517,16 +520,17 @@ namespace ExchangeSharp
                     // TODO: timestamp param is causing duplicate request errors which is a bug in the Binance API
                     // payload["timestamp"] = afterDate.Value.UnixTimestampFromDateTimeMilliseconds();
                 }
-                JToken token = MakeJsonRequest<JToken>("/allOrders", BaseUrlPrivate, payload);
+                JToken token = await MakeJsonRequestAsync<JToken>("/allOrders", BaseUrlPrivate, payload);
                 CheckError(token);
                 foreach (JToken order in token)
                 {
-                    yield return ParseOrder(order);
+                    orders.Add(ParseOrder(order));
                 }
             }
+            return orders;
         }
 
-        public override void CancelOrder(string orderId)
+        public override async Task CancelOrderAsync(string orderId)
         {
             Dictionary<string, object> payload = GetNoncePayload();
             string[] pieces = orderId.Split(',');
@@ -536,28 +540,26 @@ namespace ExchangeSharp
             }
             payload["symbol"] = pieces[0];
             payload["orderId"] = pieces[1];
-            JToken token = MakeJsonRequest<JToken>("/order", BaseUrlPrivate, payload, "DELETE");
+            JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrlPrivate, payload, "DELETE");
             CheckError(token);
         }
 
         /// <summary>A withdrawal request. Fee is automatically subtracted from the amount.</summary>
         /// <param name="withdrawalRequest">The withdrawal request.</param>
         /// <returns>Withdrawal response from Binance</returns>
-        public override ExchangeWithdrawalResponse Withdraw(ExchangeWithdrawalRequest withdrawalRequest)
+        public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
             if (string.IsNullOrWhiteSpace(withdrawalRequest.Symbol))
             {
-                throw new APIException("Symbol must be provided for Withdraw");
+                throw new ArgumentException("Symbol must be provided for Withdraw");
             }
-
-            if (string.IsNullOrWhiteSpace(withdrawalRequest.Address))
+            else if (string.IsNullOrWhiteSpace(withdrawalRequest.Address))
             {
-                throw new APIException("Address must be provided for Withdraw");
+                throw new ArgumentException("Address must be provided for Withdraw");
             }
-
-            if (withdrawalRequest.Amount <= 0)
+            else if (withdrawalRequest.Amount <= 0)
             {
-                throw new APIException("Withdrawal amount must be positive and non-zero");
+                throw new ArgumentException("Withdrawal amount must be positive and non-zero");
             }
 
             Dictionary<string, object> payload = GetNoncePayload();
@@ -571,7 +573,7 @@ namespace ExchangeSharp
                 payload["addressTag"] = withdrawalRequest.AddressTag;
             }
 
-            JToken response = MakeJsonRequest<JToken>("/withdraw.html", WithdrawalUrlPrivate, payload, "POST");
+            JToken response = await MakeJsonRequestAsync<JToken>("/withdraw.html", WithdrawalUrlPrivate, payload, "POST");
             CheckError(response);
 
             ExchangeWithdrawalResponse withdrawalResponse = new ExchangeWithdrawalResponse
@@ -810,7 +812,7 @@ namespace ExchangeSharp
         /// <returns>
         /// Deposit address details (including tag if applicable, such as XRP)
         /// </returns>
-        public override ExchangeDepositDetails GetDepositAddress(string symbol, bool forceRegenerate = false)
+        public override async Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false)
         {
             /* 
             * TODO: Binance does not offer a "regenerate" option in the API, but a second IOTA deposit to the same address will not be credited
@@ -821,7 +823,7 @@ namespace ExchangeSharp
             Dictionary<string, object> payload = GetNoncePayload();
             payload["asset"] = NormalizeSymbol(symbol);
 
-            JToken response = MakeJsonRequest<JToken>("/depositAddress.html", WithdrawalUrlPrivate, payload);
+            JToken response = await MakeJsonRequestAsync<JToken>("/depositAddress.html", WithdrawalUrlPrivate, payload);
             CheckError(response);
 
             ExchangeDepositDetails depositDetails = new ExchangeDepositDetails
@@ -837,7 +839,7 @@ namespace ExchangeSharp
         /// <summary>Gets the deposit history for a symbol</summary>
         /// <param name="symbol">The symbol to check. Null for all symbols.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public override IEnumerable<ExchangeTransaction> GetDepositHistory(string symbol)
+        public override async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol)
         {
             // TODO: API supports searching on status, startTime, endTime
             Dictionary<string, object> payload = GetNoncePayload();
@@ -846,7 +848,7 @@ namespace ExchangeSharp
                 payload["asset"] = NormalizeSymbol(symbol);
             }
 
-            JToken response = MakeJsonRequest<JToken>("/depositHistory.html", WithdrawalUrlPrivate, payload);
+            JToken response = await MakeJsonRequestAsync<JToken>("/depositHistory.html", WithdrawalUrlPrivate, payload);
             CheckError(response);
 
             var transactions = new List<ExchangeTransaction>();

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -118,7 +118,7 @@ namespace ExchangeSharp
                 var market = new ExchangeMarket
                 {
                     MarketName = symbol["symbol"].ToStringUpperInvariant(),
-                    IsActive = this.ParseMarketStatus(symbol["status"].ToStringUpperInvariant()),
+                    IsActive = ParseMarketStatus(symbol["status"].ToStringUpperInvariant()),
                     BaseCurrency = symbol["quoteAsset"].ToStringUpperInvariant(),
                     MarketCurrency = symbol["baseAsset"].ToStringUpperInvariant()
                 };
@@ -382,8 +382,8 @@ namespace ExchangeSharp
             payload["type"] = order.OrderType.ToString().ToUpperInvariant();
 
             // Binance has strict rules on which prices and quantities are allowed. They have to match the rules defined in the market definition.
-            decimal outputQuantity = this.ClampOrderQuantity(symbol, order.Amount);
-            decimal outputPrice = this.ClampOrderPrice(symbol, order.Price);
+            decimal outputQuantity = ClampOrderQuantity(symbol, order.Amount);
+            decimal outputPrice = ClampOrderPrice(symbol, order.Price);
 
             payload["quantity"] = outputQuantity;
             payload["newOrderRespType"] = "FULL";

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -39,7 +39,7 @@ namespace ExchangeSharp
             RateLimit = new RateGate(1, TimeSpan.FromSeconds(6.0));
 
             // List is from "Withdrawal Types" section https://docs.bitfinex.com/v1/reference#rest-auth-withdrawal
-            this.DepositMethodLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            DepositMethodLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 ["AID"] = "aid",
                 ["AVT"] = "aventus",
@@ -129,7 +129,7 @@ namespace ExchangeSharp
 
         public override async Task<IEnumerable<string>> GetSymbolsAsync()
         {
-            var m = await this.GetSymbolsMetadataAsync();
+            var m = await GetSymbolsMetadataAsync();
             return m.Select(x => x.MarketName);
         }
 
@@ -295,7 +295,7 @@ namespace ExchangeSharp
         /// <returns>A dictionary of symbol-fee pairs</returns>
         public Dictionary<string, decimal> GetWithdrawalFees()
         {
-            JToken obj = this.MakeJsonRequest<JToken>("/account_fees", this.BaseUrlV1, this.GetNoncePayload());
+            JToken obj = MakeJsonRequest<JToken>("/account_fees", BaseUrlV1, GetNoncePayload());
             CheckError(obj);
 
             var fees = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
@@ -552,7 +552,7 @@ namespace ExchangeSharp
             }
 
             // symbol needs to be translated to full name of coin: bitcoin/litecoin/ethereum
-            if (!this.DepositMethodLookup.TryGetValue(symbol, out string fullName))
+            if (!DepositMethodLookup.TryGetValue(symbol, out string fullName))
             {
                 return null;
             }
@@ -647,10 +647,10 @@ namespace ExchangeSharp
         /// <returns>The withdrawal response</returns>
         public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
-            string symbol = this.NormalizeSymbol(withdrawalRequest.Symbol);
+            string symbol = NormalizeSymbol(withdrawalRequest.Symbol);
 
             // symbol needs to be translated to full name of coin: bitcoin/litecoin/ethereum
-            if (!this.DepositMethodLookup.TryGetValue(symbol, out string fullName))
+            if (!DepositMethodLookup.TryGetValue(symbol, out string fullName))
             {
                 return null;
             }
@@ -658,7 +658,7 @@ namespace ExchangeSharp
             // Bitfinex adds the fee on top of what you request to withdrawal
             if (withdrawalRequest.TakeFeeFromAmount)
             {
-                Dictionary<string, decimal> fees = this.GetWithdrawalFees();
+                Dictionary<string, decimal> fees = GetWithdrawalFees();
                 if (fees.TryGetValue(symbol, out decimal feeAmt))
                 {
                     withdrawalRequest.Amount -= feeAmt;

--- a/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
 
@@ -65,12 +66,12 @@ namespace ExchangeSharp
             }
         }
         
-        private JToken MakeRequestBithumb(ref string symbol, string subUrl)
+        private async Task<Tuple<JToken, string>> MakeRequestBithumbAsync(string symbol, string subUrl)
         {
             symbol = NormalizeSymbol(symbol);
-            JObject obj = MakeJsonRequest<JObject>(subUrl.Replace("$SYMBOL$", symbol ?? string.Empty));
+            JObject obj = await MakeJsonRequestAsync<JObject>(subUrl.Replace("$SYMBOL$", symbol ?? string.Empty));
             CheckError(obj);
-            return obj["data"];
+            return new Tuple<JToken, string>(obj["data"], symbol);
         }
 
         private ExchangeTicker ParseTicker(string symbol, JToken data, DateTime? date)
@@ -105,12 +106,12 @@ namespace ExchangeSharp
             return book;
         }
 
-        public override IEnumerable<string> GetSymbols()
+        public override async Task<IEnumerable<string>> GetSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             string symbol = "all";
-            JToken data = MakeRequestBithumb(ref symbol, "/public/ticker/$SYMBOL$");
-            foreach (JProperty token in data)
+            var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
+            foreach (JProperty token in data.Item1)
             {
                 if (token.Name != "date")
                 {
@@ -120,19 +121,19 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override ExchangeTicker GetTicker(string symbol)
+        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
         {
-            JToken data = MakeRequestBithumb(ref symbol, "/public/ticker/$SYMBOL$");
-            return ParseTicker(symbol, data, null);
+            var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
+            return ParseTicker(data.Item2, data.Item1, null);
         }
 
-        public override IEnumerable<KeyValuePair<string, ExchangeTicker>> GetTickers()
+        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
         {
             string symbol = "all";
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            JToken data = MakeRequestBithumb(ref symbol, "/public/ticker/$SYMBOL$");
-            DateTime date = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(data["date"].ConvertInvariant<long>());
-            foreach (JProperty token in data)
+            var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
+            DateTime date = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(data.Item1["date"].ConvertInvariant<long>());
+            foreach (JProperty token in data.Item1)
             {
                 if (token.Name != "date")
                 {
@@ -142,18 +143,18 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        public override ExchangeOrderBook GetOrderBook(string symbol, int maxCount = 100)
+        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
         {
-            JToken data = MakeRequestBithumb(ref symbol, "/public/orderbook/$SYMBOL$");
-            return ParseOrderBook(data);
+            var data = await MakeRequestBithumbAsync(symbol, "/public/orderbook/$SYMBOL$");
+            return ParseOrderBook(data.Item1);
         }
 
-        public override IEnumerable<KeyValuePair<string, ExchangeOrderBook>> GetOrderBooks(int maxCount = 100)
+        public override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100)
         {
             string symbol = "all";
             List<KeyValuePair<string, ExchangeOrderBook>> books = new List<KeyValuePair<string, ExchangeOrderBook>>();
-            JToken data = MakeRequestBithumb(ref symbol, "/public/orderbook/$SYMBOL$");
-            foreach (JProperty book in data)
+            var data = await MakeRequestBithumbAsync(symbol, "/public/orderbook/$SYMBOL$");
+            foreach (JProperty book in data.Item1)
             {
                 if (book.Name != "timestamp" && book.Name != "payment_currency")
                 {
@@ -163,20 +164,22 @@ namespace ExchangeSharp
             return books;
         }
 
-        public override IEnumerable<ExchangeTrade> GetHistoricalTrades(string symbol, DateTime? sinceDateTime = null)
+        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
-            JToken data = MakeRequestBithumb(ref symbol, "/public/recent_transactions/$SYMBOL$");
-            foreach (JToken token in data)
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            var data = await MakeRequestBithumbAsync(symbol, "/public/recent_transactions/$SYMBOL$");
+            foreach (JToken token in data.Item1)
             {
-                yield return new ExchangeTrade
+                trades.Add(new ExchangeTrade
                 {
                     Amount = token["units_traded"].ConvertInvariant<decimal>(),
                     Price = token["price"].ConvertInvariant<decimal>(),
                     Id = -1,
                     IsBuy = token["type"].ToStringInvariant() == "bid",
                     Timestamp = token["transaction_date"].ConvertInvariant<DateTime>()
-                };
+                });
             }
+            callback(trades);
         }
     }
 }

--- a/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
@@ -106,7 +106,7 @@ namespace ExchangeSharp
             return book;
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             string symbol = "all";
@@ -121,13 +121,13 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
             return ParseTicker(data.Item2, data.Item1, null);
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             string symbol = "all";
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
@@ -143,13 +143,13 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             var data = await MakeRequestBithumbAsync(symbol, "/public/orderbook/$SYMBOL$");
             return ParseOrderBook(data.Item1);
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100)
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(int maxCount = 100)
         {
             string symbol = "all";
             List<KeyValuePair<string, ExchangeOrderBook>> books = new List<KeyValuePair<string, ExchangeOrderBook>>();
@@ -164,7 +164,7 @@ namespace ExchangeSharp
             return books;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             var data = await MakeRequestBithumbAsync(symbol, "/public/recent_transactions/$SYMBOL$");

--- a/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
@@ -106,7 +106,7 @@ namespace ExchangeSharp
             return symbol?.Replace("/", string.Empty).Replace("-", string.Empty).Replace("_", string.Empty).ToLowerInvariant();
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             foreach (JToken token in (await MakeBitstampRequestAsync("/trading-pairs-info")))
@@ -116,7 +116,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             // {"high": "0.10948945", "last": "0.10121817", "timestamp": "1513387486", "bid": "0.10112165", "vwap": "0.09958913", "volume": "9954.37332614", "low": "0.09100000", "ask": "0.10198408", "open": "0.10250028"}
             symbol = NormalizeSymbol(symbol);
@@ -137,7 +137,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
             JToken token = await MakeBitstampRequestAsync("/order_book/" + symbol);
@@ -153,7 +153,7 @@ namespace ExchangeSharp
             return book;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             // [{"date": "1513387997", "tid": "33734815", "price": "0.01724547", "type": "1", "amount": "5.56481714"}]
             symbol = NormalizeSymbol(symbol);
@@ -173,7 +173,7 @@ namespace ExchangeSharp
             callback(trades);
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             string url = "/balance/";
             var payload = GetNoncePayload();
@@ -192,7 +192,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             string url = "/balance/";
             var payload = GetNoncePayload();
@@ -211,7 +211,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
 
@@ -242,7 +242,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             //{
             //    "status": "Finished",
@@ -318,7 +318,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             symbol = NormalizeSymbol(symbol);
@@ -348,7 +348,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             symbol = NormalizeSymbol(symbol);
             // TODO: Bitstamp bug: bad request if url contains symbol, so temporarily using url for all symbols
@@ -402,7 +402,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -419,7 +419,7 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="withdrawalRequest"></param>
         /// <returns></returns>
-        public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
             string baseurl = null;
             string url;

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -169,7 +169,7 @@ namespace ExchangeSharp
             return symbol?.ToUpperInvariant();
         }
 
-        public override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
+        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
         {
             var currencies = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
 
@@ -202,7 +202,7 @@ namespace ExchangeSharp
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
         /// <returns>Collection of ExchangeMarkets</returns>
-        public override async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
         {
             var markets = new List<ExchangeMarket>();
             JObject obj = await MakeJsonRequestAsync<JObject>("/public/getmarkets");
@@ -233,12 +233,12 @@ namespace ExchangeSharp
             return markets;
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             return (await GetSymbolsMetadataAsync()).Select(x => x.MarketName);
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             JObject obj = await MakeJsonRequestAsync<JObject>("/public/getmarketsummary?market=" + NormalizeSymbol(symbol));
             JToken result = CheckError(obj);
@@ -263,7 +263,7 @@ namespace ExchangeSharp
             return null;
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             JObject obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JObject>("public/getmarketsummaries");
             JToken tickers = CheckError(obj);
@@ -354,7 +354,7 @@ namespace ExchangeSharp
             return SocketClient;
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
             JObject obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JObject>("public/getorderbook?market=" + symbol + "&type=both&limit_bids=" + maxCount + "&limit_asks=" + maxCount);
@@ -378,7 +378,7 @@ namespace ExchangeSharp
         /// <summary>Gets the deposit history for a symbol</summary>
         /// <param name="symbol">The symbol to check. May be null.</param>
         /// <returns>Collection of ExchangeTransactions</returns>
-        public override async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
         {
             var transactions = new List<ExchangeTransaction>();
             symbol = NormalizeSymbol(symbol);
@@ -409,7 +409,7 @@ namespace ExchangeSharp
             return transactions;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             // TODO: sinceDateTime is ignored
             // https://bittrex.com/Api/v2.0/pub/market/GetTicks?marketName=BTC-WAVES&tickInterval=oneMin&_=1499127220008
@@ -461,7 +461,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             symbol = NormalizeSymbol(symbol);
@@ -486,7 +486,7 @@ namespace ExchangeSharp
             return trades;
         }
 
-        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -549,7 +549,7 @@ namespace ExchangeSharp
             return candles;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             Dictionary<string, decimal> currencies = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             string url = "/account/getbalances";
@@ -569,7 +569,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             Dictionary<string, decimal> currencies = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             string url = "/account/getbalances";
@@ -589,7 +589,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             if (order.OrderType == OrderType.Market)
             {
@@ -613,7 +613,7 @@ namespace ExchangeSharp
             return new ExchangeOrderResult { Amount = orderAmount, IsBuy = order.IsBuy, OrderDate = DateTime.UtcNow, OrderId = orderId, Result = ExchangeAPIOrderResult.Pending, Symbol = symbol };
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -626,7 +626,7 @@ namespace ExchangeSharp
             return ParseOrder(result);
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             string url = "/market/getopenorders" + (string.IsNullOrWhiteSpace(symbol) ? string.Empty : "?market=" + NormalizeSymbol(symbol));
@@ -641,7 +641,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             string url = "/account/getorderhistory" + (string.IsNullOrWhiteSpace(symbol) ? string.Empty : "?market=" + NormalizeSymbol(symbol));
@@ -661,7 +661,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
             // Example: https://bittrex.com/api/v1.1/account/withdraw?apikey=API_KEY&currency=EAC&quantity=20.40&address=EAC_ADDRESS   
 
@@ -683,7 +683,7 @@ namespace ExchangeSharp
             return withdrawalResponse;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             JObject obj = await MakeJsonRequestAsync<JObject>("/market/cancel?uuid=" + orderId, null, GetNoncePayload());
             CheckError(obj);
@@ -698,7 +698,7 @@ namespace ExchangeSharp
         /// <returns>
         /// Deposit address details (including tag if applicable, such as with XRP)
         /// </returns>
-        public override async Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
         {
             IReadOnlyDictionary<string, ExchangeCurrency> updatedCurrencies = (await GetCurrenciesAsync());
 

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -317,13 +317,13 @@ namespace ExchangeSharp
                 return null;
             }
 
-            CryptoExchange.Net.CallResult<int> result = SocketClient.SubscribeToAllMarketDeltaStream
+            CryptoExchange.Net.CallResult<int> result = SocketClient.SubscribeToMarketSummariesUpdate
             (
                 summaries =>
                 {
                     // Convert Bittrex.Net tickers objects into ExchangeSharp ExchangeTickers
                     var freshTickers = new Dictionary<string, ExchangeTicker>(StringComparer.OrdinalIgnoreCase);
-                    foreach (BittrexMarketSummary market in summaries)
+                    foreach (BittrexStreamMarketSummary market in summaries)
                     {
                         decimal quantityAmount = market.Volume.ConvertInvariant<decimal>();
                         decimal last = market.Last.ConvertInvariant<decimal>();

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -38,7 +38,7 @@ namespace ExchangeSharp
 
         public ExchangeBittrexAPI()
         {
-            this.TwoFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            TwoFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "BITSHAREX",
                 "CRYPTO_NOTE_PAYMENTID",
@@ -50,7 +50,7 @@ namespace ExchangeSharp
                 "STEEM"
             };
 
-            this.OneFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            OneFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "ADA",
                 "ANTSHARES",
@@ -78,18 +78,18 @@ namespace ExchangeSharp
         {
             get
             {
-                if (this.socketClient == null)
+                if (socketClient == null)
                 {
                     lock (this)
                     {
-                        if (this.socketClient == null)
+                        if (socketClient == null)
                         {
-                            this.socketClient = new BittrexSocketClient();
+                            socketClient = new BittrexSocketClient();
                         }
                     }
                 }
 
-                return this.socketClient;
+                return socketClient;
             }
         }
 
@@ -294,7 +294,7 @@ namespace ExchangeSharp
         public override IDisposable GetTickersWebSocket(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback)
         {
             // Eat the streamId and rely on .Dispose to clean up all streams
-            return this.GetTickersWebSocket(callback, out int streamId);
+            return GetTickersWebSocket(callback, out int streamId);
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace ExchangeSharp
                 return null;
             }
 
-            CryptoExchange.Net.CallResult<int> result = this.SocketClient.SubscribeToAllMarketDeltaStream
+            CryptoExchange.Net.CallResult<int> result = SocketClient.SubscribeToAllMarketDeltaStream
             (
                 summaries =>
                 {
@@ -351,7 +351,7 @@ namespace ExchangeSharp
                 streamId = result.Data;
             }
 
-            return this.SocketClient;
+            return SocketClient;
         }
 
         public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
@@ -598,8 +598,8 @@ namespace ExchangeSharp
 
             string symbol = NormalizeSymbol(order.Symbol);
 
-            decimal orderAmount = this.ClampOrderQuantity(symbol, order.Amount);
-            decimal orderPrice = this.ClampOrderPrice(symbol, order.Price);
+            decimal orderAmount = ClampOrderQuantity(symbol, order.Amount);
+            decimal orderPrice = ClampOrderPrice(symbol, order.Price);
 
             string url = (order.IsBuy ? "/market/buylimit" : "/market/selllimit") + "?market=" + symbol + "&quantity=" +
                 orderAmount.ToStringInvariant() + "&rate=" + orderPrice.ToStringInvariant();
@@ -719,12 +719,12 @@ namespace ExchangeSharp
                 return null;
             }
 
-            if (this.TwoFieldDepositCoinTypes.Contains(coin.CoinType))
+            if (TwoFieldDepositCoinTypes.Contains(coin.CoinType))
             {
                 depositDetails.Address = coin.BaseAddress;
                 depositDetails.AddressTag = result["Address"].ToStringInvariant();
             }
-            else if (this.OneFieldDepositCoinTypes.Contains(coin.CoinType))
+            else if (OneFieldDepositCoinTypes.Contains(coin.CoinType))
             {
                 depositDetails.Address = result["Address"].ToStringInvariant();
             }

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -136,7 +136,7 @@ namespace ExchangeSharp
             return symbol?.Replace('_', '-').ToUpperInvariant();
         }
 
-        public override async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
         {
             var markets = new List<ExchangeMarket>();
             JToken products = await MakeJsonRequestAsync<JToken>("/products");
@@ -157,12 +157,12 @@ namespace ExchangeSharp
             return markets;
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             return (await GetSymbolsMetadataAsync()).Select(market => market.MarketName);
         }
 
-        public override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
+        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
         {
             var currencies = new Dictionary<string, ExchangeCurrency>();
             JToken products = await MakeJsonRequestAsync<JToken>("/currencies");
@@ -181,7 +181,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             Dictionary<string, string> ticker = await MakeJsonRequestAsync<Dictionary<string, string>>("/products/" + symbol + "/ticker");
             decimal volume = Convert.ToDecimal(ticker["volume"], System.Globalization.CultureInfo.InvariantCulture);
@@ -255,7 +255,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             string baseUrl = "/products/" + symbol.ToUpperInvariant() + "/candles?granularity=" + (sinceDateTime == null ? "3600.0" : "60.0");
             string url;
@@ -296,7 +296,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
         {
             string baseUrl = "/products/" + symbol.ToUpperInvariant() + "/trades";
             Dictionary<string, object>[] trades = await MakeJsonRequestAsync<Dictionary<string, object>[]>(baseUrl);
@@ -315,7 +315,7 @@ namespace ExchangeSharp
             return tradeList;
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 50)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 50)
         {
             string url = "/products/" + symbol.ToUpperInvariant() + "/book?level=2";
             ExchangeOrderBook orders = new ExchangeOrderBook();
@@ -333,7 +333,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -379,7 +379,7 @@ namespace ExchangeSharp
             return candles;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, GetNoncePayload());
@@ -394,7 +394,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, GetNoncePayload());
@@ -409,7 +409,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = new Dictionary<string, object>
@@ -436,13 +436,13 @@ namespace ExchangeSharp
             return ParseOrder(result);
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             JObject obj = await MakeJsonRequestAsync<JObject>("/orders/" + orderId, null, GetNoncePayload(), "GET");
             return ParseOrder(obj);
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             symbol = NormalizeSymbol(symbol);
@@ -455,7 +455,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             symbol = NormalizeSymbol(symbol);
@@ -472,7 +472,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             await MakeJsonRequestAsync<JArray>("orders/" + orderId, null, GetNoncePayload(), "DELETE");
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -96,12 +96,12 @@ namespace ExchangeSharp
             return symbol?.Replace("-", string.Empty).ToLowerInvariant();
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             return await MakeJsonRequestAsync<string[]>("/symbols");
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
             JObject obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JObject>("/pubticker/" + symbol);
@@ -119,7 +119,7 @@ namespace ExchangeSharp
             return t;
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
             JObject obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JObject>("/book/" + symbol + "?limit_bids=" + maxCount + "&limit_asks=" + maxCount);
@@ -144,7 +144,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             const int maxCount = 100;
             symbol = NormalizeSymbol(symbol);
@@ -192,7 +192,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             Dictionary<string, decimal> lookup = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JArray obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JArray>("/balances", null, GetNoncePayload());
@@ -209,7 +209,7 @@ namespace ExchangeSharp
             return lookup;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             Dictionary<string, decimal> lookup = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JArray obj = await MakeJsonRequestAsync<Newtonsoft.Json.Linq.JArray>("/balances", null, GetNoncePayload());
@@ -226,7 +226,7 @@ namespace ExchangeSharp
             return lookup;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             if (order.OrderType == OrderType.Market)
             {
@@ -254,7 +254,7 @@ namespace ExchangeSharp
             return ParseOrder(obj);
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -266,7 +266,7 @@ namespace ExchangeSharp
             return ParseOrder(result);
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             symbol = NormalizeSymbol(symbol);
@@ -286,7 +286,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             JObject result = await MakeJsonRequestAsync<JObject>("/order/cancel", null, new Dictionary<string, object>{ { "nonce", GenerateNonce() }, { "order_id", orderId } });
             CheckError(result);

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -195,14 +195,14 @@ namespace ExchangeSharp
             return base.NormalizeSymbolGlobal(symbol);
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             JObject json = await MakeJsonRequestAsync<JObject>("/0/public/AssetPairs");
             JToken result = CheckError(json);
             return (from prop in result.Children<JProperty>() where !prop.Name.Contains(".d") select prop.Name).ToArray();
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             JObject json = await MakeJsonRequestAsync<JObject>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeSymbol(symbol) } });
             JToken ticker = CheckError(json);
@@ -224,7 +224,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
             JObject json = await MakeJsonRequestAsync<JObject>("/0/public/Depth?pair=" + symbol + "&count=" + maxCount);
@@ -250,7 +250,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             symbol = NormalizeSymbol(symbol);
             string baseUrl = "/0/public/Trades?pair=" + symbol;
@@ -305,7 +305,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -350,7 +350,7 @@ namespace ExchangeSharp
             return candles;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/0/private/Balance", null, GetNoncePayload());
             JToken result = CheckError(token);
@@ -366,7 +366,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
@@ -399,7 +399,7 @@ namespace ExchangeSharp
             return result;
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -423,12 +423,12 @@ namespace ExchangeSharp
             return ParseOrder(orderId, result[orderId]); ;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             return await QueryOrdersAsync(symbol, "/0/private/OpenOrders");
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             string path = "/0/private/ClosedOrders";
             if (afterDate != null)
@@ -438,7 +438,7 @@ namespace ExchangeSharp
             return await QueryOrdersAsync(symbol, path);
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
             {

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -122,9 +122,10 @@ namespace ExchangeSharp
             return orderResult;
         }
 
-        private IEnumerable<ExchangeOrderResult> QueryOrders(string symbol, string path)
+        private async Task<IEnumerable<ExchangeOrderResult>> QueryOrdersAsync(string symbol, string path)
         {
-            JObject json = MakeJsonRequest<JObject>(path, null, GetNoncePayload());
+            List<ExchangeOrderResult> orders = new List<ExchangeSharp.ExchangeOrderResult>();
+            JObject json = await MakeJsonRequestAsync<JObject>(path, null, GetNoncePayload());
             JToken result = CheckError(json);
             result = result["open"];
 
@@ -134,9 +135,11 @@ namespace ExchangeSharp
             {
                 if (symbol == null || order.Value["descr"]["pair"].ToStringInvariant() == symbol)
                 {
-                    yield return ParseOrder(order.Name, order.Value);
+                    orders.Add(ParseOrder(order.Name, order.Value));
                 }
             }
+
+            return orders;
         }
 
         protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
@@ -192,16 +195,16 @@ namespace ExchangeSharp
             return base.NormalizeSymbolGlobal(symbol);
         }
 
-        public override IEnumerable<string> GetSymbols()
+        public override async Task<IEnumerable<string>> GetSymbolsAsync()
         {
-            JObject json = MakeJsonRequest<JObject>("/0/public/AssetPairs");
+            JObject json = await MakeJsonRequestAsync<JObject>("/0/public/AssetPairs");
             JToken result = CheckError(json);
             return (from prop in result.Children<JProperty>() where !prop.Name.Contains(".d") select prop.Name).ToArray();
         }
 
-        public override ExchangeTicker GetTicker(string symbol)
+        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
         {
-            JObject json = MakeJsonRequest<JObject>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeSymbol(symbol) } });
+            JObject json = await MakeJsonRequestAsync<JObject>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeSymbol(symbol) } });
             JToken ticker = CheckError(json);
             ticker = ticker[symbol];
             decimal last = ticker["c"][0].ConvertInvariant<decimal>();
@@ -221,10 +224,10 @@ namespace ExchangeSharp
             };
         }
 
-        public override ExchangeOrderBook GetOrderBook(string symbol, int maxCount = 100)
+        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);
-            JObject json = MakeJsonRequest<JObject>("/0/public/Depth?pair=" + symbol + "&count=" + maxCount);
+            JObject json = await MakeJsonRequestAsync<JObject>("/0/public/Depth?pair=" + symbol + "&count=" + maxCount);
             JToken obj = CheckError(json);
             obj = obj[symbol];
             if (obj == null)
@@ -247,7 +250,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override IEnumerable<ExchangeTrade> GetHistoricalTrades(string symbol, DateTime? sinceDateTime = null)
+        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             symbol = NormalizeSymbol(symbol);
             string baseUrl = "/0/public/Trades?pair=" + symbol;
@@ -261,7 +264,7 @@ namespace ExchangeSharp
                 {
                     url += "&since=" + (long)(CryptoUtility.UnixTimestampFromDateTimeMilliseconds(sinceDateTime.Value) * 1000000.0);
                 }
-                JObject obj = MakeJsonRequest<JObject>(url);
+                JObject obj = await MakeJsonRequestAsync<JObject>(url);
                 if (obj == null)
                 {
                     break;
@@ -289,9 +292,9 @@ namespace ExchangeSharp
                     });
                 }
                 trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));
-                foreach (ExchangeTrade t in trades)
+                if (!callback(trades))
                 {
-                    yield return t;
+                    break;
                 }
                 trades.Clear();
                 if (sinceDateTime == null)
@@ -302,7 +305,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override IEnumerable<MarketCandle> GetCandles(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -315,8 +318,9 @@ namespace ExchangeSharp
             symbol = NormalizeSymbol(symbol);
             startDate = startDate ?? DateTime.UtcNow.Subtract(TimeSpan.FromDays(1.0));
             endDate = endDate ?? DateTime.UtcNow;
-            JObject json = MakeJsonRequest<JObject>("/0/public/OHLC?pair=" + symbol + "&interval=" + periodSeconds / 60 + "&since=" + startDate);
+            JObject json = await MakeJsonRequestAsync<JObject>("/0/public/OHLC?pair=" + symbol + "&interval=" + periodSeconds / 60 + "&since=" + startDate);
             CheckError(json);
+            List<MarketCandle> candles = new List<MarketCandle>();
             if (json["result"].Children().Count() != 0)
             {
                 JProperty prop = json["result"].Children().First() as JProperty;
@@ -338,15 +342,17 @@ namespace ExchangeSharp
                     };
                     if (candle.Timestamp >= startDate.Value && candle.Timestamp <= endDate.Value)
                     {
-                        yield return candle;
+                        candles.Add(candle);
                     }
                 }
             }
+
+            return candles;
         }
 
-        public override Dictionary<string, decimal> GetAmounts()
+        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
         {
-            JToken token = MakeJsonRequest<JToken>("/0/private/Balance", null, GetNoncePayload());
+            JToken token = await MakeJsonRequestAsync<JToken>("/0/private/Balance", null, GetNoncePayload());
             JToken result = CheckError(token);
             Dictionary<string, decimal> balances = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             foreach (JProperty prop in result)
@@ -360,7 +366,7 @@ namespace ExchangeSharp
             return balances;
         }
 
-        public override ExchangeOrderResult PlaceOrder(ExchangeOrderRequest order)
+        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
         {
             string symbol = NormalizeSymbol(order.Symbol);
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
@@ -380,7 +386,7 @@ namespace ExchangeSharp
                 payload[kv.Key] = kv.Value;
             }
 
-            JObject obj = MakeJsonRequest<JObject>("/0/private/AddOrder", null, payload);
+            JObject obj = await MakeJsonRequestAsync<JObject>("/0/private/AddOrder", null, payload);
             JToken token = CheckError(obj);
             ExchangeOrderResult result = new ExchangeOrderResult
             {
@@ -393,7 +399,7 @@ namespace ExchangeSharp
             return result;
         }
 
-        public override ExchangeOrderResult GetOrderDetails(string orderId)
+        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -405,7 +411,7 @@ namespace ExchangeSharp
                 { "txid", orderId },
                 { "nonce", GenerateNonce() }
             };
-            JObject obj = MakeJsonRequest<JObject>("/0/private/QueryOrders", null, payload);
+            JObject obj = await MakeJsonRequestAsync<JObject>("/0/private/QueryOrders", null, payload);
             JToken result = CheckError(obj);
             ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
             if (result == null || result[orderId] == null)
@@ -417,29 +423,29 @@ namespace ExchangeSharp
             return ParseOrder(orderId, result[orderId]); ;
         }
 
-        public override IEnumerable<ExchangeOrderResult> GetOpenOrderDetails(string symbol = null)
+        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
         {
-            return QueryOrders(symbol, "/0/private/OpenOrders");
+            return await QueryOrdersAsync(symbol, "/0/private/OpenOrders");
         }
 
-        public override IEnumerable<ExchangeOrderResult> GetCompletedOrderDetails(string symbol = null, DateTime? afterDate = null)
+        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             string path = "/0/private/ClosedOrders";
             if (afterDate != null)
             {
                 path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
             }
-            return QueryOrders(symbol, path);
+            return await QueryOrdersAsync(symbol, path);
         }
 
-        public override void CancelOrder(string orderId)
+        public override async Task CancelOrderAsync(string orderId)
         {
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
             {
                 { "txid", orderId },
                 { "nonce", GenerateNonce() }
             };
-            JObject obj = MakeJsonRequest<JObject>("/0/private/CancelOrder", null, payload);
+            JObject obj = await MakeJsonRequestAsync<JObject>("/0/private/CancelOrder", null, payload);
             CheckError(obj);
         }
     }

--- a/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
@@ -72,7 +72,7 @@ namespace ExchangeSharp
             };
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             // WTF no symbols end point? Sigh...
             return await Task.FromResult<IEnumerable<string>>(new string[]
@@ -81,13 +81,13 @@ namespace ExchangeSharp
             });
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             var data = await MakeRequestOkexAsync(symbol, "/ticker.do?symbol=$SYMBOL$");
             return ParseTicker(data.Item2, data.Item1);
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             var token = await MakeRequestOkexAsync(symbol, "/depth.do?symbol=$SYMBOL$");
             ExchangeOrderBook book = new ExchangeOrderBook();
@@ -103,7 +103,7 @@ namespace ExchangeSharp
             return book;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             List<ExchangeTrade> allTrades = new List<ExchangeTrade>();
             var trades = await MakeRequestOkexAsync(symbol, "/trades.do?symbol=$SYMBOL$");

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -73,7 +73,11 @@ namespace ExchangeSharp
 
         private void CheckError(JToken result)
         {
-            if (result != null && !(result is JArray) && result["error"] != null)
+            if (result == null)
+            {
+                throw new APIException("No result");
+            }
+            else if (!(result is JArray) && result["error"] != null)
             {
                 throw new APIException(result["error"].ToStringInvariant());
             }

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -244,7 +244,7 @@ namespace ExchangeSharp
             return symbol?.ToUpperInvariant().Replace('-', '_');
         }
 
-        public override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
+        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
         {
             /*
              * {"1CR":{"id":1,"name":"1CRedit","txFee":"0.01000000","minConf":3,"depositAddress":null,"disabled":0,"delisted":1,"frozen":0},
@@ -279,7 +279,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        public override async Task<IEnumerable<string>> GetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             var tickers = await GetTickersAsync();
@@ -290,7 +290,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        public override async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
         {
             //https://poloniex.com/public?command=returnOrderBook&currencyPair=all&depth=0
             /*
@@ -335,7 +335,7 @@ namespace ExchangeSharp
             return markets;
         }
 
-        public override async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             symbol = NormalizeSymbol(symbol);
             IEnumerable<KeyValuePair<string, ExchangeTicker>> tickers = await GetTickersAsync();
@@ -349,7 +349,7 @@ namespace ExchangeSharp
             return null;
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             // {"BTC_LTC":{"last":"0.0251","lowestAsk":"0.02589999","highestBid":"0.0251","percentChange":"0.02390438","baseVolume":"6.16485315","quoteVolume":"245.82513926"}
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
@@ -417,7 +417,7 @@ namespace ExchangeSharp
             });
         }
 
-        public override async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             // {"asks":[["0.01021997",22.83117932],["0.01022000",82.3204],["0.01022480",140],["0.01023054",241.06436945],["0.01023057",140]],"bids":[["0.01020233",164.195],["0.01020232",66.22565096],["0.01020200",5],["0.01020010",66.79296968],["0.01020000",490.19563761]],"isFrozen":"0","seq":147171861}
             symbol = NormalizeSymbol(symbol);
@@ -435,7 +435,7 @@ namespace ExchangeSharp
             return book;
         }
 
-        public override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100)
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(int maxCount = 100)
         {
             List<KeyValuePair<string, ExchangeOrderBook>> books = new List<KeyValuePair<string, ExchangeOrderBook>>();
             JObject obj = await MakeJsonRequestAsync<JObject>("/public?command=returnOrderBook&currencyPair=all&depth=" + maxCount);
@@ -456,7 +456,7 @@ namespace ExchangeSharp
             return books;
         }
 
-        public override async Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        protected override async Task OnGetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
         {
             // [{"globalTradeID":245321705,"tradeID":11501281,"date":"2017-10-20 17:39:17","type":"buy","rate":"0.01022188","amount":"0.00954454","total":"0.00009756"},...]
             // https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_LTC&start=1410158341&end=1410499372
@@ -510,7 +510,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -551,7 +551,7 @@ namespace ExchangeSharp
             return candles;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
         {
             Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JToken result = await MakePrivateAPIRequestAsync("returnCompleteBalances");
@@ -567,7 +567,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        public override async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
         {
             Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             JToken result = await MakePrivateAPIRequestAsync("returnBalances");
@@ -583,7 +583,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        public override async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             if (order.OrderType == OrderType.Market)
             {
@@ -615,7 +615,7 @@ namespace ExchangeSharp
             return exchangeOrderResult;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
         {
             symbol = NormalizeSymbol(symbol);
             if (string.IsNullOrWhiteSpace(symbol))
@@ -650,7 +650,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
         {
             JToken result = await MakePrivateAPIRequestAsync("returnOrderTrades", new object[] { "orderNumber", orderId });
             try
@@ -686,7 +686,7 @@ namespace ExchangeSharp
             return null;
         }
 
-        public override async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
         {
             symbol = string.IsNullOrWhiteSpace(symbol) ? "all" : NormalizeSymbol(symbol);
 
@@ -709,7 +709,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        public override async Task CancelOrderAsync(string orderId)
+        protected override async Task OnCancelOrderAsync(string orderId)
         {
             JToken token = await MakePrivateAPIRequestAsync("cancelOrder", new object[] { "orderNumber", long.Parse(orderId) });
             CheckError(token);
@@ -719,7 +719,7 @@ namespace ExchangeSharp
             }
         }
 
-        public override async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
         {
             // If we have an address tag, verify that Polo lets you specify it as part of the withdrawal
             if (!string.IsNullOrWhiteSpace(withdrawalRequest.AddressTag))
@@ -752,7 +752,7 @@ namespace ExchangeSharp
             return resp;
         }
 
-        public override async Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
         {
             symbol = NormalizeSymbol(symbol);
 
@@ -780,7 +780,7 @@ namespace ExchangeSharp
         /// <summary>Gets the deposit history for a symbol</summary>
         /// <param name="symbol">(ignored) The symbol to check.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public override async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
         {
             JToken result = await MakePrivateAPIRequestAsync("returnDepositsWithdrawals",
                 new object[]

--- a/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
@@ -218,14 +218,14 @@ namespace ExchangeSharp
         Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100);
 
         /// <summary>
-        /// Get exchange order book for all symbols. Not all exchanges support this. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
+        /// Get exchange order book for all symbols. Not all exchanges support  Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
         /// </summary>
         /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
         /// <returns>Symbol and order books pairs</returns>
         IEnumerable<KeyValuePair<string, ExchangeOrderBook>> GetOrderBooks(int maxCount = 100);
 
         /// <summary>
-        /// ASYNC - Get exchange order book for all symbols. Not all exchanges support this. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
+        /// ASYNC - Get exchange order book for all symbols. Not all exchanges support  Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
         /// </summary>
         /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
         /// <returns>Symbol and order books pairs</returns>

--- a/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IExchangeAPI.cs
@@ -232,26 +232,26 @@ namespace ExchangeSharp
         Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100);
 
         /// <summary>
-        /// Get historical trades
+        /// Get historical trades for the exchange
         /// </summary>
-        /// <param name="symbol">Symbol</param>
-        /// <param name="sinceDateTime">Since date time</param>
-        /// <returns>Trades</returns>
-        IEnumerable<ExchangeTrade> GetHistoricalTrades(string symbol, DateTime? sinceDateTime = null);
+        /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
+        /// <param name="symbol">Symbol to get historical data for</param>
+        /// <param name="sinceDateTime">Optional date time to start getting the historical data at, null for the most recent data</param>
+        void GetHistoricalTrades(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null);
 
         /// <summary>
-        /// ASYNC - Get historical trades
+        /// ASYNC - Get historical trades for the exchange
         /// </summary>
-        /// <param name="symbol">Symbol</param>
-        /// <param name="sinceDateTime">Since date time</param>
-        /// <returns>Trades</returns>
-        Task<IEnumerable<ExchangeTrade>> GetHistoricalTradesAsync(string symbol, DateTime? sinceDateTime = null);
+        /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
+        /// <param name="symbol">Symbol to get historical data for</param>
+        /// <param name="sinceDateTime">Optional date time to start getting the historical data at, null for the most recent data</param>
+        Task GetHistoricalTradesAsync(System.Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null);
 
         /// <summary>
-        /// Get the latest trades
+        /// Get recent trades on the exchange - this implementation simply calls GetHistoricalTrades with a null sinceDateTime.
         /// </summary>
-        /// <param name="symbol">Symbol</param>
-        /// <returns>Trades</returns>
+        /// <param name="symbol">Symbol to get recent trades for</param>
+        /// <returns>An enumerator that loops through all recent trades</returns>
         IEnumerable<ExchangeTrade> GetRecentTrades(string symbol);
 
         /// <summary>
@@ -358,18 +358,19 @@ namespace ExchangeSharp
         IEnumerable<ExchangeOrderResult> GetCompletedOrderDetails(string symbol = null, DateTime? afterDate = null);
 
         /// <summary>
+        /// ASYNC - Get the details of all completed orders
+        /// </summary>
+        /// <param name="symbol">Symbol to get completed orders for or null for all</param>
+        /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
+        /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
+        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null);
+
+        /// <summary>
         /// Get the details of all completed orders via web socket
         /// </summary>
         /// <param name="callback">Callback</param>
         /// <returns>Web socket, call Dispose to close</returns>
         IDisposable GetCompletedOrderDetailsWebSocket(System.Action<ExchangeOrderResult> callback);
-
-        /// <summary>
-        /// ASYNC - Get the details of all completed orders
-        /// </summary>
-        /// <param name="symbol">Symbol to get completed orders for or null for all</param>
-        /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null);
 
         /// <summary>
         /// Cancel an order, an exception is thrown if failure

--- a/ExchangeSharp/API/IAPIRequestMaker.cs
+++ b/ExchangeSharp/API/IAPIRequestMaker.cs
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
@@ -31,6 +32,17 @@ namespace ExchangeSharp
         /// <param name="method">Request method or null for default</param>
         /// <returns>Raw response</returns>
         string MakeRequest(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null);
+
+        /// <summary>
+        /// ASYNC - Make a request to a path on the API
+        /// </summary>
+        /// <param name="url">Path and query</param>
+        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+        /// The encoding of payload is API dependant but is typically json.</param>
+        /// <param name="method">Request method or null for default</param>
+        /// <returns>Raw response</returns>
+        Task<string> MakeRequestAsync(string url, string baseUrl = null, Dictionary<string, object> payload = null, string method = null);
     }
 
     /// <summary>

--- a/ExchangeSharp/API/WebSocketWrapper.cs
+++ b/ExchangeSharp/API/WebSocketWrapper.cs
@@ -217,7 +217,7 @@ namespace ExchangeSharp
                         }
                         else if (message is string messageString)
                         {
-                            this._onMessage?.Invoke(messageString, this);
+                            _onMessage?.Invoke(messageString, this);
                         }
                     }
                     catch

--- a/ExchangeSharp/ExchangeSharp.csproj
+++ b/ExchangeSharp/ExchangeSharp.csproj
@@ -50,7 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.2.3" />
-    <PackageReference Include="Bittrex.Net" Version="2.0.10" />
+    <PackageReference Include="Bittrex.Net" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/ExchangeSharp/Forms/PlotForm.Designer.cs
+++ b/ExchangeSharp/Forms/PlotForm.Designer.cs
@@ -30,31 +30,31 @@ namespace ExchangeSharp
         /// </summary>
         private void InitializeComponent()
         {
-            this.PlotChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
-            ((System.ComponentModel.ISupportInitialize)(this.PlotChart)).BeginInit();
-            this.SuspendLayout();
+            PlotChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            ((System.ComponentModel.ISupportInitialize)(PlotChart)).BeginInit();
+            SuspendLayout();
             // 
             // PlotChart
             // 
-            this.PlotChart.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.PlotChart.Location = new System.Drawing.Point(0, 0);
-            this.PlotChart.Margin = new System.Windows.Forms.Padding(2);
-            this.PlotChart.Name = "PlotChart";
-            this.PlotChart.Size = new System.Drawing.Size(658, 412);
-            this.PlotChart.TabIndex = 0;
-            this.PlotChart.Text = "chart1";
+            PlotChart.Dock = System.Windows.Forms.DockStyle.Fill;
+            PlotChart.Location = new System.Drawing.Point(0, 0);
+            PlotChart.Margin = new System.Windows.Forms.Padding(2);
+            PlotChart.Name = "PlotChart";
+            PlotChart.Size = new System.Drawing.Size(658, 412);
+            PlotChart.TabIndex = 0;
+            PlotChart.Text = "chart1";
             // 
             // PlotForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(658, 412);
-            this.Controls.Add(this.PlotChart);
-            this.Margin = new System.Windows.Forms.Padding(2);
-            this.Name = "PlotForm";
-            this.Text = "Plot of Trade Data";
-            ((System.ComponentModel.ISupportInitialize)(this.PlotChart)).EndInit();
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(658, 412);
+            Controls.Add(PlotChart);
+            Margin = new System.Windows.Forms.Padding(2);
+            Name = "PlotForm";
+            Text = "Plot of Trade Data";
+            ((System.ComponentModel.ISupportInitialize)(PlotChart)).EndInit();
+            ResumeLayout(false);
 
         }
 

--- a/ExchangeSharp/Forms/PlotForm.cs
+++ b/ExchangeSharp/Forms/PlotForm.cs
@@ -88,8 +88,8 @@ namespace ExchangeSharp
             PlotChart.ChartAreas.Clear();
             PlotChart.ChartAreas.Add(new ChartArea());
 
-            buyPrices = buyPrices;
-            sellPrices = sellPrices;
+            this.buyPrices = buyPrices;
+            this.sellPrices = sellPrices;
             int index = 0;
             float minPrice = float.MaxValue;
             float maxPrice = float.MinValue;

--- a/ExchangeSharp/Forms/PlotForm.cs
+++ b/ExchangeSharp/Forms/PlotForm.cs
@@ -88,8 +88,8 @@ namespace ExchangeSharp
             PlotChart.ChartAreas.Clear();
             PlotChart.ChartAreas.Add(new ChartArea());
 
-            this.buyPrices = buyPrices;
-            this.sellPrices = sellPrices;
+            buyPrices = buyPrices;
+            sellPrices = sellPrices;
             int index = 0;
             float minPrice = float.MaxValue;
             float maxPrice = float.MinValue;

--- a/ExchangeSharp/Model/ExchangeDepositDetails.cs
+++ b/ExchangeSharp/Model/ExchangeDepositDetails.cs
@@ -29,7 +29,7 @@ namespace ExchangeSharp
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return $"{this.Symbol}: Address: {this.Address} AddressTag: {this.AddressTag}";
+            return $"{Symbol}: Address: {Address} AddressTag: {AddressTag}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -51,7 +51,7 @@ namespace ExchangeSharp
 
         public override string ToString()
         {
-            return $"{this.MarketName}, {this.MarketCurrency}-{this.BaseCurrency}";
+            return $"{MarketName}, {MarketCurrency}-{BaseCurrency}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeOrderRequest.cs
+++ b/ExchangeSharp/Model/ExchangeOrderRequest.cs
@@ -64,7 +64,7 @@ namespace ExchangeSharp
         /// <returns>Rounded amount or amount if no rounding is needed</returns>
         public decimal RoundAmount()
         {
-            return this.ShouldRoundAmount ? CryptoUtility.RoundAmount(this.Amount) : this.Amount;
+            return ShouldRoundAmount ? CryptoUtility.RoundAmount(Amount) : Amount;
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -62,29 +62,29 @@ namespace ExchangeSharp
         /// <param name="other">Order to append</param>
         public void AppendOrderWithOrder(ExchangeOrderResult other)
         {
-            if ((this.OrderId != null) && (this.Symbol != null) && ((this.OrderId != other.OrderId) || (this.IsBuy != other.IsBuy) || (this.Symbol != other.Symbol)))
+            if ((OrderId != null) && (Symbol != null) && ((OrderId != other.OrderId) || (IsBuy != other.IsBuy) || (Symbol != other.Symbol)))
             {
                 throw new InvalidOperationException("Appending orders requires order id, symbol and is buy to match");
             }
 
-            decimal tradeSum = this.Amount + other.Amount;
-            decimal baseAmount = this.Amount;
-            this.Amount += other.Amount;
-            this.AmountFilled += other.AmountFilled;
-            this.Fees += other.Fees;
-            this.FeesCurrency = other.FeesCurrency;
-            this.AveragePrice = (this.AveragePrice * (baseAmount / tradeSum)) + (other.AveragePrice * (other.Amount / tradeSum));
-            this.OrderId = other.OrderId;
-            this.OrderDate = this.OrderDate == default(DateTime) ? other.OrderDate : this.OrderDate;
-            this.Symbol = other.Symbol;
-            this.IsBuy = other.IsBuy;
+            decimal tradeSum = Amount + other.Amount;
+            decimal baseAmount = Amount;
+            Amount += other.Amount;
+            AmountFilled += other.AmountFilled;
+            Fees += other.Fees;
+            FeesCurrency = other.FeesCurrency;
+            AveragePrice = (AveragePrice * (baseAmount / tradeSum)) + (other.AveragePrice * (other.Amount / tradeSum));
+            OrderId = other.OrderId;
+            OrderDate = OrderDate == default(DateTime) ? other.OrderDate : OrderDate;
+            Symbol = other.Symbol;
+            IsBuy = other.IsBuy;
         }
 
         /// <summary>Returns a string that represents this instance.</summary>
         /// <returns>A string that represents this instance.</returns>
         public override string ToString()
         {
-            return $"[{this.OrderDate}], {(this.IsBuy ? "Buy" : "Sell")} {this.AmountFilled} of {this.Amount} {this.Symbol} {this.Result} at {this.AveragePrice}, fees paid {this.Fees} {this.FeesCurrency}";
+            return $"[{OrderDate}], {(IsBuy ? "Buy" : "Sell")} {AmountFilled} of {Amount} {Symbol} {Result} at {AveragePrice}, fees paid {Fees} {FeesCurrency}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeTransaction.cs
+++ b/ExchangeSharp/Model/ExchangeTransaction.cs
@@ -50,7 +50,7 @@ namespace ExchangeSharp
         public override string ToString()
         {
             return
-                $"{this.Amount} {this.Symbol} (fee: {this.TxFee}) sent to Address: {this.Address ?? "null"} with AddressTag: {this.AddressTag ?? "null"} BlockchainTxId: {this.BlockchainTxId ?? "null"} sent at {this.TimestampUTC} UTC. Status: {this.Status}. Exchange paymentId: {this.PaymentId ?? "null"}. Notes: {this.Notes ?? "null"}";
+                $"{Amount} {Symbol} (fee: {TxFee}) sent to Address: {Address ?? "null"} with AddressTag: {AddressTag ?? "null"} BlockchainTxId: {BlockchainTxId ?? "null"} sent at {TimestampUTC} UTC. Status: {Status}. Exchange paymentId: {PaymentId ?? "null"}. Notes: {Notes ?? "null"}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeWithdrawalRequest.cs
+++ b/ExchangeSharp/Model/ExchangeWithdrawalRequest.cs
@@ -43,15 +43,15 @@ namespace ExchangeSharp
         public override string ToString()
         {
             // 2.75 ETH to 0x1234asdf
-            string info = $"{this.Amount} {this.Symbol} to {this.Address}";
-            if (!string.IsNullOrWhiteSpace(this.AddressTag))
+            string info = $"{Amount} {Symbol} to {Address}";
+            if (!string.IsNullOrWhiteSpace(AddressTag))
             {
-                info += $" with address tag {this.AddressTag}";
+                info += $" with address tag {AddressTag}";
             }
 
-            if (!string.IsNullOrWhiteSpace(this.Description))
+            if (!string.IsNullOrWhiteSpace(Description))
             {
-                info += $" Description: {this.Description}";
+                info += $" Description: {Description}";
             }
 
             return info;

--- a/ExchangeSharp/Model/ExchangeWithdrawalResponse.cs
+++ b/ExchangeSharp/Model/ExchangeWithdrawalResponse.cs
@@ -30,7 +30,7 @@ namespace ExchangeSharp
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return $"Success: {this.Success} Id: {this.Id ?? "null"} Message: {this.Message ?? "null"}";
+            return $"Success: {Success} Id: {Id ?? "null"} Message: {Message ?? "null"}";
         }
     }
 }

--- a/ExchangeSharp/Traders/TraderReader.cs
+++ b/ExchangeSharp/Traders/TraderReader.cs
@@ -49,13 +49,13 @@ namespace ExchangeSharp
 
         public TradeReaderMemory(byte[] tickerData)
         {
-            this.tickerData = tickerData;
+            tickerData = tickerData;
             tickersHandle = GCHandle.Alloc(tickerData, GCHandleType.Pinned);
-            this.tickers = (Trade*)tickersHandle.AddrOfPinnedObject();
-            this.tickersStart = this.tickers;
-            this.tickersCount = tickerData.Length / 16;
-            this.tickersEnd = this.tickers + this.tickersCount;
-            this.ownsHandle = true;
+            tickers = (Trade*)tickersHandle.AddrOfPinnedObject();
+            tickersStart = tickers;
+            tickersCount = tickerData.Length / 16;
+            tickersEnd = tickers + tickersCount;
+            ownsHandle = true;
         }
 
         public void Dispose()

--- a/ExchangeSharp/Traders/TraderReader.cs
+++ b/ExchangeSharp/Traders/TraderReader.cs
@@ -49,7 +49,7 @@ namespace ExchangeSharp
 
         public TradeReaderMemory(byte[] tickerData)
         {
-            tickerData = tickerData;
+            this.tickerData = tickerData;
             tickersHandle = GCHandle.Alloc(tickerData, GCHandleType.Pinned);
             tickers = (Trade*)tickersHandle.AddrOfPinnedObject();
             tickersStart = tickers;

--- a/ExchangeSharp/Utility/RateGate.cs
+++ b/ExchangeSharp/Utility/RateGate.cs
@@ -158,7 +158,15 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="millisecondsTimeout">Number of milliseconds to wait, or -1 to wait indefinitely.</param>
         /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
-        public bool WaitToProceed(int millisecondsTimeout)
+        public bool WaitToProceed(int millisecondsTimeout) => WaitToProceedAsync(millisecondsTimeout).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Blocks the current thread until allowed to proceed or until the
+        /// specified timeout elapses.
+        /// </summary>
+        /// <param name="millisecondsTimeout">Number of milliseconds to wait, or -1 to wait indefinitely.</param>
+        /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
+        public async Task<bool> WaitToProceedAsync(int millisecondsTimeout)
         {
             // Check the arguments.
             if (millisecondsTimeout < -1)
@@ -169,7 +177,7 @@ namespace ExchangeSharp
             CheckDisposed();
 
             // Block until we can enter the semaphore or until the timeout expires.
-            var entered = semaphore.Wait(millisecondsTimeout);
+            var entered = await semaphore.WaitAsync(millisecondsTimeout);
 
             // If we entered the semaphore, compute the corresponding exit time 
             // and add it to the queue.
@@ -187,17 +195,30 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="timeout"></param>
         /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
-        public bool WaitToProceed(TimeSpan timeout)
+        public bool WaitToProceed(TimeSpan timeout) => WaitToProceedAsync(timeout).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Blocks the current thread until allowed to proceed or until the
+        /// specified timeout elapses.
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
+        public async Task<bool> WaitToProceedAsync(TimeSpan timeout)
         {
-            return WaitToProceed((int)timeout.TotalMilliseconds);
+            return await WaitToProceedAsync((int)timeout.TotalMilliseconds);
         }
 
         /// <summary>
         /// Blocks the current thread indefinitely until allowed to proceed.
         /// </summary>
-        public void WaitToProceed()
+        public void WaitToProceed() => WaitToProceedAsync().GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Blocks the current thread indefinitely until allowed to proceed.
+        /// </summary>
+        public async Task WaitToProceedAsync()
         {
-            WaitToProceed(Timeout.Infinite);
+            await WaitToProceedAsync(Timeout.Infinite);
         }
 
         /// <summary>

--- a/ExchangeSharp/Utility/RateGate.cs
+++ b/ExchangeSharp/Utility/RateGate.cs
@@ -168,6 +168,8 @@ namespace ExchangeSharp
         /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
         public async Task<bool> WaitToProceedAsync(int millisecondsTimeout)
         {
+            await new SynchronizationContextRemover();
+
             // Check the arguments.
             if (millisecondsTimeout < -1)
             {
@@ -205,6 +207,8 @@ namespace ExchangeSharp
         /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
         public async Task<bool> WaitToProceedAsync(TimeSpan timeout)
         {
+            await new SynchronizationContextRemover();
+
             return await WaitToProceedAsync((int)timeout.TotalMilliseconds);
         }
 
@@ -218,6 +222,8 @@ namespace ExchangeSharp
         /// </summary>
         public async Task WaitToProceedAsync()
         {
+            await new SynchronizationContextRemover();
+
             await WaitToProceedAsync(Timeout.Infinite);
         }
 

--- a/ExchangeSharp/Utility/SynchronizationContextRemover.cs
+++ b/ExchangeSharp/Utility/SynchronizationContextRemover.cs
@@ -1,0 +1,51 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace ExchangeSharp
+{
+    internal struct SynchronizationContextRemover : INotifyCompletion
+    {
+        public bool IsCompleted
+        {
+            get { return SynchronizationContext.Current == null; }
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            var prevContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                continuation();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevContext);
+            }
+        }
+
+        public SynchronizationContextRemover GetAwaiter()
+        {
+            return this;
+        }
+
+        public void GetResult()
+        {
+        }
+    }
+}

--- a/ExchangeSharp/Utility/SynchronizationContextRemover.cs
+++ b/ExchangeSharp/Utility/SynchronizationContextRemover.cs
@@ -28,14 +28,21 @@ namespace ExchangeSharp
         public void OnCompleted(Action continuation)
         {
             var prevContext = SynchronizationContext.Current;
-            try
+            if (prevContext == null)
             {
-                SynchronizationContext.SetSynchronizationContext(null);
-                continuation();
+                continuation?.Invoke();
             }
-            finally
+            else
             {
-                SynchronizationContext.SetSynchronizationContext(prevContext);
+                try
+                {
+                    SynchronizationContext.SetSynchronizationContext(null);
+                    continuation?.Invoke();
+                }
+                finally
+                {
+                    SynchronizationContext.SetSynchronizationContext(prevContext);
+                }
             }
         }
 

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Tests.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Tests.cs
@@ -188,6 +188,13 @@ namespace ExchangeSharpConsoleApp
 
         private static void TestExchanges()
         {
+            ExchangeTrade[] trades = null;
+            bool histTradeCallback(IEnumerable<ExchangeTrade> tradeEnum)
+            {
+                trades = tradeEnum.ToArray();
+                return true;
+            }
+
             IExchangeAPI[] apis = ExchangeAPI.GetExchangeAPIDictionary().Values.ToArray();
             foreach (IExchangeAPI api in apis)
             {
@@ -200,7 +207,8 @@ namespace ExchangeSharpConsoleApp
                     Assert(symbols != null && symbols.Count != 0 && symbols.Contains(symbol, StringComparer.OrdinalIgnoreCase));
                     Console.WriteLine($"API {api.Name} GetSymbols OK (default: {symbol}; {symbols.Count} symbols)");
 
-                    ExchangeTrade[] trades = api.GetHistoricalTrades(symbol).ToArray();
+                    api.GetHistoricalTrades(histTradeCallback, symbol);
+
                     Assert(trades.Length != 0 && trades[0].Price > 0m && trades[0].Amount > 0m);
                     Console.WriteLine($"API {api.Name} GetHistoricalTrades OK ({trades.Length})");
 

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -195,7 +195,7 @@ namespace ExchangeSharpTests
         public void GetOpenOrderDetails_Unfilled_IsCorrect()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(Unfilled);
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(Unfilled);
 
             IEnumerable<ExchangeOrderResult> orders = polo.GetOpenOrderDetails("ETH_BCH");
             ExchangeOrderResult order = orders.Single();
@@ -213,7 +213,7 @@ namespace ExchangeSharpTests
         public void GetOpenOrderDetails_AllUnfilled_IsCorrect()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(AllUnfilledOrders);
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(AllUnfilledOrders);
 
             IEnumerable<ExchangeOrderResult> orders = polo.GetOpenOrderDetails(); // all
             ExchangeOrderResult order = orders.Single();
@@ -231,7 +231,7 @@ namespace ExchangeSharpTests
         public void GetOrderDetails_HappyPath()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_SimpleBuy);
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(ReturnOrderTrades_SimpleBuy);
             ExchangeOrderResult order = polo.GetOrderDetails("1");
 
             order.OrderId.Should().Be("1");
@@ -250,7 +250,7 @@ namespace ExchangeSharpTests
         public void GetOrderDetails_OrderNotFound_DoesNotThrow()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(@"{""error"":""Order not found, or you are not the person who placed it.""}");
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(@"{""error"":""Order not found, or you are not the person who placed it.""}");
             polo.GetOrderDetails("1").Should().BeNull();
         }
 
@@ -258,7 +258,7 @@ namespace ExchangeSharpTests
         public void GetOrderDetails_OtherErrors_ThrowAPIException()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(@"{""error"":""Big scary error.""}");
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(@"{""error"":""Big scary error.""}");
 
             void a() => polo.GetOrderDetails("1");
             Invoking(a).Should().Throw<APIException>();
@@ -268,7 +268,7 @@ namespace ExchangeSharpTests
         public void GetCompletedOrderDetails_MultipleOrders()
         {
             var polo = CreateAPI();
-            polo.RequestMaker.MakeRequest(null).ReturnsForAnyArgs(ReturnOrderTrades_AllGas);
+            polo.RequestMaker.MakeRequestAsync(null).ReturnsForAnyArgs(ReturnOrderTrades_AllGas);
             IEnumerable<ExchangeOrderResult> orders = polo.GetCompletedOrderDetails("ETH_GAS");
             orders.Should().HaveCount(2);
             ExchangeOrderResult sellorder = orders.Single(x => !x.IsBuy);

--- a/ExchangeSharpTests/ExchangeSharpTests.csproj
+++ b/ExchangeSharpTests/ExchangeSharpTests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Before this change, async calls were simply wrapped in Task.Run calls. Now async calls are the base implementation, and the synchronous calls wrap the async calls. This will avoid deadlock/thread starvation. Any future api methods should be implemented with the same pattern.