### PR TITLE
Fix for https://github.com/jjxtra/ExchangeSharp/issues/120 

### DIFF
--- a/ExchangeSharpTests/ExchangeAPITests.cs
+++ b/ExchangeSharpTests/ExchangeAPITests.cs
@@ -1,0 +1,58 @@
+﻿namespace ExchangeSharpTests
+{
+    using System.Collections.Generic;
+
+    using ExchangeSharp;
+
+    using FluentAssertions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ExchangeAPITests
+    {
+        [TestMethod]
+        public void PopulateExchangeMarkets_CacheMissEmptyList_Refreshes()
+        {
+            var mockApi = new MockExchangeAPI();
+            mockApi.SetExchangeMarkets(new List<ExchangeMarket>());
+            mockApi.GetExchangeMarket("ADA/BTC").Should().BeNull();
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void PopulateExchangeMarkets_CacheHit_NoRefresh()
+        {
+            var mockApi = new MockExchangeAPI();
+            var cardano = new ExchangeMarket { MarketName = "ADA/BTC" };
+            mockApi.SetExchangeMarkets(new List<ExchangeMarket> { cardano });
+            mockApi.GetExchangeMarket("ADA/BTC").Should().Be(cardano);
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void PopulateExchangeMarkets_CacheMissNonEmptyList_RefreshesWhenMarketNotFound()
+        {
+            var mockApi = new MockExchangeAPI();
+            var eth = new ExchangeMarket { MarketName = "ETH/BTC" };
+            mockApi.SetExchangeMarkets(new List<ExchangeMarket> { eth });
+            mockApi.GetExchangeMarket("ADA/BTC").Should().BeNull();
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void PopulateExchangeMarkets_MarketsEmptiedOnRefresh()
+        {
+            var mockApi = new MockExchangeAPI();
+            var cardano = new ExchangeMarket { MarketName = "ADA/BTC" };
+            mockApi.SetExchangeMarkets(new List<ExchangeMarket> { cardano });
+            mockApi.GetExchangeMarket("ADA/BTC").Should().Be(cardano);
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(0);
+
+            mockApi.GetExchangeMarket("DOGE/BTC").Should().BeNull();
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(1);
+            mockApi.GetExchangeMarket("ADA/BTC").Should().BeNull();
+            mockApi.OnGetSymbolsMetadataAsyncCalls.Should().Be(2);
+        }
+    }
+}

--- a/ExchangeSharpTests/MockExchangeAPI.cs
+++ b/ExchangeSharpTests/MockExchangeAPI.cs
@@ -1,0 +1,32 @@
+﻿namespace ExchangeSharpTests
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using ExchangeSharp;
+
+    public class MockExchangeAPI : ExchangeAPI
+    {
+        public int OnGetSymbolsMetadataAsyncCalls;
+
+        public override string BaseUrl { get; set; }
+
+        public override string Name { get; }
+
+        public new ExchangeMarket GetExchangeMarket(string symbol)
+        {
+            return base.GetExchangeMarket(symbol);
+        }
+
+        public void SetExchangeMarkets(IEnumerable<ExchangeMarket> markets)
+        {
+            this.exchangeMarkets = markets;
+        }
+
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        {
+            this.OnGetSymbolsMetadataAsyncCalls++;
+            return await Task.Run(() => new List<ExchangeMarket>());
+        }
+    }
+}


### PR DESCRIPTION
Need to force a refresh of cached GetSymbolsMetadata if no result is found during ClampOrderPrice/Quantity