### PR TITLE
Fix null ref exception when using tickers web socket on Bittrex

### DIFF
--- a/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -180,9 +180,8 @@ namespace ExchangeSharp
 			get { return _keepAlive; }
 			set
 			{
-				_keepAlive = value;
-                if(webSocket != null)
-				    webSocket.KeepAliveInterval = value;
+			    _keepAlive = value;
+                            webSocket?.KeepAliveInterval = value;
 			}
 		}
 

--- a/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -181,7 +181,8 @@ namespace ExchangeSharp
 			set
 			{
 				_keepAlive = value;
-				webSocket.KeepAliveInterval = value;
+                if(webSocket != null)
+				    webSocket.KeepAliveInterval = value;
 			}
 		}
 


### PR DESCRIPTION
This was caused by the [most recent commit](https://github.com/jjxtra/ExchangeSharp/commit/83370161aac858e8d74068f31a3e0287771a3ce7).