### PR TITLE
Bitfinex: Re-add accidentally removed NotSupportedException on GetCurrencies

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -710,6 +710,11 @@ namespace ExchangeSharp
             }
         }
 
+        protected override Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
+        {
+            throw new NotSupportedException("Bitfinex does not provide data about its currencies via the API");
+        }
+
         private async Task<IEnumerable<ExchangeOrderResult>> GetOrderDetailsInternalAsync(string url, string symbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();


### PR DESCRIPTION
This lets consumers (such as my own code) differentiate between an incompletely implemented exchange vs. one that does not (and will probably never) support the functionality.