### PR TITLE
Add margin api

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -444,7 +444,7 @@ namespace ExchangeSharp
         /// </summary>
         static ExchangeAPI()
         {
-            foreach (Type type in typeof(ExchangeAPI).Assembly.GetTypes().Where(type => type.IsSubclassOf(typeof(ExchangeAPI))))
+            foreach (Type type in typeof(ExchangeAPI).Assembly.GetTypes().Where(type => type.IsSubclassOf(typeof(ExchangeAPI)) && !type.IsAbstract))
             {
                 ExchangeAPI api = Activator.CreateInstance(type) as ExchangeAPI;
                 apis[api.Name] = api;

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -613,6 +613,16 @@ namespace ExchangeSharp
 
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
+            return await PlaceOrderAsync(order, false);
+        }
+
+        protected override async Task<ExchangeOrderResult> OnPlaceMarginOrderAsync(ExchangeOrderRequest order)
+        {
+            return await PlaceOrderAsync(order, true);
+        }
+
+        private async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order, bool isMargin)
+        {
             if (order.OrderType == OrderType.Market)
             {
                 throw new NotSupportedException("Order type " + order.OrderType + " not supported");
@@ -635,7 +645,7 @@ namespace ExchangeSharp
                 orderParams.Add(kv.Value);
             }
 
-            JToken result = await MakePrivateAPIRequestAsync(order.IsBuy ? "buy" : "sell", orderParams);
+            JToken result = await MakePrivateAPIRequestAsync(order.IsBuy ? (isMargin ? "marginBuy" : "buy") : (isMargin ? "marginSell" : "sell"), orderParams);
             CheckError(result);
             ExchangeOrderResult exchangeOrderResult = ParsePlacedOrder(result);
             exchangeOrderResult.Symbol = symbol;

--- a/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangePoloniexAPI.cs
@@ -611,6 +611,31 @@ namespace ExchangeSharp
             return amounts;
         }
 
+        protected override async Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string symbol)
+        {
+            symbol = NormalizeSymbol(symbol);
+
+            List<object> orderParams = new List<object>
+            {
+                "currencyPair", symbol
+            };
+
+            JToken result = await MakePrivateAPIRequestAsync("getMarginPosition", orderParams);
+            CheckError(result);
+            ExchangeMarginPositionResult marginPositionResult = new ExchangeMarginPositionResult()
+            {
+                Amount = result["amount"].ConvertInvariant<decimal>(),
+                Total = result["total"].ConvertInvariant<decimal>(),
+                BasePrice = result["basePrice"].ConvertInvariant<decimal>(),
+                LiquidationPrice = result["liquidationPrice"].ConvertInvariant<decimal>(),
+                ProfitLoss = result["pl"].ConvertInvariant<decimal>(),
+                LendingFees = result["lendingFees"].ConvertInvariant<decimal>(),
+                Type = result["type"].ToStringInvariant(),
+                Symbol = symbol
+            };
+            return marginPositionResult;
+        }
+
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             return await PlaceOrderAsync(order, false);

--- a/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp
+{
+    public interface IMarginExchangeAPI : IExchangeAPI
+    {
+        /// <summary>
+        /// Get margin amounts available to trade, symbol / amount dictionary
+        /// </summary>
+        /// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
+        Dictionary<string, decimal> GetMarginAmountsAvailableToTrade();
+
+        /// <summary>
+        /// ASYNC - Get margin amounts available to trade, symbol / amount dictionary
+        /// </summary>
+        /// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
+        Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync();
+    }
+}

--- a/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
@@ -16,5 +16,19 @@ namespace ExchangeSharp
         /// </summary>
         /// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
         Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync();
+
+        /// <summary>
+        /// Place a margin order
+        /// </summary>
+        /// <param name="order">Order request</param>
+        /// <returns>Order result and message string if any</returns>
+        ExchangeOrderResult PlaceMarginOrder(ExchangeOrderRequest order);
+
+        /// <summary>
+        /// ASYNC - Place a margin order
+        /// </summary>
+        /// <param name="order">Order request</param>
+        /// <returns>Order result and message string if any</returns>
+        Task<ExchangeOrderResult> PlaceMarginOrderAsync(ExchangeOrderRequest order);
     }
 }

--- a/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/IMarginExchangeAPI.cs
@@ -30,5 +30,19 @@ namespace ExchangeSharp
         /// <param name="order">Order request</param>
         /// <returns>Order result and message string if any</returns>
         Task<ExchangeOrderResult> PlaceMarginOrderAsync(ExchangeOrderRequest order);
