### PR TITLE
Fix Binance, Exchange Symbols are reversed and can end with USTD too,…

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -45,6 +45,7 @@ namespace ExchangeSharp
             NonceStyle = NonceStyle.UnixMilliseconds;
             NonceOffset = TimeSpan.FromSeconds(10.0);
             SymbolSeparator = string.Empty;
+            SymbolIsReversed = true;
         }
 
         public override string NormalizeSymbol(string symbol)
@@ -54,18 +55,19 @@ namespace ExchangeSharp
 
         public override string ExchangeSymbolToGlobalSymbol(string symbol)
         {
-            // All pairs in Binance begin or end with BTC, ETH, or BNB
-            if (symbol.Length == 6)
+            // All pairs in Binance begin or end with BTC, ETH, BNB or USTD
+            if (symbol.EndsWith("BTC") || symbol.EndsWith("ETH") || symbol.EndsWith("BNB"))
             {
-                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Substring(0, 3) + GlobalSymbolSeparator + symbol.Substring(3)), GlobalSymbolSeparator);
+                string baseSymbol = symbol.Substring(3);
+                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Replace(baseSymbol, "") + GlobalSymbolSeparator + baseSymbol), GlobalSymbolSeparator);
             }
-            else if (symbol.StartsWith("BTC") || symbol.StartsWith("ETH") || symbol.StartsWith("BNB"))
+            if (symbol.EndsWith("USDT"))
             {
-                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Substring(3) + GlobalSymbolSeparator + symbol.Substring(0, 3)), GlobalSymbolSeparator);
+                string baseSymbol = symbol.Substring(4);
+                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Replace(baseSymbol, "") + GlobalSymbolSeparator + baseSymbol), GlobalSymbolSeparator);
             }
 
-            // reversed
-            return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Substring(symbol.Length - 3, 3) + GlobalSymbolSeparator + symbol.Substring(0, symbol.Length - 3)), GlobalSymbolSeparator);
+            return ExchangeSymbolToGlobalSymbolWithSeparator(symbol.Substring(0, symbol.Length - 3) + GlobalSymbolSeparator + (symbol.Substring(symbol.Length - 3, 3)), GlobalSymbolSeparator);
         }
 
         protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -55,7 +55,7 @@ namespace ExchangeSharp
 
         public override string ExchangeSymbolToGlobalSymbol(string symbol)
         {
-            // All pairs in Binance end with BTC, ETH, BNB or USTD
+            // All pairs in Binance end with BTC, ETH, BNB or USDT
             if (symbol.EndsWith("BTC") || symbol.EndsWith("ETH") || symbol.EndsWith("BNB"))
             {
                 string baseSymbol = symbol.Substring(3);

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -55,7 +55,7 @@ namespace ExchangeSharp
 
         public override string ExchangeSymbolToGlobalSymbol(string symbol)
         {
-            // All pairs in Binance begin or end with BTC, ETH, BNB or USTD
+            // All pairs in Binance end with BTC, ETH, BNB or USTD
             if (symbol.EndsWith("BTC") || symbol.EndsWith("ETH") || symbol.EndsWith("BNB"))
             {
                 string baseSymbol = symbol.Substring(3);


### PR DESCRIPTION
… also first 3, last 3 characters split is wrong because Binance offers e.g. BTC-CLOAK (3 Characters/5 Characters), BTC-USDT (3 Characters/4 Characters) or USDT-BTC (4 Characters/3 Characters)