### PR TITLE
Fixes for the KuCoin API

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
@@ -46,7 +46,7 @@ namespace ExchangeSharp
                 request.Headers.Add("KC-API-KEY", PublicApiKey.ToUnsecureString());
                 request.Headers.Add("KC-API-NONCE", payload["nonce"].ToStringInvariant());
 
-                var endpoint = request.RequestUri.PathAndQuery;
+                var endpoint = request.RequestUri.AbsolutePath;
                 var message = string.Format("{0}/{1}/{2}", endpoint, payload["nonce"], GetFormForPayload(payload, false));
                 var sig = CryptoUtility.SHA256Sign(Convert.ToBase64String(Encoding.UTF8.GetBytes(message)), PrivateApiKey.ToUnsecureString());
 
@@ -357,9 +357,10 @@ namespace ExchangeSharp
             var payload = GetNoncePayload();
             payload["amount"] = order.Amount;
             payload["price"] = order.Price;
+            payload["symbol"] = order.Symbol;
             payload["type"] = order.IsBuy ? "BUY" : "SELL";
             // {"orderOid": "596186ad07015679730ffa02" }
-            JToken token = await MakeJsonRequestAsync<JToken>("/order?symbol=" + order.Symbol, null, payload, "POST");
+            JToken token = await MakeJsonRequestAsync<JToken>("/order?" + GetFormForPayload(payload, false), null, payload, "POST");
             token = CheckError(token);
             return new ExchangeOrderResult() { OrderId = token["orderOid"].ToStringInvariant() };       // this is different than the oid created when filled
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
@@ -305,7 +305,7 @@ namespace ExchangeSharp
             var rc = CheckError(obj);
             foreach (JToken child in rc["datas"])
             {
-                decimal amount = child.Value<decimal>("blance");
+                decimal amount = child.Value<decimal>("balance");
                 if (amount > 0m) amounts.Add(child.Value<string>("coinType"), amount);
             }
             return amounts;


### PR DESCRIPTION
* Fix PlaceOrder for KuCoin caused the "Signature verification failed".
* Typo that caused GetBalance for KuCoin error.