+
+        /// <summary>
+        /// Get open margin position
+        /// </summary>
+        /// <param name="symbol">Symbol</param>
+        /// <returns>Open margin position result</returns>
+        ExchangeMarginPositionResult GetOpenPosition(string symbol);
+
+        /// <summary>
+        /// ASYNC - Get open margin position
+        /// </summary>
+        /// <param name="symbol">Symbol</param>
+        /// <returns>Open margin position result</returns>
+        Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string symbol);
     }
 }

--- a/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
@@ -40,7 +40,26 @@ namespace ExchangeSharp
             return await OnPlaceMarginOrderAsync(order);
         }
 
+        /// <summary>
+        /// Get open margin position
+        /// </summary>
+        /// <param name="symbol">Symbol</param>
+        /// <returns>Open margin position result</returns>
+        public ExchangeMarginPositionResult GetOpenPosition(string symbol) => GetOpenPositionAsync(symbol).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Get open margin position
+        /// </summary>
+        /// <param name="symbol">Symbol</param>
+        /// <returns>Open margin position result</returns>
+        public async Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string symbol)
+        {
+            await new SynchronizationContextRemover();
+            return await OnGetOpenPositionAsync(symbol);
+        }
+
         protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync() => throw new NotImplementedException();
         protected virtual Task<ExchangeOrderResult> OnPlaceMarginOrderAsync(ExchangeOrderRequest order) => throw new NotImplementedException();
+        protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string symbol) => throw new NotImplementedException();
     }
 }

--- a/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp
+{
+    public abstract class MarginExchangeAPI : ExchangeAPI, IMarginExchangeAPI
+    {
+        /// <summary>
+        /// Get margin amounts available to trade, symbol / amount dictionary
+        /// </summary>
+        /// <returns>Symbol / amount dictionary</returns>
+        public Dictionary<string, decimal> GetMarginAmountsAvailableToTrade() => GetMarginAmountsAvailableToTradeAsync().GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Get margin amounts available to trade, symbol / amount dictionary
+        /// </summary>
+        /// <returns>Symbol / amount dictionary</returns>
+        public async Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync()
+        {
+            await new SynchronizationContextRemover();
+            return await OnGetMarginAmountsAvailableToTradeAsync();
+        }
+
+        protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync() => throw new NotImplementedException();
+    }
+}

--- a/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/MarginExchangeAPI.cs
@@ -22,6 +22,25 @@ namespace ExchangeSharp
             return await OnGetMarginAmountsAvailableToTradeAsync();
         }
 
+        /// <summary>
+        /// Place a margin order
+        /// </summary>
+        /// <param name="order">The order request</param>
+        /// <returns>Result</returns>
+        public ExchangeOrderResult PlaceMarginOrder(ExchangeOrderRequest order) => PlaceMarginOrderAsync(order).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// ASYNC - Place a margin order
+        /// </summary>
+        /// <param name="order">The order request</param>
+        /// <returns>Result</returns>
+        public async Task<ExchangeOrderResult> PlaceMarginOrderAsync(ExchangeOrderRequest order)
+        {
+            await new SynchronizationContextRemover();
+            return await OnPlaceMarginOrderAsync(order);
+        }
+
         protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync() => throw new NotImplementedException();
+        protected virtual Task<ExchangeOrderResult> OnPlaceMarginOrderAsync(ExchangeOrderRequest order) => throw new NotImplementedException();
     }
 }

--- a/ExchangeSharp/Model/ExchangeMarginPositionResult.cs
+++ b/ExchangeSharp/Model/ExchangeMarginPositionResult.cs
@@ -1,0 +1,21 @@
+﻿namespace ExchangeSharp
+{
+    public class ExchangeMarginPositionResult
+    {
+        public string Symbol { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public decimal Total { get; set; }
+
+        public decimal ProfitLoss { get; set; }
+
+        public decimal LendingFees { get; set; }
+
+        public string Type { get; set; }
+
+        public decimal BasePrice { get; set; }
+
+        public decimal LiquidationPrice { get; set; }
+    }
+}


### PR DESCRIPTION
Added a new interface IMarginExchangeAPI for use by exchanges that allow margin accounts and trades.  Any exchange class that wants to take advantage of this new API should change their base class from ExchangeAPI to MarginExchangeAPI (which itself inherits from ExchangeAPI).  I included a few methods to start with and implemented these methods in the ExchangePoloniexAPI class.  Since these all require the private api, I didn't include any tests in the test console; however, I did test them independently with a live Poloniex margin account.