### PR TITLE
Added Abucoins Exchange

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -616,6 +616,11 @@ namespace ExchangeSharp
         public const string Gemini = "Gemini";
 
         /// <summary>
+        /// Gemini
+        /// </summary>
+        public const string Hitbtc = "Hitbtc";
+
+        /// <summary>
         /// Kraken
         /// </summary>
         public const string Kraken = "Kraken";

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -616,7 +616,7 @@ namespace ExchangeSharp
         public const string Gemini = "Gemini";
 
         /// <summary>
-        /// Gemini
+        /// Hitbtc
         /// </summary>
         public const string Hitbtc = "Hitbtc";
 

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -601,6 +601,11 @@ namespace ExchangeSharp
         public const string Bittrex = "Bittrex";
 
         /// <summary>
+        /// Bittrex
+        /// </summary>
+        public const string Bleutrade = "Bleutrade";
+
+        /// <summary>
         /// GDAX
         /// </summary>
         public const string GDAX = "GDAX";

--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -573,6 +573,11 @@ namespace ExchangeSharp
         /// <summary>
         /// Binance
         /// </summary>
+        public const string Abucoins = "Abucoins";
+
+        /// <summary>
+        /// Binance
+        /// </summary>
         public const string Binance = "Binance";
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
@@ -116,7 +116,7 @@ namespace ExchangeSharp
                         Bid = token["bid"].ConvertInvariant<decimal>(),
                         Volume = new ExchangeVolume()
                     };
-                    // sometimes the size is null and sometimes it is returned using exponent notaion and sometimes not. 
+                    // sometimes the size is null and sometimes it is returned using exponent notation and sometimes not. 
                     // We therefore parse as string and convert to decimal with float option
                     if ((string)token["size"] != null) ticker.Volume.PriceAmount = decimal.Parse((string)token["size"], NumberStyles.Float);
                     ticker.Volume.QuantityAmount = token.Value<decimal>("volume");
@@ -341,8 +341,7 @@ namespace ExchangeSharp
                     Symbol = token["product_id"].ToStringInvariant(),
                 };
 
