### PR TITLE
Implement OrderBook delta socket for Binance and pave the way for other exchanges

### DIFF
--- a/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAPI.cs
@@ -1069,7 +1069,7 @@ namespace ExchangeSharp
             decimal lowPrice = decimal.MaxValue;
             if (isBuy)
             {
-                foreach (ExchangeOrderPrice ask in book.Asks)
+                foreach (ExchangeOrderPrice ask in book.Asks.Values)
                 {
                     counter += ask.Amount;
                     highPrice = Math.Max(highPrice, ask.Price);
@@ -1082,7 +1082,7 @@ namespace ExchangeSharp
             }
             else
             {
-                foreach (ExchangeOrderPrice bid in book.Bids)
+                foreach (ExchangeOrderPrice bid in book.Bids.Values)
                 {
                     counter += bid.Amount;
                     highPrice = Math.Max(highPrice, bid.Price);

--- a/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeAbucoinsAPI.cs
@@ -154,8 +154,23 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/products/" + symbol + "/book?level=" + (maxCount > 50 ? "0" : "2"));
             if (token.HasValues)
             {
-                foreach (JArray array in token["bids"]) if (orders.Bids.Count < maxCount) orders.Bids.Add(new ExchangeOrderPrice() { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
-                foreach (JArray array in token["asks"]) if (orders.Asks.Count < maxCount) orders.Asks.Add(new ExchangeOrderPrice() { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
+                foreach (JArray array in token["bids"])
+                {
+                    if (orders.Bids.Count < maxCount)
+                    {
+                        var depth = new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() };
+                        orders.Bids[depth.Price] = depth;
+                    }
+                }
+
+                foreach (JArray array in token["asks"])
+                {
+                    if (orders.Asks.Count < maxCount)
+                    {
+                        var depth = new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() };
+                        orders.Asks[depth.Price] = depth;
+                    }
+                }
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -250,7 +250,7 @@ namespace ExchangeSharp
             });
         }
 
-        public IDisposable GetOrderBooksDifferentialSocket(IEnumerable<string> symbol, Action<ExchangeSequencedWebsocketMessage<ExchangeOrderBook>> callback)
+        public IDisposable GetOrderBooksDifferentialSocket(IEnumerable<string> symbol, Action<BinanceMarketDepthDiffUpdate> callback)
         {
             if (callback == null)
             {
@@ -258,20 +258,16 @@ namespace ExchangeSharp
             }
 
             string combined = string.Join("/", symbol.Select(s => this.NormalizeSymbol(s).ToLowerInvariant() + "@depth"));
-            //var normalizedSymbol = NormalizeSymbol(symbol).ToLowerInvariant();
 
             return ConnectWebSocket($"/stream?streams={combined}", (msg, _socket) =>
             {
                 try
                 {
-                    //JToken token = JToken.Parse(msg.UTF8String());
-                    //var orderBook = ParseOrderBook(token);
-                    //var sequenceNumber = token["lastUpdateId"].ConvertInvariant<int>();
-                    //callback(new ExchangeSequencedWebsocketMessage<ExchangeOrderBook>(sequenceNumber, orderBook));
+                    var update = JsonConvert.DeserializeObject<BinanceMultiDepthStream>(msg.UTF8String());
+                    callback(update.Data);
                 }
-                catch (Exception ex)
+                catch
                 {
-                    //Console.WriteLine("Fail: " + ex);
                 }
             });
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -679,11 +679,13 @@ namespace ExchangeSharp
             ExchangeOrderBook book = new ExchangeOrderBook();
             foreach (JArray array in token["bids"])
             {
-                book.Bids.Add(new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() };
+                book.Bids[depth.Price] = depth;
             }
             foreach (JArray array in token["asks"])
             {
-                book.Asks.Add(new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() };
+                book.Asks[depth.Price] = depth;
             }
             return book;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBinanceAPI.cs
@@ -250,6 +250,32 @@ namespace ExchangeSharp
             });
         }
 
+        public IDisposable GetOrderBooksDifferentialSocket(IEnumerable<string> symbol, Action<ExchangeSequencedWebsocketMessage<ExchangeOrderBook>> callback)
+        {
+            if (callback == null)
+            {
+                return null;
+            }
+
+            string combined = string.Join("/", symbol.Select(s => this.NormalizeSymbol(s).ToLowerInvariant() + "@depth"));
+            //var normalizedSymbol = NormalizeSymbol(symbol).ToLowerInvariant();
+
+            return ConnectWebSocket($"/stream?streams={combined}", (msg, _socket) =>
+            {
+                try
+                {
+                    //JToken token = JToken.Parse(msg.UTF8String());
+                    //var orderBook = ParseOrderBook(token);
+                    //var sequenceNumber = token["lastUpdateId"].ConvertInvariant<int>();
+                    //callback(new ExchangeSequencedWebsocketMessage<ExchangeOrderBook>(sequenceNumber, orderBook));
+                }
+                catch (Exception ex)
+                {
+                    //Console.WriteLine("Fail: " + ex);
+                }
+            });
+        }
+
         protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
         {
             symbol = NormalizeSymbol(symbol);

--- a/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitfinexAPI.cs
@@ -253,11 +253,11 @@ namespace ExchangeSharp
             {
                 if (book[2] > 0m)
                 {
-                    orders.Bids.Add(new ExchangeOrderPrice { Amount = book[2], Price = book[0] });
+                    orders.Bids[book[0]] = new ExchangeOrderPrice { Amount = book[2], Price = book[0] };
                 }
                 else
                 {
-                    orders.Asks.Add(new ExchangeOrderPrice { Amount = -book[2], Price = book[0] });
+                    orders.Asks[book[0]] = new ExchangeOrderPrice { Amount = -book[2], Price = book[0] };
                 }
             }
             return orders;
@@ -699,7 +699,7 @@ namespace ExchangeSharp
                 {
                     if (symbol == null || token["symbol"].ToStringInvariant() == symbol)
                     {
-                       orders.Add(ParseOrder(token));
+                        orders.Add(ParseOrder(token));
                     }
                 }
             }

--- a/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBithumbAPI.cs
@@ -76,7 +76,7 @@ namespace ExchangeSharp
             }
             return result;
         }
