### PR TITLE
Allow user to set IWebSocket.ConnectInterval and KeepAlive

### DIFF
--- a/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -533,10 +533,20 @@ namespace ExchangeSharp
     /// </summary>
     public interface IWebSocket : IDisposable
     {
-        /// <summary>
-        /// Connected event
-        /// </summary>
-        event WebSocketConnectionDelegate Connected;
+		/// <summary>
+		/// Interval to call connect at regularly (default is 1 hour)
+		/// </summary>
+		TimeSpan ConnectInterval { get; set; }
+
+		/// <summary>
+		/// Keep alive interval (default varies by exchange)
+		/// </summary>
+		TimeSpan KeepAlive { get; set; }
+
+		/// <summary>
+		/// Connected event
+		/// </summary>
+		event WebSocketConnectionDelegate Connected;
 
         /// <summary>
         /// Disconnected event

--- a/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -171,15 +171,24 @@ namespace ExchangeSharp
         /// </summary>
         public TimeSpan ConnectInterval { get; set; } = TimeSpan.FromHours(1.0);
 
-        /// <summary>
-        /// Keep alive interval (default is 30 seconds)
-        /// </summary>
-        public TimeSpan KeepAlive { get; set; } = TimeSpan.FromSeconds(30.0);
+		private TimeSpan _keepAlive = TimeSpan.FromSeconds(30.0);
+		/// <summary>
+		/// Keep alive interval (default is 30 seconds)
+		/// </summary>
+		public TimeSpan KeepAlive
+		{
+			get { return _keepAlive; }
+			set
+			{
+				_keepAlive = value;
+				webSocket.KeepAliveInterval = value;
+			}
+		}
 
-        /// <summary>
-        /// Allows additional listeners for connect event
-        /// </summary>
-        public event WebSocketConnectionDelegate Connected;
+		/// <summary>
+		/// Allows additional listeners for connect event
+		/// </summary>
+		public event WebSocketConnectionDelegate Connected;
 
         /// <summary>
         /// Allows additional listeners for disconnect event

--- a/ExchangeSharp/Utility/SignalrManager.cs
+++ b/ExchangeSharp/Utility/SignalrManager.cs
@@ -47,10 +47,38 @@ namespace ExchangeSharp
             private string functionFullName;
             private bool disposed;
 
-            /// <summary>
-            /// Connected event
-            /// </summary>
-            public event WebSocketConnectionDelegate Connected;
+			private TimeSpan _connectInterval = TimeSpan.FromHours(1.0);
+			/// <summary>
+			/// Interval to call connect at regularly (default is 1 hour)
+			/// </summary>
+			public TimeSpan ConnectInterval
+			{
+				get { return _connectInterval; }
+				set
+				{
+					_connectInterval = value;
+					manager.ConnectInterval = value;
+				}
+			}
+
+			private TimeSpan _keepAlive = TimeSpan.FromSeconds(5.0);
+			/// <summary>
+			/// Keep alive interval (default is 5 seconds)
+			/// </summary>
+			public TimeSpan KeepAlive
+			{
+				get { return _keepAlive; }
+				set
+				{
+					_keepAlive = value;
+					manager.KeepAlive = value;
+				}
+			}
+
+			/// <summary>
+			/// Connected event
+			/// </summary>
+			public event WebSocketConnectionDelegate Connected;
 
             /// <summary>
             /// Disconnected event
@@ -202,12 +230,17 @@ namespace ExchangeSharp
         {
             private IConnection connection;
             private string connectionData;
-            public ExchangeSharp.ClientWebSocket WebSocket { get; private set; }
+			TimeSpan connectInterval;
+			TimeSpan keepAlive;
+			public ExchangeSharp.ClientWebSocket WebSocket { get; private set; }
 
             public override bool SupportsKeepAlive => true;
 
-            public WebsocketCustomTransport(IHttpClient client) : base(client, "webSockets")
+            public WebsocketCustomTransport(IHttpClient client, TimeSpan connectInterval, TimeSpan keepAlive) 
+				: base(client, "webSockets")
             {
+				this.connectInterval = connectInterval;
+				this.keepAlive = keepAlive;
                 WebSocket = new ExchangeSharp.ClientWebSocket();
             }
 
@@ -239,7 +272,8 @@ namespace ExchangeSharp
                 WebSocket.Uri = new Uri(connectUrl);
                 WebSocket.OnBinaryMessage = WebSocketOnBinaryMessageReceived;
                 WebSocket.OnTextMessage = WebSocketOnTextMessageReceived;
-                WebSocket.KeepAlive = TimeSpan.FromSeconds(5.0);
+				WebSocket.ConnectInterval = connectInterval;
+                WebSocket.KeepAlive = keepAlive;         
                 WebSocket.Start();
             }
 
@@ -313,14 +347,45 @@ namespace ExchangeSharp
         private readonly List<SignalrSocketConnection> sockets = new List<SignalrSocketConnection>();
         private readonly SemaphoreSlim reconnectLock = new SemaphoreSlim(1);
 
-        private HubConnection hubConnection;
+		private WebsocketCustomTransport customTransport;
+		private HubConnection hubConnection;
         private IHubProxy hubProxy;
         private bool disposed;
 
-        /// <summary>
-        /// Connection url
-        /// </summary>
-        public string ConnectionUrl { get; private set; }
+		private TimeSpan _connectInterval = TimeSpan.FromHours(1.0);
+		/// <summary>
+		/// Interval to call connect at regularly (default is 1 hour)
+		/// </summary>
+		public TimeSpan ConnectInterval
+		{
+			get { return _connectInterval; }
+			set
+			{
+				_connectInterval = value;
+				if (customTransport != null)
+					customTransport.WebSocket.ConnectInterval = value;
+			}
+		}
+
+		private TimeSpan _keepAlive = TimeSpan.FromSeconds(5.0);
+		/// <summary>
+		/// Keep alive interval (default is 5 seconds)
+		/// </summary>
+		public TimeSpan KeepAlive
+		{
+			get { return _keepAlive; }
+			set
+			{
+				_keepAlive = value;
+				if (customTransport != null)
+					customTransport.WebSocket.KeepAlive = value;
+			}
+		}
+
+		/// <summary>
+		/// Connection url
+		/// </summary>
+		public string ConnectionUrl { get; private set; }
 
         /// <summary>
         /// Hub name
@@ -505,7 +570,7 @@ namespace ExchangeSharp
 
             // create a custom transport, the default transport is really buggy
             DefaultHttpClient client = new DefaultHttpClient();
-            WebsocketCustomTransport customTransport = new WebsocketCustomTransport(client);
+            customTransport = new WebsocketCustomTransport(client, ConnectInterval, KeepAlive);
             var autoTransport = new AutoTransport(client, new IClientTransport[] { customTransport });
             hubConnection.TransportConnectTimeout = hubConnection.DeadlockErrorTimeout = TimeSpan.FromSeconds(10.0);
 


### PR DESCRIPTION
This would allow users to set IWebSocket.ConnectInterval and KeepAlive, such as below:

```c#
			var exchangeAPI = new ExchangeBittrexAPI();
			var tempSymbols = await exchangeAPI.GetSymbolsMetadataAsync();
			using (var socket = exchangeAPI.GetTradesWebSocket(kvp =>
				{
					Console.WriteLine($"{kvp.Key}, {kvp.Value}");
				}, new string[] { "USDT-BTC", "BTC-LTC", "BTC-ETH" }))
			{
				socket.ConnectInterval = TimeSpan.FromDays(0);
				socket.Connected += async s =>
					Console.WriteLine("connected");
				socket.Disconnected += async s => Console.WriteLine("disconnected");
				Console.WriteLine("Press ENTER to shutdown.");
				Console.ReadLine();
			}
```