-                DateTime dt;
-                if (DateTime.TryParse(token["created_at"].ToStringInvariant(), out dt)) eor.OrderDate = dt;
+                if (DateTime.TryParse(token["created_at"].ToStringInvariant(), out DateTime dt)) eor.OrderDate = dt;
                 if (token["status"].ToStringInvariant().Equals("open")) eor.Result = ExchangeAPIOrderResult.Pending;
                 else
                 {

--- a/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace neuCryptoManager.Shared
+namespace ExchangeSharp
 {
     public sealed class ExchangebuCoinsAPI : ExchangeAPI
     {

--- a/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
@@ -11,13 +11,13 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
-    public sealed class ExchangebuCoinsAPI : ExchangeAPI
+    public sealed class ExchangeAbucoinsAPI : ExchangeAPI
     {
         public override string Name => ExchangeName.Abucoins;
         public override string BaseUrl { get; set; } = "https://api.abucoins.com";
         public override string BaseUrlWebSocket { get; set; } = "wss://ws.abucoins.com";
 
-        public neuAbuCoinsAPI()
+        public ExchangeAbucoinsAPI()
         {
             RequestContentType = "application/json";
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
@@ -1,0 +1,573 @@
+﻿using ExchangeSharp;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace neuCryptoManager.Shared
+{
+    public sealed class ExchangebuCoinsAPI : ExchangeAPI
+    {
+        public override string Name => ExchangeName.Abucoins;
+        public override string BaseUrl { get; set; } = "https://api.abucoins.com";
+        public override string BaseUrlWebSocket { get; set; } = "wss://ws.abucoins.com";
+
+        public neuAbuCoinsAPI()
+        {
+            RequestContentType = "application/json";
+        }
+
+        #region ProcessRequest 
+
+        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        {
+            if (CanMakeAuthenticatedRequest(payload))
+            {
+                payload.Remove("nonce");
+                string body = GetJsonForPayload(payload);
+                string timestamp = ((int)DateTime.UtcNow.UnixTimestampFromDateTimeSeconds()).ToString();
+                string msg = timestamp + request.Method + request.RequestUri.PathAndQuery + (request.Method.Equals("POST") ? body : string.Empty);
+                string sign = CryptoUtility.SHA256SignBase64(msg, CryptoUtility.SecureStringToBytesBase64Decode(PrivateApiKey));
+
+                request.Headers["AC-ACCESS-KEY"] = CryptoUtility.SecureStringToString(PublicApiKey);
+                request.Headers["AC-ACCESS-SIGN"] = sign;
+                request.Headers["AC-ACCESS-TIMESTAMP"] = timestamp;
+                request.Headers["AC-ACCESS-PASSPHRASE"] = CryptoUtility.SecureStringToString(Passphrase);
+
+                if (request.Method == "POST") WriteFormToRequest(request, body);
+            }
+        }
+
+
+        #endregion
+
+        #region Public APIs
+
+        
+
+        
+        protected override Task<IReadOnlyDictionary<string, ExchangeCurrency>>  OnGetCurrenciesAsync()
+        {
+            throw new NotSupportedException("Abucoins does not provide data about its currencies via the API");
+        }
+
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        {
+            List<string> symbols = new List<string>();
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products");
+            foreach (JToken token in obj) symbols.Add(token["id"].Value<string>());
+            return symbols;
+        }
+         
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        {
+            List<ExchangeMarket> markets = new List<ExchangeMarket>();
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products");
+            const decimal StepSize = 0.00000001m;
+            foreach (JToken token in obj)
+            {
+                markets.Add(new ExchangeMarket
+                {
+                     MarketName = token["id"].ToStringInvariant(),
+                     BaseCurrency = token["base_currency"].ToStringInvariant(),
+                     MarketCurrency = token["quote_currency"].ToStringInvariant(),
+                     MinTradeSize = token["base_min_size"].ConvertInvariant<decimal>(),
+                     MaxTradeSize = token["base_max_size"].ConvertInvariant<decimal>(),
+                     QuantityStepSize = token["quote_increment"].ConvertInvariant<decimal>(),
+                     MaxPrice = StepSize,
+                     MinPrice = StepSize,
+                     PriceStepSize = StepSize,
+                    IsActive = true
+                });
+            }
+            return markets;
+        }
+
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        {
+            JToken token = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/ticker");
+            if (!token.HasValues) return null;
+            return new ExchangeTicker
+            {
+                Ask = token["ask"].ConvertInvariant<decimal>(),
+                Bid = token["bid"].ConvertInvariant<decimal>(),
+                Last = decimal.Parse(token["price"].ToStringLowerInvariant(), System.Globalization.NumberStyles.Float),
+                Volume = new ExchangeVolume()
+                {
+                    PriceAmount = decimal.Parse(token["size"].ToStringLowerInvariant(), NumberStyles.Float),
+                    QuantityAmount = token["volume"].ConvertInvariant<decimal>(),
+                    Timestamp = DateTime.UtcNow
+                }
+            };
+        }
+
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+        {
+            List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products/ticker");
+            if (obj.HasValues)
+            {
+                foreach (JToken token in obj)
+                {
+                    ExchangeTicker ticker = new ExchangeTicker
+                    {
+                        Ask = token["ask"].ConvertInvariant<decimal>(),
+                        Bid = token["bid"].ConvertInvariant<decimal>(),
+                        Volume = new ExchangeVolume()
+                    };
+                    // sometimes the size is null and sometimes it is returned using exponent notaion and sometimes not. 
+                    // We therefore parse as string and convert to decimal with float option
+                    if ((string)token["size"] != null) ticker.Volume.PriceAmount = decimal.Parse((string)token["size"], NumberStyles.Float);
+                    ticker.Volume.QuantityAmount = token.Value<decimal>("volume");
+                    if ((string)token["price"] != null) ticker.Last = decimal.Parse(token.Value<string>("price"), System.Globalization.NumberStyles.Float);
+
+                    tickers.Add(new KeyValuePair<string, ExchangeTicker>(token.Value<string>("product_id"), ticker));
+                }
+            }
+            return tickers;
+        }
+
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        {
+            ExchangeOrderBook orders = new ExchangeOrderBook();
+            JToken token = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/book?level=" + (maxCount > 50 ? "0" : "2"));
+            if (token.HasValues)
+            {
+                foreach (JArray array in token["bids"]) if (orders.Bids.Count < maxCount) orders.Bids.Add(new ExchangeOrderPrice() { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
+                foreach (JArray array in token["asks"]) if (orders.Asks.Count < maxCount) orders.Asks.Add(new ExchangeOrderPrice() { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
+            }
+            return orders;
+        }
+
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        {
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+
+            // { "time": "2017-09-21T12:33:03Z", "trade_id": "553794", "price": "14167.99328000", "size": "0.00035000", "side": "buy"}
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/trades");
+            if (obj.HasValues) foreach(JToken token in obj) trades.Add(parseExchangeTrade(token));
+            return trades;
+        }
+
+        protected override Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        {
+            if (sinceDateTime == null) return GetRecentTrades(symbol);
+
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            DateTime earliestTrade = DateTime.Now;
+            long? lastTradeID = null;
+            // Abucoins uses a page curser based on trade_id to iterate history. Keep paginating until startDate is reached
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/trades");
+            if (obj.HasValues)
+            {
+                foreach (JToken token in obj)
+                {
+                    ExchangeTrade trade = parseExchangeTrade(token);
+                    lastTradeID = trade.Id;
+                    if (trade.Timestamp > sinceDateTime)
+                    {
+                        earliestTrade = trade.Timestamp;
+                        trades.Add(trade);
+                    } else break;
+                }
+
+                while (earliestTrade > sinceDateTime && !(lastTradeID is null))
+                {
+                    obj = MakeJsonRequest<JToken>("/products/" + symbol + "/trades?before=" + lastTradeID);
+                    if (obj.HasValues)
+                    {
+                        foreach (JToken token in obj)
+                        {
+                            ExchangeTrade trade = parseExchangeTrade(token);
+                            lastTradeID = trade.Id;
+                            if (trade.Timestamp > sinceDateTime)
+                            {
+                                earliestTrade = trade.Timestamp;
+                                trades.Add(trade);
+                            }
+                            else break;
+                        }
+                    } else break;
+                }
+            }
+            return trades.OrderByDescending(t => t.Timestamp);
+        }
+
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        {
+            //if (limit != null) throw new APIException("Limit parameter not supported");  Really? You want to throw an exception instead of ignoring the parm?
+            List<MarketCandle> candles = new List<MarketCandle>();
+
+            endDate = endDate ?? DateTime.UtcNow;
+            startDate = startDate ?? endDate.Value.Subtract(TimeSpan.FromDays(1.0));
+
+            //[time, low, high, open, close, volume], ["1505984400","14209.92500000","14209.92500000","14209.92500000","14209.92500000","0.001"]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/candles?granularity=" + periodSeconds + "&start=" + ((DateTime)startDate).ToString("o") + "&end=" + ((DateTime)endDate).ToString("o"));
+            if (obj.HasValues)
+            {
+                foreach(JArray array in obj)
+                {
+                    candles.Add(new MarketCandle()
+                    {
+                        ExchangeName = this.Name,
+                        Name = symbol,
+                        Timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(array[0].ConvertInvariant<long>()),
+                        PeriodSeconds = periodSeconds,
+                        LowPrice = array[1].ConvertInvariant<decimal>(),
+                        HighPrice = array[2].ConvertInvariant<decimal>(),
+                        OpenPrice = array[3].ConvertInvariant<decimal>(),
+                        ClosePrice = array[4].ConvertInvariant<decimal>(),
+                        VolumeQuantity = array[5].ConvertInvariant<double>()
+                    });
+                }
+            }
+            return candles;
+        }
+
+
+        #endregion
+
+        #region Private APIs
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, GetNoncePayload(), "GET");
+            foreach (JToken token in array)
+            {
+                decimal amount = token["balance"].ConvertInvariant<decimal>();
+                if (amount > 0m) amounts[token["currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, GetNoncePayload(), "GET");
+            foreach (JToken token in array)
+            {
+                decimal amount = token["available"].ConvertInvariant<decimal>();
+                if (amount > 0m) amounts[token["currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
+        {
+            JToken token = await MakeJsonRequestAsync<JToken>("/orders?orderID", null, GetNoncePayload(), "GET");
+            ExchangeOrderResult eor = new ExchangeOrderResult()
+            {
+                OrderId = token["id"].ToStringInvariant(),
+                Amount = token["size"].ConvertInvariant<decimal>(),
+                AmountFilled = token["filled_size"].ConvertInvariant<decimal>(),
+                AveragePrice = token["price"].ConvertInvariant<decimal>(),
+                IsBuy = token["side"].ToStringInvariant().Equals("buy"),
+                Symbol = token["product_id"].ToStringInvariant(),
+            };
+
+            if (DateTime.TryParse(token["created_at"].ToStringInvariant(), out DateTime dt)) eor.OrderDate = dt;
+            if (token["status"].ToStringInvariant().Equals("open")) eor.Result = ExchangeAPIOrderResult.Pending;
+            else
+            {
+                if (eor.Amount == eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.Filled;
+                else if (eor.Amount < eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.FilledPartially;
+                else eor.Result = ExchangeAPIOrderResult.Unknown;
+            }
+            return eor;
+        }
+
+
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        {
+            List<ExchangeOrderResult> result = new List<ExchangeOrderResult>();
+            JArray array = await MakeJsonRequestAsync<JArray>("/orders?status=done", null, GetNoncePayload(), "GET");
+            foreach (var token in array)
+            {
+                ExchangeOrderResult eor = new ExchangeOrderResult()
+                {
+                    OrderId = token["id"].ToStringInvariant(),
+                    Amount = token["size"].ConvertInvariant<decimal>(),
+                    AmountFilled = token["filled_size"].ConvertInvariant<decimal>(),
+                    AveragePrice = token["price"].ConvertInvariant<decimal>(),
+                    IsBuy = token["side"].ConvertInvariant<decimal>().Equals("buy"),
+                    Symbol = token["product_id"].ToStringInvariant(),
+                };
+
+                if (DateTime.TryParse(token["created_at"].ToStringInvariant(), out DateTime dt)) eor.OrderDate = dt;
+                if (token["status"].ToStringInvariant().Equals("open")) eor.Result = ExchangeAPIOrderResult.Pending;
+                else
+                {
+                    if (eor.Amount == eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.Filled;
+                    else if (eor.Amount < eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.FilledPartially;
+                    else eor.Result = ExchangeAPIOrderResult.Unknown;
+                }
+                result.Add(eor);
+            }
+            return result;
+        }
+
+        
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        {
+            List<ExchangeOrderResult> result = new List<ExchangeOrderResult>();
+            JArray array = await MakeJsonRequestAsync<JArray>("/orders?status=open", null, GetNoncePayload(), "GET");
+            foreach (var token in array)
+            {
+                ExchangeOrderResult eor = new ExchangeOrderResult()
+                {
+                    OrderId = token["id"].ToStringInvariant(),
+                    Amount = token["size"].ConvertInvariant<decimal>(),
+                    AmountFilled = token["filled_size"].ConvertInvariant<decimal>(),
+                    AveragePrice = token["price"].ConvertInvariant<decimal>(),
+                    IsBuy = token["side"].ToStringInvariant().Equals("buy"),
+                    Symbol = token["product_id"].ToStringInvariant(),
+                };
+
+                DateTime dt;
+                if (DateTime.TryParse(token["created_at"].ToStringInvariant(), out dt)) eor.OrderDate = dt;
+                if (token["status"].ToStringInvariant().Equals("open")) eor.Result = ExchangeAPIOrderResult.Pending;
+                else
+                {
+                    if (eor.Amount == eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.Filled;
+                    else if (eor.Amount < eor.AmountFilled) eor.Result = ExchangeAPIOrderResult.FilledPartially;
+                    else eor.Result = ExchangeAPIOrderResult.Unknown;
+                }
+                result.Add(eor);
+            }
+            return result;
+        }
+
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+        {
+            ExchangeOrderResult result = new ExchangeOrderResult() { Result = ExchangeAPIOrderResult.Error };
+            var payload = GetNoncePayload();
+            payload["priduct_id"] = order.Symbol;
+            payload["side"] = order.IsBuy ? "buy" : "sell";
+            payload["size"] = order.Amount;
+            if (order.OrderType == OrderType.Limit) payload["price"] = order.Price;
+            else payload["type"] = "market";
+
+            // {"product_id":"ZEC-BTC","used":"17.3124", "size":"17.3124", "price":"0.035582569", "id":"4217215", "side":"buy", "type":"limit", "time_in_force":"GTT", "post_only":false, "created_at":"2017-11-15T12:41:58Z","filled_size":"17.3124", "fill_fees":"0", "executed_value":"0.61601967", "status":"done", "settled":true, "hidden":false }
+            // status (pending, open, done, rejected)
+            JToken token = await MakeJsonRequestAsync<JToken>("/orders", null, payload, "POST");
+            if (token != null && token.HasValues)
+            {
+                result.OrderId = token["id"].ToStringInvariant();
+                result.Amount = token["size"].ConvertInvariant<decimal>();
+                result.AmountFilled = token["filled_size"].ConvertInvariant<decimal>();
+                result.AveragePrice = token["price"].ConvertInvariant<decimal>();
+                result.Fees = token["fill_fees"].ConvertInvariant<decimal>();
+                result.IsBuy = token["buy"].ToStringInvariant().Equals("buy");
+                result.OrderDate = token["created_at".ConvertInvariant<DateTime>();
+                result.Price = token["price"].ConvertInvariant<decimal>();
+                result.Symbol = token["product_id"].ToStringInvariant();
+                result.Message = token["reject_reason"].ToStringInvariant();
+                switch(token["status"].ToStringInvariant())
+                {
+                    case "done": result.Result = ExchangeAPIOrderResult.Filled; break;
+                    case "pending":
+                    case "open": result.Result = ExchangeAPIOrderResult.Pending; break;
+                    case "rejected": result.Result = ExchangeAPIOrderResult.Error; break;
+                    default: result.Result = ExchangeAPIOrderResult.Unknown; break;
+                }
+                return result;
+            }
+            return result;
+        }
+
+        // This should have a return value for success
+        protected override async Task OnCancelOrderAsync(string orderId)
+        {
+            await MakeJsonRequestAsync<JArray>("/orders/" + orderId, null, GetNoncePayload(), "DELETE");
+        }
+
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        {
+            List<ExchangeTransaction> deposits = new List<ExchangeTransaction>();
+
+            var payload = GetNoncePayload();
+            payload["limit"] = 1000;
+
+            // History by symbol is not supported, so we'll get max and filter the results
+            // response fields = deposit_id currency date amount fee status (awaiting-email-confirmation pending complete) url
+            JArray token = await MakeJsonRequestAsync<JArray>("/deposits/history", null, payload, "GET");
+            if (token != null && token.HasValues)
+            {
+                ExchangeTransaction deposit = new ExchangeTransaction()
+                {
+                    Symbol = token["currency"].ToStringInvariant(),
+                    Amount = token["amount"].ConvertInvariant<decimal>(),
+                    TimestampUTC = token["date"].ConvertInvariant<DateTime>(),
+                    PaymentId = token["deposit_id"].ToStringInvariant(),
+                    TxFee = token["fee"].ConvertInvariant<decimal>()
+                };
+                switch(token["status"].ToStringInvariant())
+                {
+                    case "complete": deposit.Status = TransactionStatus.Complete; break;
+                    case "pending": deposit.Status = TransactionStatus.Processing; break;
+                    default: deposit.Status = TransactionStatus.AwaitingApproval; break;
+                }
+                if (deposit.Symbol == symbol) deposits.Add(deposit);
+            }
+            return deposits;
+        }
+
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        {
+            symbol = NormalizeSymbol(symbol);
+            var payload = GetNoncePayload();
+            JArray array = MakeJsonRequest<JArray>("/payment-methods", null, GetNoncePayload(), "GET");
+            if (array != null)
+            {
+                var rc = array.Where(t => t.Value<string>("currency") == symbol).FirstOrDefault();
+                payload = GetNoncePayload();
+                payload["currency"] = NormalizeSymbol(symbol);
+                payload["method"] = rc.Value<string>("id");
+
+                JToken token = await MakeJsonRequestAsync<JToken>("/deposits/make", null, payload, "POST");
+                ExchangeDepositDetails deposit = new ExchangeDepositDetails()
+                {
+                    Symbol = symbol,
+                    Address = token["address"].ToStringInvariant(),
+                    AddressTag = token["tag"].ToStringInvariant()
+                };
+                return deposit;
+            }
+            return null;
+        }
+
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        {
+            ExchangeWithdrawalResponse response = new ExchangeWithdrawalResponse { Success = false };
+            string symbol = NormalizeSymbol(withdrawalRequest.Symbol);
+            var payload = GetNoncePayload();
+            JArray array = await MakeJsonRequestAsync<JArray>("/payment-methods", null, GetNoncePayload(), "GET");
+            if (array != null)
+            {
+                var rc = array.Where(t => t.Value<string>("currency") == symbol).FirstOrDefault();
+
+                payload = GetNoncePayload();
+                payload["amount"] = withdrawalRequest.Amount;
+                payload["currency"] = symbol;
+                payload["method"] = rc.Value<string>("id");
+                if (!String.IsNullOrEmpty(withdrawalRequest.AddressTag)) payload["tag"] = withdrawalRequest.AddressTag;
+                // "status": 0,  "message": "Your transaction is pending. Please confirm it via email.",  "payoutId": "65",  "balance": []...
+                JToken token = MakeJsonRequest<JToken>("/withdrawals/make", null, payload, "POST");
+                response.Id = token["payoutId"].ToStringInvariant();
+                response.Message = token["message"].ToStringInvariant();
+                response.Success = token["status"].ConvertInvariant<int>().Equals(0);
+            }
+            return response;
+        }
+
+
+        #endregion
+
+        #region WebSocket APIs
+
+        /// <summary>
+        /// Abucoins Order Subscriptions require Order IDs to subscribe to, and will stop feeds when they are completed
+        /// So with each new order, a new subscription is required. 
+        /// </summary>
+        /// <param name="callback"></param>
+        /// <returns></returns>
+        public override IDisposable GetCompletedOrderDetailsWebSocket(Action<ExchangeOrderResult> callback)
+        {
+            if (callback == null) return null;
+
+            var orders = GetOpenOrderDetails().Select(o => o.OrderId).ToList();
+            string ids = JsonConvert.SerializeObject(JArray.FromObject(orders));
+
+            return ConnectWebSocket(string.Empty, (msg, _socket) =>
+            {
+                try
+                {
+                    //{"type":"done","time":"2018-02-20T14:59:45Z","product_id":"BTC-PLN","sequence":648771,"price":"39034.08000000","order_id":"277370262","reason":"canceled",  "side":"sell","remaining_size":0.503343}
+                    JToken token = JToken.Parse(msg);
+                    if ((string)token["type"] == "done")
+                    {
+                        callback.Invoke(new ExchangeOrderResult()
+                        {
+                             OrderId = token["order_id"].ToStringInvariant(),
+                             Symbol = token["product_id"].ToStringInvariant(),
+                             OrderDate = token["time"].ConvertInvariant<DateTime>(),
+                             Message = token["reason"].ToStringInvariant(),
+                             IsBuy = token["side"].ToStringInvariant().Equals("buy"),
+                             Price = token["price"].ConvertInvariant<decimal>()
+                        });
+                    }
+                }
+                catch (Exception ex) { Debug.WriteLine(ex.Message); }
+            }, (_socket) =>
+            {
+                // subscribe to done channel
+                _socket.SendMessage("{\"type\":\"subscribe\",\"channels\":[{ \"name\":\"done\",\"product_ids\":" + ids + "}]}");
+            });
+        }
+
+        public override IDisposable GetTickersWebSocket(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers)
+        {
+            if (tickers == null) return null;
+
+            var symbols = GetTickers().Select(t => t.Key).ToList();
+            string ids = JsonConvert.SerializeObject(JArray.FromObject(symbols));
+
+            return ConnectWebSocket(string.Empty, (msg, _socket) =>
+            {
+                try
+                {
+                    //{"type": "ticker","trade_id": 20153558,"sequence": 3262786978,"time": "2017-09-02T17:05:49.250000Z","product_id": "BTC-USD","price": "4388.01000000","last_size": "0.03000000","best_bid": "4388","best_ask": "4388.01"}
+                    JToken token = JToken.Parse(msg);
+                    if ((string)token["type"] == "ticker")
+                    {
+                        tickers.Invoke(new List<KeyValuePair<string, ExchangeTicker>>
+                        {
+                            new KeyValuePair<string, ExchangeTicker>(token.Value<string>("product_id"), new ExchangeTicker()
+                            {
+                                Id = token["trade_id"].ConvertInvariant<long>().ToString(),
+                                Last = token["price"].ConvertInvariant<decimal>(),
+                                Ask = token["best_ask"].ConvertInvariant<decimal>(),
+                                Bid = token["best_bid"].ConvertInvariant<decimal>(),
+                                Volume = new ExchangeVolume()
+                                {
+                                    QuantitySymbol = token["product_id"].ToStringInvariant(),
+                                    QuantityAmount = token["last_size"].ConvertInvariant<decimal>(),
+                                    Timestamp = token["time"].ConvertInvariant<DateTime>()
+                                }
+                            })
+                        });
+                    }
+                } catch( Exception ex) { Debug.WriteLine(ex.Message); }
+            }, (_socket) =>
+            {
+                // subscribe to ticker channel
+                _socket.SendMessage("{\"type\": \"subscribe\", \"channels\": [{ \"name\": \"ticker\", \"product_ids\": " + ids + " }] }");
+            });
+        }
+
+        #endregion
+
+        #region Private Functions
+
+        private ExchangeTrade parseExchangeTrade(JToken token)
+        {
+            return new ExchangeTrade()
+            {
+                Id = token["trade_id"].ConvertInvariant<long>(),
+                Timestamp = token["time"].ConvertInvariant<DateTime>(),
+                Amount = token["size"].ConvertInvariant<decimal>(),
+                Price = token["price"].ConvertInvariant<decimal>(),
+                IsBuy = token["buy"].ToStringLowerInvariant().Equals("buy")
+            };
+        }
+
+        #endregion
+
+    }
+}

--- a/ExchangeSharp/API/Exchanges/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBleutradeAPI.cs
@@ -1,0 +1,424 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace ExchangeSharp
+{ 
+
+    public class ExchangeBleutradeAPI : ExchangeAPI
+    {
+        public override string Name => ExchangeName.BleuTrade;
+        public override string BaseUrl { get; set; } = "https://bleutrade.com/api/v2";
+
+        public ExchangeBleutradeAPI()
+        {
+            NonceStyle = NonceStyle.UnixMillisecondsString;
+        }
+
+        #region ProcessRequest 
+
+        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        {
+            if (CanMakeAuthenticatedRequest(payload))
+            {
+                request.Headers["apisign"] = CryptoUtility.SHA512Sign(request.RequestUri.ToString(), PrivateApiKey.ToUnsecureString()).ToLower();
+            }
+        }
+
+        protected override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
+        {
+            if (CanMakeAuthenticatedRequest(payload))
+            {
+                // payload is ignored, except for the nonce which is added to the url query
+                var query = HttpUtility.ParseQueryString(url.Query);
+                url.Query = "apikey=" + PublicApiKey.ToUnsecureString() + "&nonce=" + payload["nonce"].ToString() + (query.Count == 0 ? string.Empty : "&" + query.ToString());
+            }
+            return url.Uri;
+        }
+
+        #endregion
+
+        #region Public APIs
+
+        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
+        {
+            var currencies = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
+            //{ "success" : true,"message" : "", "result" : [{"Currency" : "BTC","CurrencyLong" : "Bitcoin","MinConfirmation" : 2,"TxFee" : 0.00080000,"IsActive" : true, "CoinType" : "BITCOIN","MaintenanceMode" : false}, ... 
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getcurrencies", null, null);
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                var coin = new ExchangeCurrency
+                {
+                    CoinType = token["CoinType"].ToStringInvariant(),
+                    FullName = token["CurrencyLong"].ToStringInvariant(),
+                    IsEnabled = token["MaintenanceMode"].ConvertInvariant<bool>().Equals(false),
+                    MinConfirmations = token["MinConfirmation"].ConvertInvariant<int>(),
+                    Name = token["Currency"].ToStringUpperInvariant(),
+                    Notes = token["Notice"].ToStringInvariant(),
+                   TxFee = token["TxFee"].ConvertInvariant<decimal>(),
+                };
+                currencies[coin.Name] = coin;
+            }
+            return currencies;
+        }
+
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        {
+            List<string> symbols = new List<string>();
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkets", null, null);
+            result = CheckError(result);
+            foreach (var market in result) symbols.Add(market["MarketName"].ToStringInvariant());
+            return symbols;
+        }
+
+
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        {
+            List<ExchangeMarket> markets = new List<ExchangeMarket>();
+            // "result" : [{"MarketCurrency" : "DOGE","BaseCurrency" : "BTC","MarketCurrencyLong" : "Dogecoin","BaseCurrencyLong" : "Bitcoin", "MinTradeSize" : 0.10000000, "MarketName" : "DOGE_BTC", "IsActive" : true, }, ...
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkets", null, null);
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                markets.Add(new ExchangeMarket()
+                {
+                     MarketName = token["MarketName"].ToStringInvariant(),
+                     BaseCurrency = token["BaseCurrency"].ToStringInvariant(),
+                     MarketCurrency = token["MarketCurrency"].ToStringInvariant(),
+                     IsActive = token["IsActive"].ToStringInvariant().Equals("true"),
+                     MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
+                });
+            }
+            return markets;
+        }
+
+
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        {
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getticker?market=" + symbol);
+            result = CheckError(result);
+            if (result[0] != null)
+            {
+                return new ExchangeTicker
+                {
+                    Ask = result["Ask"].ConvertInvariant<decimal>(),
+                    Bid = result["Bid"].ConvertInvariant<decimal>(),
+                    Last = result["Last"].ConvertInvariant<decimal>()
+                };
+            }
+            return null;
+        }
+
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+        {
+            List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+            // "result" : [{"MarketCurrency" : "Ethereum","BaseCurrency" : "Bitcoin","MarketName" : "ETH_BTC","PrevDay" : 0.00095000,"High" : 0.00105000,"Low" : 0.00086000, "Last" : 0.00101977, "Average" : 0.00103455, "Volume" : 2450.97496015, "BaseVolume" : 2.40781647,    "TimeStamp" : "2014-07-29 11:19:30", "Bid" : 0.00100000, "Ask" : 0.00101977, "IsActive" : true }, ... ]
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getmarketsummaries");
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                var ticker = new ExchangeTicker
+                {
+                    Ask = token["Ask"].ConvertInvariant<decimal>(),
+                    Bid = token["Bid"].ConvertInvariant<decimal>(),
+                    Last = token["Last"].ConvertInvariant<decimal>(),
+                    Volume = new ExchangeVolume()
+                    {
+                        Timestamp = token["TimeStamp"].ConvertInvariant<DateTime>(),
+                        PriceSymbol = token["BaseCurrency"].ToStringInvariant(),
+                        PriceAmount = token["BaseVolume"].ConvertInvariant<decimal>(),
+                        QuantitySymbol = token["MarketCurrency"].ToStringInvariant(),
+                        QuantityAmount = token["Volume"].ConvertInvariant<decimal>()
+                    }
+                };
+                tickers.Add(new  KeyValuePair<string, ExchangeTicker>(token["MarketName"].ToStringInvariant(), ticker));
+            }
+            return tickers;
+        }
+
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        {
+            List<MarketCandle> candles = new List<MarketCandle>();
+            string periodString;
+            if (periodSeconds <= 900) { periodString = "15m"; periodSeconds = 900; }
+            else if (periodSeconds <= 1200) { periodString = "20m"; periodSeconds = 1200; }
+            else if (periodSeconds <= 1800) { periodString = "30m"; periodSeconds = 1800; }
+            else if (periodSeconds <= 3600) { periodString = "1h"; periodSeconds = 3600; }
+            else if (periodSeconds <= 7200) { periodString = "2h"; periodSeconds = 7200; }
+            else if (periodSeconds <= 10800) { periodString = "3h"; periodSeconds = 10800; }
+            else if (periodSeconds <= 14400) { periodString = "4h"; periodSeconds = 14400; }
+            else if (periodSeconds <= 21600) { periodString = "6h"; periodSeconds = 21600; }
+            else if (periodSeconds <= 43200) { periodString = "12h"; periodSeconds = 43200; }
+            else { periodString = "1d"; periodSeconds = 86400; }
+
+            limit = limit ?? (limit > 2160 ? 2160 : limit);
+            symbol = NormalizeSymbol(symbol);
+            endDate = endDate ?? DateTime.UtcNow;
+            startDate = startDate ?? endDate.Value.Subtract(TimeSpan.FromDays(1.0));
+
+            //market period(15m, 20m, 30m, 1h, 2h, 3h, 4h, 6h, 8h, 12h, 1d) count(default: 1000, max: 999999) lasthours(default: 24, max: 2160) 
+            //"result":[{"TimeStamp":"2014-07-31 10:15:00","Open":"0.00000048","High":"0.00000050","Low":"0.00000048","Close":"0.00000049","Volume":"594804.73036048","BaseVolume":"0.11510368" }, ...
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getcandles?market=" + symbol + "&period=" + periodString + (limit == null ? string.Empty : "&lasthours=" + limit));
+            result = CheckError(result);
+                foreach (JToken jsonCandle in result)
+                {
+                    MarketCandle candle = new MarketCandle
+                    {
+                        ExchangeName = this.Name,
+                        Name = symbol,
+                        Timestamp = jsonCandle["TimeStamp"].ConvertInvariant<DateTime>(),
+                        OpenPrice = jsonCandle["Open"].ConvertInvariant<decimal>(),
+                        HighPrice = jsonCandle["High"].ConvertInvariant<decimal>(),
+                        LowPrice = jsonCandle["Low"].ConvertInvariant<decimal>(),
+                        ClosePrice = jsonCandle["Close"].ConvertInvariant<decimal>(),
+                        PeriodSeconds = periodSeconds,
+                        VolumePrice = jsonCandle["BaseVolume"].ConvertInvariant<double>(),
+                        VolumeQuantity = jsonCandle["Volume"].ConvertInvariant<double>()
+                    };
+                    if (candle.Timestamp >= startDate && candle.Timestamp <= endDate) candles.Add(candle);
+                }
+            return candles;
+        }
+
+
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        {
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            //"result" : [{ "TimeStamp" : "2014-07-29 18:08:00","Quantity" : 654971.69417461,"Price" : 0.00000055,"Total" : 0.360234432,"OrderType" : "BUY"}, ...  ]
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getmarkethistory?market=" + symbol);
+            result = CheckError(result);
+            foreach(JToken token in result) trades.Add(ParseTrade(token));
+            return trades;
+        }
+
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        {
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            // Not directly supported so the best we can do is get their Max 200 and check the timestamp if necessary
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getmarkethistory?market=" + symbol + "&count=200");
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                ExchangeTrade trade = ParseTrade(token);
+                if (sinceDateTime != null && trade.Timestamp > sinceDateTime) trades.Add(trade);
+                else trades.Add(trade);
+            }
+            if (callback != null) callback(trades);
+        }
+
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        {
+            ExchangeOrderBook orders = new ExchangeOrderBook();
+            //"result" : { "buy" : [{"Quantity" : 4.99400000,"Rate" : 3.00650900}, {"Quantity" : 50.00000000, "Rate" : 3.50000000 }  ] ...
+            JToken result = await MakeJsonRequestAsync<JObject>("/public/getorderbook?market=" + symbol + "&type=ALL&depth=" + maxCount);
+            result = CheckError(result);
+            foreach (JToken token in result["buy"]) if (orders.Bids.Count < maxCount) orders.Bids.Add(new ExchangeOrderPrice() { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() });
+            foreach (JToken token in result["sell"]) if (orders.Asks.Count < maxCount) orders.Asks.Add(new ExchangeOrderPrice() { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() });
+            return orders;
+        }
+
+        #endregion
+
+        # region Private APIs
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            // "result" : [{"Currency" : "DOGE","Balance" : 0.00000000,"Available" : 0.00000000,"Pending" : 0.00000000,"CryptoAddress" : "DBSwFELQiVrwxFtyHpVHbgVrNJXwb3hoXL", "IsActive" : true}, ... 
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getbalances", null, GetNoncePayload());
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                decimal amount = result["Balance"].ConvertInvariant<decimal>();
+                if (amount > 0) amounts[token["Currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            // "result" : [{"Currency" : "DOGE","Balance" : 0.00000000,"Available" : 0.00000000,"Pending" : 0.00000000,"CryptoAddress" : "DBSwFELQiVrwxFtyHpVHbgVrNJXwb3hoXL", "IsActive" : true}, ... 
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getbalances", null, GetNoncePayload());
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                decimal amount = result["Available"].ConvertInvariant<decimal>();
+                if (amount > 0) amounts[token["Currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
+        {
+            // "result" : { "OrderId" : "65489","Exchange" : "LTC_BTC", "Type" : "BUY", "Quantity" : 20.00000000, "QuantityRemaining" : 5.00000000, "QuantityBaseTraded" : "0.16549400", "Price" : 0.01268311, "Status" : "OPEN", "Created" : "2014-08-03 13:55:20", "Comments" : "My optional comment, eg function id #123"  }
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getorder?orderid=" + orderId , null, GetNoncePayload());
+            result = CheckError(result);
+            return ParseOrder(result);
+        }
+
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getorders?market=" + (string.IsNullOrEmpty(symbol) ? "ALL" : symbol) + "&orderstatus=OK&ordertype=ALL", null, GetNoncePayload());
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                ExchangeOrderResult order = ParseOrder(token);
+                if (afterDate != null) { if (order.OrderDate > afterDate) orders.Add(order); }
+                else orders.Add(order);
+            }
+            return orders;
+        }
+
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+            JToken result = await MakeJsonRequestAsync<JToken>("/market/getopenorders", null, GetNoncePayload());
+            result = CheckError(result);
+            foreach (JToken token in result) orders.Add(ParseOrder(token));
+            return orders;
+        }
+
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+        {
+            ExchangeOrderResult result = new ExchangeOrderResult() { Result = ExchangeAPIOrderResult.Error };
+            // Only limit order is supported - no indication on how it is filled
+            JToken token = await MakeJsonRequestAsync<JToken>((order.IsBuy ? "/market/buylimit?" : "market/selllimit?") + "market=" + order.Symbol + "&rate=" + order.Price + "&quantity=" + order.Amount, null, GetNoncePayload());
+            token = CheckError(token);
+            if (token.HasValues)
+            {
+                // Only the orderid is returned on success
+                result.OrderId = token["orderid"].ToStringInvariant();
+                result.Result = ExchangeAPIOrderResult.Filled;
+            }
+            return result;
+        }
+
+        protected override async Task OnCancelOrderAsync(string orderId)
+        {
+            JToken result = await MakeJsonRequestAsync<JToken>("/market/cancel?orderid=" + orderId, null, GetNoncePayload());
+            CheckError(result);
+        }
+
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        {
+            JToken token = await MakeJsonRequestAsync<JToken>("/account/getdepositaddress?" + "currency=" + NormalizeSymbol(symbol), BaseUrl, GetNoncePayload(), "GET");
+            token = CheckError(token);
+            if (token["Currency"].ToStringInvariant().Equals(symbol) && token["Address"] != null)
+            {
+                // At this time, according to Bleutrade support, they don't support any currency requiring an Address Tag, but they will add this feature in the future
+                return new ExchangeDepositDetails()
+                {
+                     Symbol = token["Currency"].ToStringInvariant(),
+                     Address = token["Address"].ToStringInvariant()
+                 };
+            }
+            return null;
+        }
+
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        {
+            List<ExchangeTransaction> transactions = new List<ExchangeTransaction>();
+
+            // "result" : [{"Id" : "44933431","TimeStamp" : "2015-05-13 07:15:23","Coin" : "LTC","Amount" : -0.10000000,"Label" : "Withdraw: 0.99000000 to address Anotheraddress; fee 0.01000000","TransactionId" : "c396228895f8976e3810286c1537bddd4a45bb37d214c0e2b29496a4dee9a09b" }
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getdeposithistory", BaseUrl, GetNoncePayload(), "GET");
+            result = CheckError(result);
+            foreach (JToken token in result)
+            {
+                transactions.Add(new ExchangeTransaction()
+                {
+                     PaymentId = token["Id"].ToStringInvariant(),
+                     BlockchainTxId = token["TransactionId"].ToStringInvariant(),
+                     TimestampUTC = token["TimeStamp"].ConvertInvariant<DateTime>(),
+                     Symbol = token["Coin"].ToStringInvariant(),
+                     Amount = token["Amount"].ConvertInvariant<decimal>(),
+                     Notes = token["Label"].ToStringInvariant(),
+                     TxFee = token["fee"].ConvertInvariant<decimal>(),
+                     Status = TransactionStatus.Unknown
+                });
+            }
+            return transactions;
+        }
+
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        {
+            var payload = GetNoncePayload();
+            payload["currency"] = NormalizeSymbol(withdrawalRequest.Symbol);
+            payload["quantity"] = withdrawalRequest.Amount;
+            payload["address"] = withdrawalRequest.Address;
+            if (!string.IsNullOrEmpty(withdrawalRequest.AddressTag)) payload["comments"] = withdrawalRequest.AddressTag;
+            
+            JToken token = await MakeJsonRequestAsync<JToken>("/account/withdraw", BaseUrl, payload, "GET");
+            CheckError(token);
+            // Bleutrade doesn't return any info, just an empty string on success. The CheckError will throw an exception if there's an error
+            return new ExchangeWithdrawalResponse() { Success = true };
+        }
+
+
+        #endregion
+
+        #region Private Functions
+
+        private JToken CheckError(JToken result)
+        {
+            if (result == null || (result["success"] != null && result["success"].Value<bool>() != true))
+            {
+                throw new APIException((result["message"] != null ? result["message"].Value<string>() : "Unknown Error"));
+            }
+            return result["result"];
+        }
+
+        private ExchangeTrade ParseTrade(JToken token)
+        {
+            return new ExchangeTrade()
+            {
+                Timestamp = token["TimeStamp"].ConvertInvariant<DateTime>(),
+                IsBuy = token["OrderType"].ToStringInvariant().Equals("BUY"),
+                Price = token["Price"].ConvertInvariant<decimal>(),
+                Amount = token["Quantity"].ConvertInvariant<decimal>()
+            };
+        }
+
+
+        private ExchangeOrderResult ParseOrder(JToken token)
+        {
+            var order = new ExchangeOrderResult()
+            {
+                OrderId = token["OrderId"].ToStringInvariant(),
+                IsBuy = token["Type"].ToStringInvariant().Equals("BUY"),
+                Symbol = token["Exchange"].ToStringInvariant(),
+                Amount = token["Quantity"].ConvertInvariant<decimal>(),
+                OrderDate = token["Created"].ConvertInvariant<DateTime>(),
+                AveragePrice = token["Price"].ConvertInvariant<decimal>(),
+                AmountFilled = token["QuantityBaseTraded"].ConvertInvariant<decimal>(),
+                Message = token["Comments"].ToStringInvariant(),
+            };
+
+            switch (token["status"].ToStringInvariant())
+            {
+                case "OPEN":
+                    order.Result = ExchangeAPIOrderResult.Pending;
+                    break;
+                case "OK":
+                    if (order.Amount == order.AmountFilled) order.Result = ExchangeAPIOrderResult.Filled;
+                    else order.Result = ExchangeAPIOrderResult.FilledPartially;
+                    break;
+                case "CANCELED":
+                    order.Result = ExchangeAPIOrderResult.Canceled;
+                    break;
+                default:
+                    order.Result = ExchangeAPIOrderResult.Unknown;
+                    break;
+            }
+            return order;
+        }
+
+        #endregion
+
+    }
+}

--- a/ExchangeSharp/API/Exchanges/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeHitbtcAPI.cs
@@ -1,0 +1,502 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Web;
+using ExchangeSharp;
+using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp
+{
+    class neuHitbtcAPI : ExchangeAPI
+    {
+        public override string Name => ExchangeName.HitBTC;
+        public override string BaseUrl { get; set; } = "https://api.hitbtc.com/api/2";
+        public override string BaseUrlWebSocket { get; set; } = "wss://api.hitbtc.com/api/2/ws";
+
+        public neuHitbtcAPI()
+        {
+            RequestContentType = "x-www-form-urlencoded";
+            NonceStyle = ExchangeSharp.NonceStyle.UnixMillisecondsString;
+        }
+
+        #region ProcessRequest 
+
+        protected override void ProcessRequest(HttpWebRequest request, Dictionary<string, object> payload)
+        {
+            if (CanMakeAuthenticatedRequest(payload))
+            {
+                using (var hmacsha512 = new HMACSHA512(Encoding.UTF8.GetBytes(PrivateApiKey.ToUnsecureString())))
+                {
+                    hmacsha512.ComputeHash(Encoding.UTF8.GetBytes(request.RequestUri.PathAndQuery));
+                    request.Headers["X-Signature"] = string.Concat(hmacsha512.Hash.Select(b => b.ToString("x2")).ToArray()); // minimalistic hex-encoding and lower case
+                }
+            }
+        }
+
+        protected override Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object> payload)
+        {
+            if (CanMakeAuthenticatedRequest(payload))
+            {
+                // payload is ignored, except for the nonce which is added to the url query - HitBTC puts all the "post" parameters in the url query instead of the request body
+                var query = HttpUtility.ParseQueryString(url.Query);
+                string newQuery = "nonce=" + payload["nonce"].ToString() + "&apikey=" + PublicApiKey.ToUnsecureString() + (query.Count == 0 ? string.Empty : "&" + query.ToString()) +
+                    (payload.Count > 1 ? "&" + GetFormForPayload(payload, false) : string.Empty);
+                url.Query = newQuery;
+                return url.Uri;
+            }
+            return base.ProcessRequestUrl(url, payload);
+        }
+
+        #endregion
+
+        #region Public APIs
+
+        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
+        {
+            Dictionary<string, ExchangeCurrency> currencies = new Dictionary<string, ExchangeCurrency>();
+            //[{"id": "BTC", "fullName": "Bitcoin", "crypto": true, "payinEnabled": true, "payinPaymentId": false, "payinConfirmations": 2, "payoutEnabled": true, "payoutIsPaymentId": false, "transferEnabled": true, "delisted": false, "payoutFee": "0.00958" }, ...
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/currency");
+            foreach(JToken token in obj)
+            {
+                currencies.Add(token["id"].ToStringInvariant(), new ExchangeCurrency()
+                {
+                    Name = token["id"].ToStringInvariant(),
+                    FullName = token["fullName"].ToStringInvariant(),
+                    TxFee = token["payoutFee"].ConvertInvariant<decimal>(),
+                    MinConfirmations = token["payinConfirmations"].ConvertInvariant<int>(),
+                    IsEnabled = token["delisted"].ToStringInvariant().Equals("false")
+                });
+            }
+            return currencies;
+        }
+
+        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        {
+            List<string> symbols = new List<string>();
+            // [ {"id": "ETHBTC","baseCurrency": "ETH","quoteCurrency": "BTC", "quantityIncrement": "0.001", "tickSize": "0.000001", "takeLiquidityRate": "0.001", "provideLiquidityRate": "-0.0001", "feeCurrency": "BTC"  } ... ]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/symbol");
+            foreach(JToken token in obj) symbols.Add(token["id"].ToStringInvariant());
+            return symbols;
+        }
+
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        {
+            List<ExchangeMarket> markets = new List<ExchangeMarket>();
+            // [ {"id": "ETHBTC","baseCurrency": "ETH","quoteCurrency": "BTC", "quantityIncrement": "0.001", "tickSize": "0.000001", "takeLiquidityRate": "0.001", "provideLiquidityRate": "-0.0001", "feeCurrency": "BTC"  } ... ]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/symbol");
+            foreach (JToken token in obj)
+            {
+                markets.Add(new ExchangeMarket()
+                {
+                     MarketName = token["id"].ToStringInvariant(),
+                     BaseCurrency = token["baseCurrency"].ToStringInvariant(),
+                     MarketCurrency = token["quoteCurrency"].ToStringInvariant(),
+                     QuantityStepSize = token["quantityIncrement"].ConvertInvariant<decimal>(),
+                     PriceStepSize = token["tickSize"].ConvertInvariant<decimal>(),
+                     IsActive = true
+                });
+            }
+            return markets;
+        }
+
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        {
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/ticker/" + symbol);
+            return ParseTicker(obj);
+        }
+
+        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+        {
+            List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/ticker");
+            foreach (JToken token in obj) tickers.Add(new KeyValuePair<string, ExchangeTicker>(token["symbol"].ToStringInvariant(), ParseTicker(token)));
+            return tickers;
+        }
+
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        {
+            List<MarketCandle> candles = new List<MarketCandle>();
+
+            string periodString;
+            if (periodSeconds <= 60) { periodString = "M1"; periodSeconds = 60; }
+            else if (periodSeconds <= 180) { periodString = "M3"; periodSeconds = 180; }
+            else if (periodSeconds <= 300) { periodString = "M5"; periodSeconds = 300; }
+            else if (periodSeconds <= 900) { periodString = "M15"; periodSeconds = 900; }
+            else if (periodSeconds <= 1800) { periodString = "M30"; periodSeconds = 1800; }
+            else if (periodSeconds <= 3600) { periodString = "H1"; periodSeconds = 3600; }
+            else if (periodSeconds <= 14400) { periodString = "H4"; periodSeconds = 14400; }
+            else if (periodSeconds <= 86400) { periodString = "D1"; periodSeconds = 86400; }
+            else if (periodSeconds <= 604800) { periodString = "D7"; periodSeconds = 604800; }
+            else { periodString = "1M"; periodSeconds = 4233600; }
+
+            limit = limit ?? 100;
+
+            // [ {"timestamp": "2017-10-20T20:00:00.000Z","open": "0.050459","close": "0.050087","min": "0.050000","max": "0.050511","volume": "1326.628", "volumeQuote": "66.555987736"}, ... ]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/candles/" + symbol + "?period=" + periodString + "&limit=" + limit);
+            foreach(JToken token in obj)
+            {
+                candles.Add(new MarketCandle()
+                {
+                    ExchangeName = this.Name,
+                    Name = symbol,
+                    Timestamp = token["timestamp"].ConvertInvariant<DateTime>(),
+                    OpenPrice = token["open"].ConvertInvariant<decimal>(),
+                    ClosePrice = token["close"].ConvertInvariant<decimal>(),
+                    LowPrice = token["min"].ConvertInvariant<decimal>(),
+                    HighPrice = token["max"].ConvertInvariant<decimal>(),
+                    VolumeQuantity = token["volume"].ConvertInvariant<double>(),
+                    VolumePrice = token["volumeQuote"].ConvertInvariant<double>(),
+                    PeriodSeconds = periodSeconds
+                });
+            }
+            return candles;
+        }
+
+
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        {
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            // Putting an arbitrary limit of 10 for 'recent'
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + symbol + "?limit=10");
+            foreach (JToken token in obj) trades.Add(ParseExchangeTrade(token));
+            return trades;
+        }
+
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        {
+            ExchangeOrderBook orders = new ExchangeOrderBook();
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/orderbook/" + symbol + "?limit=" + maxCount.ToString());
+            if (obj != null && obj.HasValues)
+            {
+                foreach (JToken order in obj["ask"]) if (orders.Asks.Count < maxCount) orders.Asks.Add(new ExchangeOrderPrice() { Price = order["price"].ConvertInvariant<decimal>(), Amount = order["size"].ConvertInvariant<decimal>() });
+                foreach (JToken order in obj["bid"]) if (orders.Bids.Count < maxCount) orders.Bids.Add(new ExchangeOrderPrice() { Price = order["price"].ConvertInvariant<decimal>(), Amount = order["size"].ConvertInvariant<decimal>() });
+            }
+            return orders;
+        }
+
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? sinceDateTime = null)
+        {
+            List<ExchangeTrade> trades = new List<ExchangeTrade>();
+            long? lastTradeID = null;
+            // Can't get Hitbtc to return other than the last 50 trades even though their API says it should (by orderid or timestamp). When passing either of these parms, it still returns the last 50
+            // So until there is an update, that's what we'll go with
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + symbol);
+            if (obj.HasValues)
+            {
+                foreach (JToken token in obj)
+                {
+                    ExchangeTrade trade = ParseExchangeTrade(token);
+                    lastTradeID = trade.Id;
+                    if (sinceDateTime != null)
+                    {
+                        if (trade.Timestamp > sinceDateTime) trades.Add(trade);
+                        else
+                        {
+                            if (callback != null && trades.Count > 0) callback(trades.OrderBy(t => t.Timestamp));
+                            return;
+                        }
+                    }
+                    else trades.Add(trade);
+                }
+                if (callback != null && trades.Count > 0) callback(trades);
+            }
+        }
+
+        #endregion
+
+        # region Private APIs
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            // [ {"currency": "BTC","available": "0.0504600","reserved": "0.0000000"}, ... ]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/trading/balance", null, GetNoncePayload(), "GET");
+            foreach (JToken token in obj["balance"])
+            {
+                decimal amount = token["available"].ConvertInvariant<decimal>() + token["reserved"].ConvertInvariant<decimal>();
+                if (amount > 0m) amounts[token["currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            // [ {"currency": "BTC","available": "0.0504600","reserved": "0.0000000"}, ... ]
+            JToken obj = await MakeJsonRequestAsync<JToken>("/trading/balance", null, GetNoncePayload(), "GET");
+            foreach (JToken token in obj["balance"])
+            {
+                decimal amount = token["available"].ConvertInvariant<decimal>();
+                if (amount > 0m) amounts[token["currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+        /// <summary>
+        /// HitBtc differentiates between active orders and historical trades. They also have three diffrent OrderIds (the id, the orderId, and the ClientOrderId).
+        /// When placing an order, we return the ClientOrderId, which is only in force for the duration of the order. Completed orders are given a different id.
+        /// Therefore, this call returns an open order only. Do not use it to return an historical trade order.
+        /// To retrieve an historical trade order by id, use the GetCompletedOrderDetails with the symbol parameter empty, then filter for desired Id.
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <returns></returns>
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId)
+        {
+            JToken obj = await MakeJsonRequestAsync<JToken>("/history/order/" + orderId + "/trades", null, GetNoncePayload(), "GET");
+            if (obj != null && obj.HasValues) return ParseCompletedOrder(obj);
+            return null;
+        }
+
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+            var payload = GetNoncePayload();
+            if (!string.IsNullOrEmpty(symbol)) payload["symbol"] = symbol;
+            if (afterDate != null) payload["from"] = afterDate;
+            JToken obj = await MakeJsonRequestAsync<JToken>("/history/trades", null, payload, "GET");
+            if (obj != null && obj.HasValues) foreach (JToken token in obj) orders.Add(ParseCompletedOrder(token));
+            return orders;
+        }
+
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        {
+            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+            var payload = GetNoncePayload();
+            if (!string.IsNullOrEmpty(symbol)) payload["symbol"] = symbol;
+            JToken obj = await MakeJsonRequestAsync<JToken>("/history/order", null, payload, "GET");
+            if (obj != null && obj.HasValues) foreach (JToken token in obj) orders.Add(ParseOpenOrder(token));
+            return orders;
+        }
+
+        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+        {
+            ExchangeOrderResult result = new ExchangeOrderResult() { Result = ExchangeAPIOrderResult.Error };
+            var payload = GetNoncePayload();
+            //payload["clientOrderId"] = "neuMedia" + payload["nonce"];     Currently letting hitbtc assign this, but may not be unique for more than 24 hours
+            payload["amount"] = order.Amount;
+            payload["symbol"] = order.Symbol;
+            payload["side"] = order.IsBuy ? "buy" : "sell";
+            payload["type"] = order.OrderType == OrderType.Limit ? "limit" : "market";
+            if (order.OrderType == OrderType.Limit) payload["price"] = order.Price;
+            payload["timeInForce"] = "GTC";
+            // { "id": 0,"clientOrderId": "d8574207d9e3b16a4a5511753eeef175","symbol": "ETHBTC","side": "sell","status": "new","type": "limit","timeInForce": "GTC","quantity": "0.063","price": "0.046016","cumQuantity": "0.000","createdAt": "2017-05-15T17:01:05.092Z","updatedAt": "2017-05-15T17:01:05.092Z"  } 
+            JToken token = await MakeJsonRequestAsync<JToken>("/trading/new_order", null, payload, "POST");
+            if (token != null)
+            {
+                if (token["error"] == null)
+                {
+                    result.OrderId = token["ClientOrderId"].ToStringInvariant();
+                    result.Symbol = token["symbol"].ToStringInvariant();
+                    result.OrderDate = token["createdAt"].ConvertInvariant<DateTime>();
+                    result.Amount = token["quantity"].ConvertInvariant<decimal>();
+                    result.Price = token["price"].ConvertInvariant<decimal>();
+                    result.AmountFilled = token["cumQuantity"].ConvertInvariant<decimal>();
+                    if (result.AmountFilled >= result.Amount) result.Result = ExchangeAPIOrderResult.Filled;
+                    else if (result.AmountFilled > 0m) result.Result = ExchangeAPIOrderResult.FilledPartially;
+                    else result.Result = ExchangeAPIOrderResult.Pending;
+                }
+                else result.Message = token["error"]["message"].ToStringInvariant();
+            }
+            return result;
+        }
+
+        protected override async Task OnCancelOrderAsync(string orderId)
+        {
+            // this call returns info about the success of the cancel. Sure would be nice have a return type on this method.
+            JToken token = await MakeJsonRequestAsync<JToken>("/order/" + orderId, null, GetNoncePayload(), "DELETE");
+        }
+
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        {
+            ExchangeDepositDetails deposit = new ExchangeDepositDetails() { Symbol = symbol };
+            JToken token = await MakeJsonRequestAsync<JToken>("/payment/address/" + symbol, null, GetNoncePayload(), "GET");
+            if (token != null)
+            {
+                deposit.Address =token["address"].ToStringInvariant();
+                if (deposit.Address.StartsWith("bitcoincash:")) deposit.Address = deposit.Address.Replace("bitcoincash:", string.Empty);  // don't know why they do this for bitcoincash
+                deposit.AddressTag = token["wallet"].ToStringInvariant();
+            }
+            return deposit;
+        }
+
+
+        /// <summary>
+        /// This returns both Deposit and Withdawl history for the Bank and Trading Accounts. Currently returning everything and not filtering. 
+        /// There is no support for retrieving by Symbol, so we'll filter that after reteiving all symbols
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <returns></returns>
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        {
+            List<ExchangeTransaction> transactions = new List<ExchangeTransaction>();
+            // [ {"id": "6a2fb54d-7466-490c-b3a6-95d8c882f7f7","index": 20400458,"currency": "ETH","amount": "38.616700000000000000000000","fee": "0.000880000000000000000000", "address": "0xfaEF4bE10dDF50B68c220c9ab19381e20B8EEB2B", "hash": "eece4c17994798939cea9f6a72ee12faa55a7ce44860cfb95c7ed71c89522fe8","status": "pending","type": "payout", "createdAt": "2017-05-18T18:05:36.957Z", "updatedAt": "2017-05-18T19:21:05.370Z" }, ... ]
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/transactions", null, GetNoncePayload(), "GET");
+            if (result != null && result.HasValues)
+            {
+                foreach(JToken token in result)
+                {
+                    if (token["currency"].ToStringInvariant().Equals(symbol))
+                    {
+                        ExchangeTransaction transaction = new ExchangeTransaction();
+                        transaction.PaymentId = token["id"].ToStringInvariant();
+                        transaction.Symbol = token["currency"].ToStringInvariant();
+                        transaction.Address = token["address"].ToStringInvariant();               // Address Tag isn't returned
+                        transaction.BlockchainTxId = token["hash"].ToStringInvariant();           // not sure about this
+                        transaction.Amount = token["amount"].ConvertInvariant<decimal>();
+                        transaction.Notes = token["type"].ToStringInvariant();                    // since no notes are returned, we'll use this to show the transaction type
+                        transaction.TxFee = token["fee"].ConvertInvariant<decimal>();
+                        transaction.TimestampUTC = token["createdAt"].ConvertInvariant<DateTime>();
+
+                        string status = token["status"].ToStringInvariant();
+                        if (status.Equals("pending")) transaction.Status = TransactionStatus.Processing;
+                        else if (status.Equals("success")) transaction.Status = TransactionStatus.Complete;
+                        else if (status.Equals("failed")) transaction.Status = TransactionStatus.Failure;
+                        else transaction.Status = TransactionStatus.Unknown;
+
+                        transactions.Add(transaction);
+                    }
+                }
+            }
+            return transactions;
+        }
+
+        protected override async Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+        {
+            ExchangeWithdrawalResponse withdraw = new ExchangeWithdrawalResponse() { Success = false }; 
+            var payload = GetNoncePayload();
+            payload["amount"] = withdrawalRequest.Amount;
+            payload["currency_code"] = withdrawalRequest.Symbol;
+            payload["address"] = withdrawalRequest.Address;
+            if (!string.IsNullOrEmpty(withdrawalRequest.AddressTag)) payload["paymentId"] = withdrawalRequest.AddressTag;
+            //{ "id": "d2ce578f-647d-4fa0-b1aa-4a27e5ee597b"}   that's all folks!
+            JToken token = await MakeJsonRequestAsync<JToken>("/payment/payout", null, payload, "POST");
+            if (token != null && token["id"] != null)
+            {
+                withdraw.Success = true;
+                withdraw.Id = token["id"].ToStringInvariant();
+            }
+            return withdraw;
+        }
+
+        #endregion
+
+        #region WebSocket APIs
+
+        // working on it. Hitbtc has extensive support for sockets, including trading
+
+        #endregion
+
+        #region Hitbtc Public Functions outside the ExchangeAPI
+        // HitBTC has two accounts per client: the main bank and trading 
+        // Coins deposited from this API go into the bank, and must be withdrawn from there as well
+        // Trading only takes place from the trading account.
+        // You must transfer coin balances from the bank to trading in order to trade, and back again to withdaw
+        // These functions aid in that process
+
+        public Dictionary<string, decimal> GetBankAmounts()
+        {
+            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+            JToken obj = MakeJsonRequest<JToken>("/account/balance", null, GetNoncePayload(), "GET");
+            foreach (JToken token in obj["balance"])
+            {
+                decimal amount = token["available"].ConvertInvariant<decimal>();
+                if (amount > 0m) amounts[token["currency"].ToStringInvariant()] = amount;
+            }
+            return amounts;
+        }
+
+
+        public bool AccountTransfer(string Symbol, decimal Amount, bool ToBank)
+        {
+            var payload = GetNoncePayload();
+            payload["type"] = ToBank ? "exchangeToBank" : "bankToExchange";
+            payload["currency"] = Symbol;
+            payload["amount"] = Amount;
+            JToken obj = MakeJsonRequest<JToken>("/account/transfer", null, GetNoncePayload(), "GET");
+            if (obj != null && obj.HasValues && !String.IsNullOrEmpty(obj["id"].ToStringInvariant())) return true;
+            else return false;
+        }
+
+        #endregion
+
+        #region Private Functions
+
+        private ExchangeTicker ParseTicker(JToken token)
+        {
+            // [ {"ask": "0.050043","bid": "0.050042","last": "0.050042","open": "0.047800","low": "0.047052","high": "0.051679","volume": "36456.720","volumeQuote": "1782.625000","timestamp": "2017-05-12T14:57:19.999Z","symbol": "ETHBTC"} ]
+            return new ExchangeTicker()
+            {
+                Ask = token["ask"].ConvertInvariant<decimal>(),
+                Bid = token["bid"].ConvertInvariant<decimal>(),
+                Last = token["last"].ConvertInvariant<decimal>(),
+                Volume = new ExchangeVolume()
+                {
+                    Timestamp = token["timestamp"].ConvertInvariant<DateTime>(),
+                    PriceAmount = token["volumeQuote"].ConvertInvariant<decimal>(),
+                    QuantityAmount = token["volume"].ConvertInvariant<decimal>()
+                }
+            };
+        }
+
+        private ExchangeTrade ParseExchangeTrade(JToken token)
+        {
+            // [ { "id": 9533117, "price": "0.046001", "quantity": "0.220", "side": "sell", "timestamp": "2017-04-14T12:18:40.426Z" }, ... ]
+            return new ExchangeTrade()
+            {
+                Id = token["id"].ConvertInvariant<long>(),
+                Timestamp = token["timestamp"].ConvertInvariant<DateTime>(),
+                Price = token["price"].ConvertInvariant<decimal>(),
+                Amount = token["quantity"].ConvertInvariant<decimal>(),
+                IsBuy = token["side"].ToStringInvariant().Equals("buy")
+            };
+        }
+
+        private ExchangeOrderResult ParseCompletedOrder(JToken token)
+        {
+            //[ { "id": 9535486, "clientOrderId": "f8dbaab336d44d5ba3ff578098a68454", "orderId": 816088377, "symbol": "ETHBTC", "side": "sell", "quantity": "0.061", "price": "0.045487", "fee": "0.000002775", "timestamp": "2017-05-17T12:32:57.848Z" }, 
+            return new ExchangeOrderResult()
+            {
+                OrderId = token["orderId"].ToStringInvariant(),          // here we're using OrderId. I have no idea what the id field is used for.
+                Symbol = token["symbol"].ToStringInvariant(),
+                IsBuy = token["side"].ToStringInvariant().Equals("buy"),
+                Amount = token["quantity"].ConvertInvariant<decimal>(),
+                AmountFilled = token["quantity"].ConvertInvariant<decimal>(),   // these are closed, so I guess the filled quantity matches the order quantiity
+                Price = token["price"].ConvertInvariant<decimal>(),
+                Fees = token["fee"].ConvertInvariant<decimal>(),
+                OrderDate = token["timestamp"].ConvertInvariant<DateTime>(),
+                Result = ExchangeAPIOrderResult.Filled
+            };
+        }
+
+        private ExchangeOrderResult ParseOpenOrder(JToken token)
+        {
+            // [ { "id": 840450210, "clientOrderId": "c1837634ef81472a9cd13c81e7b91401", "symbol": "ETHBTC", "side": "buy", "status": "partiallyFilled", "type": "limit", "timeInForce": "GTC", "quantity": "0.020", "price": "0.046001", "cumQuantity": "0.005", "createdAt": "2017-05-12T17:17:57.437Z",   "updatedAt": "2017-05-12T17:18:08.610Z" }]
+            ExchangeOrderResult result = new ExchangeOrderResult()
+            {
+                OrderId = token["clientOrderId"].ToStringInvariant(),        // here we're using ClientOrderId in order to get order details by open orders
+                Symbol = token["symbol"].ToStringInvariant(),
+                IsBuy = token["side"].ToStringInvariant().Equals("buy"),
+                Amount = token["quantity"].ConvertInvariant<decimal>(),
+                AmountFilled = token["cumQuantity"].ConvertInvariant<decimal>(),
+                Price = token["price"].ConvertInvariant<decimal>(),
+                OrderDate = token["createdAt"].ConvertInvariant<DateTime>(),
+                Message = string.Format("OrderType: {0}, TimeInForce: {1}", token["type"].ToStringInvariant(), token["timeInForce"].ToStringInvariant())   // A bit arbitrary, but this will show the ordertype and timeinforce
+            };
+            // new, suspended, partiallyFilled, filled, canceled, expired
+            string status = token["status"].ToStringInvariant();
+            if (status.Equals("filled")) result.Result = ExchangeAPIOrderResult.Filled;
+            else if (status.Equals("partiallyFilled")) result.Result = ExchangeAPIOrderResult.FilledPartially;
+            else if (status.Equals("canceled") || status.Equals("expired")) result.Result = ExchangeAPIOrderResult.Canceled;
+            else if (status.Equals("new")) result.Result = ExchangeAPIOrderResult.Pending;
+            else result.Result = ExchangeAPIOrderResult.Error;
+
+            return result;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Implemented OnGetHistoricalTradesAsync with new pattern. On other ExchangeSharp exchanges  this call should always check if the callback is null before sending results because the calling object may be disposed by the time the call is complete.