### PR TITLE
Allow Name to be settable by unit tests

### DIFF
--- a/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/ExchangeSharp/API/Common/BaseAPI.cs
@@ -129,7 +129,7 @@ namespace ExchangeSharp
         /// <summary>
         /// Gets the name of the API
         /// </summary>
-        public string Name { get; private set; }
+        public virtual string Name { get; private set; }
 
         /// <summary>
         /// Public API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!


### PR DESCRIPTION
To get through the switch (api.Name) in GetOrderBookWebSocket in a unit test, the test needs to be able to control the name of a mocked IExchangeAPI. Make virtual.

Note: The other option is to make the setter public, but this would be less clear that exchange name shouldn't/won't be changed at runtime.