-        
+
         private async Task<Tuple<JToken, string>> MakeRequestBithumbAsync(string symbol, string subUrl)
         {
             symbol = NormalizeSymbol(symbol);
@@ -108,11 +108,13 @@ namespace ExchangeSharp
             ExchangeOrderBook book = new ExchangeOrderBook();
             foreach (JToken token in data["bids"])
             {
-                book.Bids.Add(new ExchangeOrderPrice { Amount = token["quantity"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = token["quantity"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
+                book.Bids[depth.Price] = depth;
             }
             foreach (JToken token in data["asks"])
             {
-                book.Asks.Add(new ExchangeOrderPrice { Amount = token["quantity"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = token["quantity"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
+                book.Asks[depth.Price] = depth;
             }
             return book;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBitstampAPI.cs
@@ -127,11 +127,13 @@ namespace ExchangeSharp
             ExchangeOrderBook book = new ExchangeOrderBook();
             foreach (JArray ask in token["asks"])
             {
-                book.Asks.Add(new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() };
+                book.Asks[depth.Price] = depth;
             }
             foreach (JArray bid in token["bids"])
             {
-                book.Bids.Add(new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() };
+                book.Bids[depth.Price] = depth;
             }
             return book;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBittrexAPI.cs
@@ -625,14 +625,14 @@ namespace ExchangeSharp
             JToken bids = book["buy"];
             foreach (JToken token in bids)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
-                orders.Bids.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
+                orders.Bids[depth.Price] = depth;
             }
             JToken asks = book["sell"];
             foreach (JToken token in asks)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
-                orders.Asks.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
+                orders.Asks[depth.Price] = depth;
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeBleutradeAPI.cs
@@ -252,8 +252,23 @@ namespace ExchangeSharp
             //"result" : { "buy" : [{"Quantity" : 4.99400000,"Rate" : 3.00650900}, {"Quantity" : 50.00000000, "Rate" : 3.50000000 }  ] ...
             JToken result = await MakeJsonRequestAsync<JObject>("/public/getorderbook?market=" + symbol + "&type=ALL&depth=" + maxCount);
             result = CheckError(result);
-            foreach (JToken token in result["buy"]) if (orders.Bids.Count < maxCount) orders.Bids.Add(new ExchangeOrderPrice() { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() });
-            foreach (JToken token in result["sell"]) if (orders.Asks.Count < maxCount) orders.Asks.Add(new ExchangeOrderPrice() { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() });
+            foreach (JToken token in result["buy"])
+            {
+                if (orders.Bids.Count < maxCount)
+                {
+                    var depth = new ExchangeOrderPrice { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
+                    orders.Bids[depth.Price] = depth;
+                }
+            }
+
+            foreach (JToken token in result["sell"])
+            {
+                if (orders.Asks.Count < maxCount)
+                {
+                    var depth = new ExchangeOrderPrice() { Amount = token["Quantity"].ConvertInvariant<decimal>(), Price = token["Rate"].ConvertInvariant<decimal>() };
+                    orders.Asks[depth.Price] = depth;
+                }
+            }
             return orders;
         }
 

--- a/ExchangeSharp/API/Exchanges/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeCryptopiaAPI.cs
@@ -160,8 +160,16 @@ namespace ExchangeSharp
             token = CheckError(token);
             if (token.HasValues)
             {
-                foreach (JToken order in token["Buy"]) orders.Bids.Add(new ExchangeOrderPrice() { Price = order.Value<decimal>("Price"), Amount = order.Value<decimal>("Volume") });
-                foreach (JToken order in token["Sell"]) orders.Asks.Add(new ExchangeOrderPrice() { Price = order.Value<decimal>("Price"), Amount = order.Value<decimal>("Volume") });
+                foreach (JToken order in token["Buy"])
+                {
+                    var depth = new ExchangeOrderPrice() { Price = order.Value<decimal>("Price"), Amount = order.Value<decimal>("Volume") };
+                    orders.Bids[depth.Price] = depth;
+                }
+                foreach (JToken order in token["Sell"])
+                {
+                    var depth = new ExchangeOrderPrice() { Price = order.Value<decimal>("Price"), Amount = order.Value<decimal>("Volume") };
+                    orders.Asks[depth.Price] = depth;
+                }
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGdaxAPI.cs
@@ -332,11 +332,13 @@ namespace ExchangeSharp
             JArray bids = books["bids"] as JArray;
             foreach (JArray ask in asks)
             {
-                orders.Asks.Add(new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() };
+                orders.Asks[depth.Price] = depth;
             }
             foreach (JArray bid in bids)
             {
-                orders.Bids.Add(new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() };
+                orders.Bids[depth.Price] = depth;
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeGeminiAPI.cs
@@ -124,14 +124,14 @@ namespace ExchangeSharp
             JToken bids = obj["bids"];
             foreach (JToken token in bids)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token["amount"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
-                orders.Bids.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token["amount"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
+                orders.Bids[depth.Price] = depth;
             }
             JToken asks = obj["asks"];
             foreach (JToken token in asks)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token["amount"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
-                orders.Asks.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token["amount"].ConvertInvariant<decimal>(), Price = token["price"].ConvertInvariant<decimal>() };
+                orders.Asks[depth.Price] = depth;
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKrakenAPI.cs
@@ -295,14 +295,14 @@ namespace ExchangeSharp
             JToken bids = obj["bids"];
             foreach (JToken token in bids)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token[1].ConvertInvariant<decimal>(), Price = token[0].ConvertInvariant<decimal>() };
-                orders.Bids.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token[1].ConvertInvariant<decimal>(), Price = token[0].ConvertInvariant<decimal>() };
+                orders.Bids[depth.Price] = depth;
             }
             JToken asks = obj["asks"];
             foreach (JToken token in asks)
             {
-                ExchangeOrderPrice order = new ExchangeOrderPrice { Amount = token[1].ConvertInvariant<decimal>(), Price = token[0].ConvertInvariant<decimal>() };
-                orders.Asks.Add(order);
+                ExchangeOrderPrice depth = new ExchangeOrderPrice { Amount = token[1].ConvertInvariant<decimal>(), Price = token[0].ConvertInvariant<decimal>() };
+                orders.Asks[depth.Price] = depth;
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeKucoinAPI.cs
@@ -125,8 +125,16 @@ namespace ExchangeSharp
             token = CheckError(token);
             if (token.HasValues)
             {
-                foreach (JToken order in token["BUY"]) orders.Bids.Add(new ExchangeOrderPrice() { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() });
-                foreach (JToken order in token["SELL"]) orders.Asks.Add(new ExchangeOrderPrice() { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() });
+                foreach (JToken order in token["BUY"])
+                {
+                    var depth = new ExchangeOrderPrice { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() };
+                    orders.Bids[depth.Price] = depth;
+                }
+                foreach (JToken order in token["SELL"])
+                {
+                    var depth = new ExchangeOrderPrice { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() };
+                    orders.Asks[depth.Price] = depth;
+                }
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeLivecoinAPI.cs
@@ -131,19 +131,21 @@ namespace ExchangeSharp
             {
                 foreach (JToken order in token["asks"])
                 {
-                    orders.Asks.Add(new ExchangeOrderPrice()
+                    var depth = new ExchangeOrderPrice()
                     {
                         Price = order[0].ConvertInvariant<decimal>(),
                         Amount = order[1].ConvertInvariant<decimal>()
-                    });
+                    };
+                    orders.Asks[depth.Price] = depth;
                 }
                 foreach (JToken order in token["bids"])
                 {
-                    orders.Bids.Add(new ExchangeOrderPrice()
+                    var depth = new ExchangeOrderPrice()
                     {
                         Price = order[0].ConvertInvariant<decimal>(),
                         Amount = order[1].ConvertInvariant<decimal>()
-                    });
+                    };
+                    orders.Bids[depth.Price] = depth;
                 }
             }
             return orders;

--- a/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeOkexAPI.cs
@@ -218,12 +218,14 @@ namespace ExchangeSharp
                     var orderBook = new ExchangeOrderBook();
                     foreach (JArray array in data["asks"])
                     {
-                        orderBook.Asks.Add(new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() });
+                        var depth = new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() };
+                        orderBook.Asks[depth.Price] = depth;
                     }
-                    orderBook.Asks.Sort((a1, a2) => a1.Price.CompareTo(a2.Price));
+
                     foreach (JArray array in data["bids"])
                     {
-                        orderBook.Bids.Add(new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() });
+                        var depth = new ExchangeOrderPrice { Price = array[0].ConvertInvariant<decimal>(), Amount = array[1].ConvertInvariant<decimal>() };
+                        orderBook.Bids[depth.Price] = depth;
                     }
 
                     callback(new ExchangeSequencedWebsocketMessage<ExchangeOrderBook>(seq, orderBook));
@@ -246,12 +248,13 @@ namespace ExchangeSharp
             ExchangeOrderBook book = new ExchangeOrderBook();
             foreach (JArray ask in token.Item1["asks"])
             {
-                book.Asks.Add(new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = ask[1].ConvertInvariant<decimal>(), Price = ask[0].ConvertInvariant<decimal>() };
+                book.Asks[depth.Price] = depth;
             }
-            book.Asks.Sort((a1, a2) => a1.Price.CompareTo(a2.Price));
             foreach (JArray bid in token.Item1["bids"])
             {
-                book.Bids.Add(new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = bid[1].ConvertInvariant<decimal>(), Price = bid[0].ConvertInvariant<decimal>() };
+                book.Bids[depth.Price] = depth;
             }
             return book;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeTuxExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeTuxExchangeAPI.cs
@@ -165,8 +165,17 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/api?method=getorders&coin=" + split[1] + "&market=" + split[0]);
             if (token != null && token.HasValues)
             {
-                foreach (JArray order in token["asks"]) orders.Asks.Add(new ExchangeOrderPrice() { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() });
-                foreach (JArray order in token["bids"]) orders.Bids.Add(new ExchangeOrderPrice() { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() });
+                foreach (JArray order in token["asks"])
+                {
+                    var depth = new ExchangeOrderPrice { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() };
+                    orders.Asks[depth.Price] = depth;
+                }
+
+                foreach (JArray order in token["bids"])
+                {
+                    var depth = new ExchangeOrderPrice { Price = order[0].ConvertInvariant<decimal>(), Amount = order[1].ConvertInvariant<decimal>() };
+                    orders.Bids[depth.Price] = depth;
+                }
             }
             return orders;
         }

--- a/ExchangeSharp/API/Exchanges/ExchangeYobitAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ExchangeYobitAPI.cs
@@ -137,8 +137,17 @@ namespace ExchangeSharp
             symbol = NormalizeSymbol(symbol);
             ExchangeOrderBook orders = new ExchangeOrderBook();
             JToken obj = await MakeJsonRequestAsync<JToken>("/depth/" + symbol + "?limit=" + maxCount, BaseUrl, null, "GET");
-            foreach (JArray prop in obj.Value<JToken>(symbol).Value<JArray>("asks")) orders.Asks.Add(new ExchangeOrderPrice() { Price = prop[0].ConvertInvariant<decimal>(), Amount = prop[1].ConvertInvariant<decimal>() });
-            foreach (JArray prop in obj.Value<JToken>(symbol).Value<JArray>("bids")) orders.Bids.Add(new ExchangeOrderPrice() { Price = prop[0].ConvertInvariant<decimal>(), Amount = prop[1].ConvertInvariant<decimal>() });
+            foreach (JArray prop in obj.Value<JToken>(symbol).Value<JArray>("asks"))
+            {
+                var depth = new ExchangeOrderPrice { Price = prop[0].ConvertInvariant<decimal>(), Amount = prop[1].ConvertInvariant<decimal>() };
+                orders.Asks[depth.Price] = depth;
+            }
+
+            foreach (JArray prop in obj.Value<JToken>(symbol).Value<JArray>("bids"))
+            {
+                var depth = new ExchangeOrderPrice { Price = prop[0].ConvertInvariant<decimal>(), Amount = prop[1].ConvertInvariant<decimal>() };
+                orders.Bids[depth.Price] = depth;
+            }
 
             return orders;
         }

--- a/ExchangeSharp/API/Services/CryptowatchAPI.cs
+++ b/ExchangeSharp/API/Services/CryptowatchAPI.cs
@@ -130,14 +130,16 @@ namespace ExchangeSharp
             {
                 if (++count > maxCount)
                     break;
-                book.Asks.Add(new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() };
+                book.Asks[depth.Price] = depth;
             }
             count = 0;
             foreach (JArray array in result["bids"])
             {
                 if (++count > maxCount)
                     break;
-                book.Bids.Add(new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() });
+                var depth = new ExchangeOrderPrice { Amount = array[1].ConvertInvariant<decimal>(), Price = array[0].ConvertInvariant<decimal>() };
+                book.Bids[depth.Price] = depth;
             }
             return book;
         }

--- a/ExchangeSharp/ExchangeSharp.csproj
+++ b/ExchangeSharp/ExchangeSharp.csproj
@@ -81,9 +81,4 @@
     <DefineConstants>HAS_WINDOWS_FORMS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|x64'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
 </Project>

--- a/ExchangeSharp/ExchangeSharp.csproj
+++ b/ExchangeSharp/ExchangeSharp.csproj
@@ -81,4 +81,9 @@
     <DefineConstants>HAS_WINDOWS_FORMS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|x64'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
 </Project>

--- a/ExchangeSharp/Model/Binance/BinanceMarketDepthDiffUpdate.cs
+++ b/ExchangeSharp/Model/Binance/BinanceMarketDepthDiffUpdate.cs
@@ -1,0 +1,42 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2018 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharp
+{
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
+    public class BinanceMarketDepthDiffUpdate
+    {
+        [JsonProperty("e")]
+        public string EventType { get; set; }
+
+        [JsonProperty("E")]
+        public int EventTime { get; set; }
+
+        [JsonProperty("s")]
+        public string Symbol { get; set; }
+
+        [JsonProperty("U")]
+        public int FirstUpdate { get; set; }
+
+        [JsonProperty("u")]
+        public int FinalUpdate { get; set; }
+
+        [JsonProperty("b")]
+        public List<List<object>> Bids { get; set; }
+
+        [JsonProperty("a")]
+        public List<List<object>> Asks { get; set; }
+    }
+}

--- a/ExchangeSharp/Model/Binance/BinanceMarketDepthDiffUpdate.cs
+++ b/ExchangeSharp/Model/Binance/BinanceMarketDepthDiffUpdate.cs
@@ -22,7 +22,7 @@ namespace ExchangeSharp
         public string EventType { get; set; }
 
         [JsonProperty("E")]
-        public int EventTime { get; set; }
+        public long EventTime { get; set; }
 
         [JsonProperty("s")]
         public string Symbol { get; set; }

--- a/ExchangeSharp/Model/Binance/BinanceMultiDepthStream.cs
+++ b/ExchangeSharp/Model/Binance/BinanceMultiDepthStream.cs
@@ -1,0 +1,25 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2018 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharp
+{
+    using Newtonsoft.Json;
+
+    public class BinanceMultiDepthStream
+    {
+        [JsonProperty("stream")]
+        public string Stream { get; set; }
+
+        [JsonProperty("data")]
+        public BinanceMarketDepthDiffUpdate Data { get; set; }
+    }
+}

--- a/ExchangeSharp/Model/ExchangeOrderBook.cs
+++ b/ExchangeSharp/Model/ExchangeOrderBook.cs
@@ -19,6 +19,8 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
+    using ExchangeSharp.Utility;
+
     /// <summary>
     /// A price entry in an exchange order book
     /// </summary>
@@ -72,12 +74,12 @@ namespace ExchangeSharp
         /// <summary>
         /// List of asks (sells)
         /// </summary>
-        public List<ExchangeOrderPrice> Asks { get; } = new List<ExchangeOrderPrice>();
+        public SortedDictionary<decimal, ExchangeOrderPrice> Asks { get; } = new SortedDictionary<decimal, ExchangeOrderPrice>();
 
         /// <summary>
         /// List of bids (buys)
         /// </summary>
-        public List<ExchangeOrderPrice> Bids { get; } = new List<ExchangeOrderPrice>();
+        public SortedDictionary<decimal, ExchangeOrderPrice> Bids { get; } = new SortedDictionary<decimal, ExchangeOrderPrice>(new DescendingComparer<decimal>());
 
         /// <summary>
         /// ToString
@@ -96,11 +98,11 @@ namespace ExchangeSharp
         {
             writer.Write(Asks.Count);
             writer.Write(Bids.Count);
-            foreach (ExchangeOrderPrice price in Asks)
+            foreach (ExchangeOrderPrice price in Asks.Values)
             {
                 price.ToBinary(writer);
             }
-            foreach (ExchangeOrderPrice price in Bids)
+            foreach (ExchangeOrderPrice price in Bids.Values)
             {
                 price.ToBinary(writer);
             }
@@ -118,11 +120,13 @@ namespace ExchangeSharp
             int bidCount = reader.ReadInt32();
             while (askCount-- > 0)
             {
-                Asks.Add(new ExchangeOrderPrice(reader));
+                var exchangeOrderPrice = new ExchangeOrderPrice(reader);
+                Asks.Add(exchangeOrderPrice.Price, exchangeOrderPrice);
             }
             while (bidCount-- > 0)
             {
-                Bids.Add(new ExchangeOrderPrice(reader));
+                var exchangeOrderPrice = new ExchangeOrderPrice(reader);
+                Bids.Add(exchangeOrderPrice.Price, exchangeOrderPrice);
             }
         }
 

--- a/ExchangeSharp/Utility/DescendingComparer.cs
+++ b/ExchangeSharp/Utility/DescendingComparer.cs
@@ -1,0 +1,26 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharp.Utility
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class DescendingComparer<T> : IComparer<T>
+        where T : IComparable<T>
+    {
+        public int Compare(T x, T y)
+        {
+            return y.CompareTo(x);
+        }
+    }
+}

