### PR TITLE
Make cache optional

### DIFF
--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -402,27 +402,33 @@ namespace ExchangeSharp
         /// <summary>
         /// Get exchange symbols
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Array of symbols</returns>
-        public virtual async Task<IEnumerable<string>> GetSymbolsAsync()
+        public virtual async Task<IEnumerable<string>> GetSymbolsAsync(bool cacheResponse = true)
         {
             await new SynchronizationContextRemover();
-            return (await Cache.Get<string[]>(nameof(GetSymbolsAsync), async () =>
-            {
-                return new CachedItem<string[]>((await OnGetSymbolsAsync()).ToArray(), CryptoUtility.UtcNow.AddHours(1.0));
-            })).Value;
+            return cacheResponse
+                       ? (await Cache.Get<string[]>(
+                                  nameof(GetSymbolsAsync),
+                                  async () => new CachedItem<string[]>((await OnGetSymbolsAsync()).ToArray(), CryptoUtility.UtcNow.AddHours(1.0))
+                              )).Value
+                       : (await OnGetSymbolsAsync()).ToArray();
         }
 
         /// <summary>
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Collection of ExchangeMarkets</returns>
-        public virtual async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        public virtual async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync(bool cacheResponse = true)
         {
             await new SynchronizationContextRemover();
-            return (await Cache.Get<ExchangeMarket[]>(nameof(GetSymbolsMetadataAsync), async () =>
-            {
-                return new CachedItem<ExchangeMarket[]>((await OnGetSymbolsMetadataAsync()).ToArray(), CryptoUtility.UtcNow.AddHours(1.0));
-            })).Value;
+            return cacheResponse
+                       ? (await Cache.Get<ExchangeMarket[]>(
+                                  nameof(GetSymbolsMetadataAsync),
+                                  async () => new CachedItem<ExchangeMarket[]>((await OnGetSymbolsMetadataAsync()).ToArray(), CryptoUtility.UtcNow.AddHours(1.0))
+                              )).Value
+                       : (await OnGetSymbolsMetadataAsync()).ToArray();
         }
 
         /// <summary>
@@ -566,14 +572,17 @@ namespace ExchangeSharp
         /// <summary>
         /// Get total amounts, symbol / amount dictionary
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Dictionary of symbols and amounts</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetAmountsAsync()
+        public virtual async Task<Dictionary<string, decimal>> GetAmountsAsync(bool cacheResponse = false)
         {
             await new SynchronizationContextRemover();
-            return (await Cache.Get<Dictionary<string, decimal>>(nameof(GetAmountsAsync), async () =>
-            {
-                return new CachedItem<Dictionary<string, decimal>>((await OnGetAmountsAsync()), CryptoUtility.UtcNow.AddMinutes(1.0));
-            })).Value;
+            return cacheResponse
+                       ? (await Cache.Get<Dictionary<string, decimal>>(
+                                  nameof(GetAmountsAsync),
+                                  async () => new CachedItem<Dictionary<string, decimal>>((await OnGetAmountsAsync()), CryptoUtility.UtcNow.AddMinutes(1.0))
+                              )).Value
+                       : await OnGetAmountsAsync();
         }
 
         /// <summary>
@@ -589,14 +598,17 @@ namespace ExchangeSharp
         /// <summary>
         /// Get amounts available to trade, symbol / amount dictionary
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Symbol / amount dictionary</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+        public virtual async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync(bool cacheResponse = false)
         {
             await new SynchronizationContextRemover();
-            return (await Cache.Get<Dictionary<string, decimal>>(nameof(GetAmountsAvailableToTradeAsync), async () =>
-            {
-                return new CachedItem<Dictionary<string, decimal>>((await GetAmountsAvailableToTradeAsync()), CryptoUtility.UtcNow.AddMinutes(1.0));
-            })).Value;
+            return cacheResponse
+                       ? (await Cache.Get<Dictionary<string, decimal>>(
+                                  nameof(GetAmountsAvailableToTradeAsync),
+                                  async () => new CachedItem<Dictionary<string, decimal>>((await GetAmountsAvailableToTradeAsync()), CryptoUtility.UtcNow.AddMinutes(1.0))
+                              )).Value
+                       : await GetAmountsAvailableToTradeAsync();
         }
 
         /// <summary>
@@ -654,16 +666,19 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="symbol">Symbol to get completed orders for or null for all</param>
         /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null, bool cacheResponse = false)
         {
             await new SynchronizationContextRemover();
             symbol = NormalizeSymbol(symbol);
             string cacheKey = "GetCompletedOrderDetails_" + symbol + "_" + (afterDate == null ? string.Empty : afterDate.Value.Ticks.ToStringInvariant());
-            return (await Cache.Get<ExchangeOrderResult[]>(cacheKey, async () =>
-            {
-                return new CachedItem<ExchangeOrderResult[]>((await OnGetCompletedOrderDetailsAsync(symbol, afterDate)).ToArray(), CryptoUtility.UtcNow.AddMinutes(2.0));
-            })).Value;
+            return cacheResponse
+                       ? (await Cache.Get<ExchangeOrderResult[]>(
+                                  cacheKey,
+                                  async () => new CachedItem<ExchangeOrderResult[]>((await OnGetCompletedOrderDetailsAsync(symbol, afterDate)).ToArray(), CryptoUtility.UtcNow.AddMinutes(2.0))
+                              )).Value
+                       : (await OnGetCompletedOrderDetailsAsync(symbol, afterDate)).ToArray();
         }
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -154,14 +154,16 @@ namespace ExchangeSharp
         /// <summary>
         /// Get symbols for the exchange
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Symbols</returns>
-        Task<IEnumerable<string>> GetSymbolsAsync();
+        Task<IEnumerable<string>> GetSymbolsAsync(bool cacheResponse = true);
 
         /// <summary>
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Collection of ExchangeMarkets</returns>
-        Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync();
+        Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync(bool cacheResponse = true);
 
         /// <summary>
         /// Get latest ticker
@@ -206,14 +208,16 @@ namespace ExchangeSharp
         /// <summary>
         /// Get total amounts, symbol / amount dictionary
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Dictionary of symbols and amounts</returns>
-        Task<Dictionary<string, decimal>> GetAmountsAsync();
+        Task<Dictionary<string, decimal>> GetAmountsAsync(bool cacheResponse = false);
 
         /// <summary>
         /// Get amounts available to trade, symbol / amount dictionary
         /// </summary>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>Dictionary of symbols and amounts available to trade</returns>
-        Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync();
+        Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync(bool cacheResponse = false);
 
         /// <summary>
         /// Place an order
@@ -248,8 +252,9 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="symbol">Symbol to get completed orders for or null for all</param>
         /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
+        /// <param name="cacheResponse">Cache the response?</param>
         /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null);
+        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null, bool cacheResponse = false);
 
         /// <summary>
         /// Cancel an order, an exception is thrown if failure


### PR DESCRIPTION
I noticed that you added some forced caching into some of the methods. I'm not against having a caching mechanism available, but making it mandatory doesn't seem like the way to go. It should be up to the consumers of the library to specify if they need the calls cached or not.

That being said, in this code change I left the caching enabled by default on the GetSymbols methods because I'm pretty sure they've been that way for a while and I didn't want to break anyone's code. The other cache calls, however, are new so I thought it was best to leave the cache disabled by default.

Also, just a suggestion, but if you're going to include caching with the library, it would be better if the durations were configurable somehow instead of hard coded like they are now.