### PR TITLE
Add option to include zero balances when calling GetMarginAmountsAvailableToTradeAsync

### DIFF
--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -651,7 +651,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync()
+        protected override async Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances)
         {
             Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
             var accountArgumentName = "account";
@@ -660,7 +660,7 @@ namespace ExchangeSharp
             foreach (JProperty child in result[accountArgumentValue].Children())
             {
                 decimal amount = child.Value.ConvertInvariant<decimal>();
-                if (amount > 0m)
+                if (amount > 0m || includeZeroBalances)
                 {
                     amounts[child.Name] = amount;
                 }

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -92,7 +92,7 @@ namespace ExchangeSharp
         protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null) => throw new NotImplementedException();
         protected virtual Task OnCancelOrderAsync(string orderId, string symbol = null) => throw new NotImplementedException();
         protected virtual Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest) => throw new NotImplementedException();
-        protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync() => throw new NotImplementedException();
+        protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances) => throw new NotImplementedException();
         protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string symbol) => throw new NotImplementedException();
         protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string symbol) => throw new NotImplementedException();
 
@@ -691,11 +691,12 @@ namespace ExchangeSharp
         /// <summary>
         /// Get margin amounts available to trade, symbol / amount dictionary
         /// </summary>
+        /// <param name="includeZeroBalances">Include currencies with zero balance in return value</param>
         /// <returns>Symbol / amount dictionary</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync()
+        public virtual async Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances = false)
         {
             await new SynchronizationContextRemover();
-            return await OnGetMarginAmountsAvailableToTradeAsync();
+            return await OnGetMarginAmountsAvailableToTradeAsync(includeZeroBalances);
         }
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -261,8 +261,9 @@ namespace ExchangeSharp
         /// <summary>
         /// Get margin amounts available to trade, symbol / amount dictionary
         /// </summary>
+        /// <param name="includeZeroBalances">Include currencies with zero balance in return value</param>
         /// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
-        Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync();
+        Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances = false);
 
         /// <summary>
         /// Get open margin position


### PR DESCRIPTION
I need to be able to get all margin amount available, even if they are 0.