--- a/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
+++ b/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
@@ -1,0 +1,101 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2018 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+namespace ExchangeSharpTests
+{
+    using ExchangeSharp.Model.Binance;
+
+    using FluentAssertions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class BinanceMarketDepthDiffTests
+    {
+        [TestMethod]
+        public void DeserializeDiff()
+        {
+            string toParse = @"{
+  ""e"": ""depthUpdate"",
+  ""E"": 123456789,    
+  ""s"": ""BNBBTC"",     
+  ""U"": 157,          
+  ""u"": 160,          
+  ""b"": [             
+    [
+      ""0.0024"",      
+      ""10"",
+      []             
+    ]
+  ],
+  ""a"": [             
+    [
+      ""0.0026"",      
+      ""100"",         
+      []             
+    ]
+  ]
+}";
+            var diff = JsonConvert.DeserializeObject<BinanceMarketDepthDiff>(toParse);
+            diff.EventType.Should().Be("depthUpdate");
+            diff.EventTime.Should().Be(123456789);
+            diff.Symbol.Should().Be("BNBBTC");
+            diff.FirstUpdate.Should().Be(157);
+            diff.FinalUpdate.Should().Be(160);
+            diff.Bids[0][0].Should().Be("0.0024");
+            diff.Bids[0][1].Should().Be("10");
+            diff.Asks[0][0].Should().Be("0.0026");
+            diff.Asks[0][1].Should().Be("100");
+        }
+
+        [TestMethod]
+        public void DeserializeComboStream()
+        {
+            string toParse = @"{
+	""stream"": ""bnbbtc@depth"",
+	""data"": {
+		""e"": ""depthUpdate"",
+		""E"": 123456789,
+		""s"": ""BNBBTC"",
+		""U"": 157,
+		""u"": 160,
+		""b"": [
+			[
+				""0.0024"",
+				""10"", []
+			]
+		],
+		""a"": [
+			[
+				""0.0026"",
+				""100"", []
+			]
+		]
+	}
+}";
+
+            var multistream = JsonConvert.DeserializeObject<BinanceMultiDepthStream>(toParse);
+            multistream.Stream.Should().Be("bnbbtc@depth");
+            multistream.Data.EventType.Should().Be("depthUpdate");
+            multistream.Data.EventTime.Should().Be(123456789);
+            multistream.Data.Symbol.Should().Be("BNBBTC");
+            multistream.Data.FirstUpdate.Should().Be(157);
+            multistream.Data.FinalUpdate.Should().Be(160);
+            multistream.Data.Bids[0][0].Should().Be("0.0024");
+            multistream.Data.Bids[0][1].Should().Be("10");
+            multistream.Data.Asks[0][0].Should().Be("0.0026");
+            multistream.Data.Asks[0][1].Should().Be("100");
+        }
+    }
+}

--- a/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
+++ b/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace ExchangeSharpTests
 {
-    using ExchangeSharp.Model.Binance;
+    using ExchangeSharp;
 
     using FluentAssertions;
 
@@ -47,7 +47,7 @@ namespace ExchangeSharpTests
     ]
   ]
 }";
-            var diff = JsonConvert.DeserializeObject<BinanceMarketDepthDiff>(toParse);
+            var diff = JsonConvert.DeserializeObject<BinanceMarketDepthDiffUpdate>(toParse);
             diff.EventType.Should().Be("depthUpdate");
             diff.EventTime.Should().Be(123456789);
             diff.Symbol.Should().Be("BNBBTC");

--- a/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
+++ b/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
@@ -48,15 +48,7 @@ namespace ExchangeSharpTests
   ]
 }";
             var diff = JsonConvert.DeserializeObject<BinanceMarketDepthDiffUpdate>(toParse);
-            diff.EventType.Should().Be("depthUpdate");
-            diff.EventTime.Should().Be(123456789);
-            diff.Symbol.Should().Be("BNBBTC");
-            diff.FirstUpdate.Should().Be(157);
-            diff.FinalUpdate.Should().Be(160);
-            diff.Bids[0][0].Should().Be("0.0024");
-            diff.Bids[0][1].Should().Be("10");
-            diff.Asks[0][0].Should().Be("0.0026");
-            diff.Asks[0][1].Should().Be("100");
+            ValidateDiff(diff);
         }
 
         [TestMethod]
@@ -87,15 +79,27 @@ namespace ExchangeSharpTests
 
             var multistream = JsonConvert.DeserializeObject<BinanceMultiDepthStream>(toParse);
             multistream.Stream.Should().Be("bnbbtc@depth");
-            multistream.Data.EventType.Should().Be("depthUpdate");
-            multistream.Data.EventTime.Should().Be(123456789);
-            multistream.Data.Symbol.Should().Be("BNBBTC");
-            multistream.Data.FirstUpdate.Should().Be(157);
-            multistream.Data.FinalUpdate.Should().Be(160);
-            multistream.Data.Bids[0][0].Should().Be("0.0024");
-            multistream.Data.Bids[0][1].Should().Be("10");
-            multistream.Data.Asks[0][0].Should().Be("0.0026");
-            multistream.Data.Asks[0][1].Should().Be("100");
+            ValidateDiff(multistream.Data);
+        }
+
+        [TestMethod]
+        public void DeserializeRealData()
+        {
+            string real = "{\"stream\":\"bnbbtc@depth\",\"data\":{\"e\":\"depthUpdate\",\"E\":1527540113575,\"s\":\"BNBBTC\",\"U\":77730662,\"u\":77730663,\"b\":[[\"0.00167300\",\"0.00000000\",[]],[\"0.00165310\",\"16.44000000\",[]]],\"a\":[]}}";
+            var diff = JsonConvert.DeserializeObject<BinanceMultiDepthStream>(real);
+        }
+
+        private static void ValidateDiff(BinanceMarketDepthDiffUpdate diff)
+        {
+            diff.EventType.Should().Be("depthUpdate");
+            diff.EventTime.Should().Be(123456789);
+            diff.Symbol.Should().Be("BNBBTC");
+            diff.FirstUpdate.Should().Be(157);
+            diff.FinalUpdate.Should().Be(160);
+            diff.Bids[0][0].Should().Be("0.0024");
+            diff.Bids[0][1].Should().Be("10");
+            diff.Asks[0][0].Should().Be("0.0026");
+            diff.Asks[0][1].Should().Be("100");
         }
     }
 }

--- a/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
+++ b/ExchangeSharpTests/BinanceMarketDepthDiffTests.cs
@@ -87,6 +87,7 @@ namespace ExchangeSharpTests
         {
             string real = "{\"stream\":\"bnbbtc@depth\",\"data\":{\"e\":\"depthUpdate\",\"E\":1527540113575,\"s\":\"BNBBTC\",\"U\":77730662,\"u\":77730663,\"b\":[[\"0.00167300\",\"0.00000000\",[]],[\"0.00165310\",\"16.44000000\",[]]],\"a\":[]}}";
             var diff = JsonConvert.DeserializeObject<BinanceMultiDepthStream>(real);
+            diff.Data.EventTime.Should().Be(1527540113575);
         }
 
         private static void ValidateDiff(BinanceMarketDepthDiffUpdate diff)

--- a/ExchangeSharpTests/ExchangeOrderBookTests.cs
+++ b/ExchangeSharpTests/ExchangeOrderBookTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExchangeSharpTests
+{
+    using System.Linq;
+
+    using ExchangeSharp;
+
+    using FluentAssertions;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ExchangeOrderBookTests
+    {
+        [TestMethod]
+        public void AsksSorted_Ascending()
+        {
+            var exchangeOrderBook = new ExchangeOrderBook();
+            exchangeOrderBook.Asks.Add(1.123m, new ExchangeOrderPrice { Price = 1.123m });
+            exchangeOrderBook.Asks.Add(0.24m, new ExchangeOrderPrice { Price = 0.24m });
+            exchangeOrderBook.Asks.Add(2.85m, new ExchangeOrderPrice { Price = 2.85m });
+
+            exchangeOrderBook.Asks.First().Key.Should().Be(0.24m);
+            exchangeOrderBook.Asks.Last().Key.Should().Be(2.85m);
+        }
+
+
+        [TestMethod]
+        public void BidsSorted_Descending()
+        {
+            var exchangeOrderBook = new ExchangeOrderBook();
+            exchangeOrderBook.Bids.Add(1.123m, new ExchangeOrderPrice());
+            exchangeOrderBook.Bids.Add(0.24m, new ExchangeOrderPrice());
+            exchangeOrderBook.Bids.Add(2.85m, new ExchangeOrderPrice());
+
+            exchangeOrderBook.Bids.First().Key.Should().Be(2.85m);
+            exchangeOrderBook.Bids.Last().Key.Should().Be(0.24m);
+        }
+    }
+}


### PR DESCRIPTION
To make runtime of updating a delta socket O(updates) rather than O(bookSize*updates), I refactored ExchangeOrderBook Bids/Asks into SortedDictionaries with Asks sorted ascending and Bids sorted descending (worse prices deeper in the dictionary). This allowed us to remove some now superfluous order book sorting which will improve runtime on certain exchanges.