### PR TITLE
Fix inconsistent naming

### DIFF
--- a/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
@@ -390,21 +390,21 @@ namespace ExchangeSharp
             return deposits;
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             var payload = await GetNoncePayloadAsync();
             JArray array = await MakeJsonRequestAsync<JArray>("/payment-methods", null, await GetNoncePayloadAsync());
             if (array != null)
             {
-                var rc = array.Where(t => t["currency"].ToStringInvariant() == symbol).FirstOrDefault();
+                var rc = array.Where(t => t["currency"].ToStringInvariant() == currency).FirstOrDefault();
                 payload = await GetNoncePayloadAsync();
-                payload["currency"] = symbol;
+                payload["currency"] = currency;
                 payload["method"] = rc["id"].ToStringInvariant();
 
                 JToken token = await MakeJsonRequestAsync<JToken>("/deposits/make", null, payload, "POST");
                 ExchangeDepositDetails deposit = new ExchangeDepositDetails()
                 {
-                    Symbol = symbol,
+                    Currency = currency,
                     Address = token["address"].ToStringInvariant(),
                     AddressTag = token["tag"].ToStringInvariant()
                 };

--- a/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
@@ -359,7 +359,7 @@ namespace ExchangeSharp
             await MakeJsonRequestAsync<JArray>("/orders/" + orderId, null, await GetNoncePayloadAsync(), "DELETE");
         }
 
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> deposits = new List<ExchangeTransaction>();
 
@@ -373,7 +373,7 @@ namespace ExchangeSharp
             {
                 ExchangeTransaction deposit = new ExchangeTransaction()
                 {
-                    Symbol = token["currency"].ToStringInvariant(),
+                    Currency = token["currency"].ToStringInvariant(),
                     Amount = token["amount"].ConvertInvariant<decimal>(),
                     Timestamp = token["date"].ToDateTimeInvariant(),
                     PaymentId = token["deposit_id"].ToStringInvariant(),
@@ -385,7 +385,7 @@ namespace ExchangeSharp
                     case "pending": deposit.Status = TransactionStatus.Processing; break;
                     default: deposit.Status = TransactionStatus.AwaitingApproval; break;
                 }
-                if (deposit.Symbol == symbol) deposits.Add(deposit);
+                if (deposit.Currency == currency) deposits.Add(deposit);
             }
             return deposits;
         }

--- a/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Abucoins/ExchangeAbucoinsAPI.cs
@@ -82,20 +82,17 @@ namespace ExchangeSharp
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             JToken obj = await MakeJsonRequestAsync<JToken>("/products");
-            const decimal StepSize = 0.00000001m;
             foreach (JToken token in obj)
             {
                 markets.Add(new ExchangeMarket
                 {
                     MarketName = token["id"].ToStringInvariant(),
                     BaseCurrency = token["base_currency"].ToStringInvariant(),
-                    MarketCurrency = token["quote_currency"].ToStringInvariant(),
+                    QuoteCurrency = token["quote_currency"].ToStringInvariant(),
                     MinTradeSize = token["base_min_size"].ConvertInvariant<decimal>(),
                     MaxTradeSize = token["base_max_size"].ConvertInvariant<decimal>(),
-                    QuantityStepSize = token["quote_increment"].ConvertInvariant<decimal>(),
-                    MaxPrice = StepSize,
-                    MinPrice = StepSize,
-                    PriceStepSize = StepSize,
+                    PriceStepSize = token["quote_increment"].ConvertInvariant<decimal>(),
+                    MinPrice = token["quote_increment"].ConvertInvariant<decimal>(),
                     IsActive = true
                 });
             }

--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -905,12 +905,12 @@ namespace ExchangeSharp
         /// <summary>
         /// Gets the address to deposit to and applicable details.
         /// </summary>
-        /// <param name="symbol">Symbol to get address for</param>
+        /// <param name="currency">Currency to get address for</param>
         /// <param name="forceRegenerate">(ignored) Binance does not provide the ability to generate new addresses</param>
         /// <returns>
         /// Deposit address details (including tag if applicable, such as XRP)
         /// </returns>
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             /* 
             * TODO: Binance does not offer a "regenerate" option in the API, but a second IOTA deposit to the same address will not be credited
@@ -919,12 +919,12 @@ namespace ExchangeSharp
             */
 
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["asset"] = symbol;
+            payload["asset"] = currency;
 
             JToken response = await MakeJsonRequestAsync<JToken>("/depositAddress.html", WithdrawalUrlPrivate, payload);
             ExchangeDepositDetails depositDetails = new ExchangeDepositDetails
             {
-                Symbol = response["asset"].ToStringInvariant(),
+                Currency = response["asset"].ToStringInvariant(),
                 Address = response["address"].ToStringInvariant(),
                 AddressTag = response["addressTag"].ToStringInvariant()
             };

--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -250,7 +250,7 @@ namespace ExchangeSharp
                 foreach (JToken childToken in token["data"])
                 {
                     ticker = ParseTickerWebSocket(childToken);
-                    tickerList.Add(new KeyValuePair<string, ExchangeTicker>(ticker.Volume.BaseSymbol, ticker));
+                    tickerList.Add(new KeyValuePair<string, ExchangeTicker>(ticker.Volume.QuoteCurrency, ticker));
                 }
                 if (tickerList.Count != 0)
                 {

--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -117,38 +117,40 @@ namespace ExchangeSharp
         {
             /*
              *         {
-            "symbol": "QTUMETH",
-            "status": "TRADING",
-            "baseAsset": "QTUM",
-            "baseAssetPrecision": 8,
-            "quoteAsset": "ETH",
-            "quotePrecision": 8,
-            "orderTypes": [
-                "LIMIT",
-                "LIMIT_MAKER",
-                "MARKET",
-                "STOP_LOSS_LIMIT",
-                "TAKE_PROFIT_LIMIT"
-            ],
-            "icebergAllowed": true,
-            "filters": [
-                {
-                    "filterType": "PRICE_FILTER",
-                    "minPrice": "0.00000100",
-                    "maxPrice": "100000.00000000",
-                    "tickSize": "0.00000100"
-                },
-                {
-                    "filterType": "LOT_SIZE",
-                    "minQty": "0.01000000",
-                    "maxQty": "90000000.00000000",
-                    "stepSize": "0.01000000"
-                },
-                {
-                    "filterType": "MIN_NOTIONAL",
-                    "minNotional": "0.01000000"
-                }
-            ]
+                "symbol": "ETHBTC",
+                "status": "TRADING",
+                "baseAsset": "ETH",
+                "baseAssetPrecision": 8,
+                "quoteAsset": "BTC",
+                "quotePrecision": 8,
+                "orderTypes": [
+                    "LIMIT",
+                    "MARKET",
+                    "STOP_LOSS",
+                    "STOP_LOSS_LIMIT",
+                    "TAKE_PROFIT",
+                    "TAKE_PROFIT_LIMIT",
+                    "LIMIT_MAKER"
+                ],
+                "icebergAllowed": false,
+                "filters": [
+                    {
+                        "filterType": "PRICE_FILTER",
+                        "minPrice": "0.00000100",
+                        "maxPrice": "100000.00000000",
+                        "tickSize": "0.00000100"
+                    }, 
+                    {
+                        "filterType": "LOT_SIZE",
+                        "minQty": "0.00100000",
+                        "maxQty": "100000.00000000",
+                        "stepSize": "0.00100000"
+                    }, 
+                    {
+                        "filterType": "MIN_NOTIONAL",
+                        "minNotional": "0.00100000"
+                    }
+                ]
         },
              */
 
@@ -161,8 +163,8 @@ namespace ExchangeSharp
                 {
                     MarketName = symbol["symbol"].ToStringUpperInvariant(),
                     IsActive = ParseMarketStatus(symbol["status"].ToStringUpperInvariant()),
-                    BaseCurrency = symbol["quoteAsset"].ToStringUpperInvariant(),
-                    MarketCurrency = symbol["baseAsset"].ToStringUpperInvariant()
+                    QuoteCurrency = symbol["quoteAsset"].ToStringUpperInvariant(),
+                    BaseCurrency = symbol["baseAsset"].ToStringUpperInvariant()
                 };
 
                 // "LOT_SIZE"
@@ -182,6 +184,13 @@ namespace ExchangeSharp
                     market.MaxPrice = priceFilter["maxPrice"].ConvertInvariant<decimal>();
                     market.MinPrice = priceFilter["minPrice"].ConvertInvariant<decimal>();
                     market.PriceStepSize = priceFilter["tickSize"].ConvertInvariant<decimal>();
+                }
+
+                // MIN_NOTIONAL
+                JToken minNotionalFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "MIN_NOTIONAL"));
+                if (minNotionalFilter != null)
+                {
+                    market.MinTradeSizeInQuoteCurrency = minNotionalFilter["minNotional"].ConvertInvariant<decimal>();
                 }
                 markets.Add(market);
             }
@@ -688,11 +697,12 @@ namespace ExchangeSharp
                 switch (status)
                 {
                     case "TRADING":
-                    case "PRE_TRADING":
-                    case "POST_TRADING":
                         isActive = true;
                         break;
-                        /* case "END_OF_DAY":
+                        /* 
+                            case "PRE_TRADING":
+                            case "POST_TRADING":
+                            case "END_OF_DAY":
                             case "HALT":
                             case "AUCTION_MATCH":
                             case "BREAK": */

--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -44,18 +44,18 @@ namespace ExchangeSharp
             };
         }
 
-        private string GetWebSocketStreamUrlForSymbols(string suffix, params string[] symbols)
+        private string GetWebSocketStreamUrlForSymbols(string suffix, params string[] marketSymbols)
         {
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = GetSymbolsAsync().Sync().ToArray();
+                marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
 
             StringBuilder streams = new StringBuilder("/stream?streams=");
-            for (int i = 0; i < symbols.Length; i++)
+            for (int i = 0; i < marketSymbols.Length; i++)
             {
-                string symbol = NormalizeSymbol(symbols[i]).ToLowerInvariant();
-                streams.Append(symbol);
+                string marketSymbol = NormalizeMarketSymbol(marketSymbols[i]).ToLowerInvariant();
+                streams.Append(marketSymbol);
                 streams.Append(suffix);
                 streams.Append('/');
             }
@@ -70,39 +70,39 @@ namespace ExchangeSharp
             RequestWindow = TimeSpan.FromMinutes(15.0);
             NonceStyle = NonceStyle.UnixMilliseconds;
             NonceOffset = TimeSpan.FromSeconds(10.0);
-            SymbolSeparator = string.Empty;
+            MarketSymbolSeparator = string.Empty;
             WebSocketOrderBookType = WebSocketOrderBookType.DeltasOnly;
         }
 
-        public override string ExchangeSymbolToGlobalSymbol(string symbol)
+        public override string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
             // All pairs in Binance end with BTC, ETH, BNB or USDT
-            if (symbol.EndsWith("BTC") || symbol.EndsWith("ETH") || symbol.EndsWith("BNB"))
+            if (marketSymbol.EndsWith("BTC") || marketSymbol.EndsWith("ETH") || marketSymbol.EndsWith("BNB"))
             {
-                string baseSymbol = symbol.Substring(symbol.Length - 3);
-                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Replace(baseSymbol, "") + GlobalSymbolSeparator + baseSymbol), GlobalSymbolSeparator);
+                string baseSymbol = marketSymbol.Substring(marketSymbol.Length - 3);
+                return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator((marketSymbol.Replace(baseSymbol, "") + GlobalMarketSymbolSeparator + baseSymbol), GlobalMarketSymbolSeparator);
             }
-            if (symbol.EndsWith("USDT"))
+            if (marketSymbol.EndsWith("USDT"))
             {
-                string baseSymbol = symbol.Substring(symbol.Length - 4);
-                return ExchangeSymbolToGlobalSymbolWithSeparator((symbol.Replace(baseSymbol, "") + GlobalSymbolSeparator + baseSymbol), GlobalSymbolSeparator);
+                string baseSymbol = marketSymbol.Substring(marketSymbol.Length - 4);
+                return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator((marketSymbol.Replace(baseSymbol, "") + GlobalMarketSymbolSeparator + baseSymbol), GlobalMarketSymbolSeparator);
             }
 
-            return ExchangeSymbolToGlobalSymbolWithSeparator(symbol.Substring(0, symbol.Length - 3) + GlobalSymbolSeparator + (symbol.Substring(symbol.Length - 3, 3)), GlobalSymbolSeparator);
+            return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(marketSymbol.Substring(0, marketSymbol.Length - 3) + GlobalMarketSymbolSeparator + (marketSymbol.Substring(marketSymbol.Length - 3, 3)), GlobalMarketSymbolSeparator);
         }
 
         /// <summary>
         /// Get the details of all trades
         /// </summary>
-        /// <param name="symbol">Symbol to get trades for or null for all</param>
+        /// <param name="marketSymbol">Symbol to get trades for or null for all</param>
         /// <returns>All trades for the specified symbol, or all if null symbol</returns>
-        public async Task<IEnumerable<ExchangeOrderResult>> GetMyTradesAsync(string symbol = null, DateTime? afterDate = null)
+        public async Task<IEnumerable<ExchangeOrderResult>> GetMyTradesAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             await new SynchronizationContextRemover();
-            return await OnGetMyTradesAsync(symbol, afterDate);
+            return await OnGetMyTradesAsync(marketSymbol, afterDate);
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/allPrices");
@@ -113,7 +113,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             /*
              *         {
@@ -157,18 +157,18 @@ namespace ExchangeSharp
             var markets = new List<ExchangeMarket>();
             JToken obj = await MakeJsonRequestAsync<JToken>("/exchangeInfo");
             JToken allSymbols = obj["symbols"];
-            foreach (JToken symbol in allSymbols)
+            foreach (JToken marketSymbolToken in allSymbols)
             {
                 var market = new ExchangeMarket
                 {
-                    MarketName = symbol["symbol"].ToStringUpperInvariant(),
-                    IsActive = ParseMarketStatus(symbol["status"].ToStringUpperInvariant()),
-                    QuoteCurrency = symbol["quoteAsset"].ToStringUpperInvariant(),
-                    BaseCurrency = symbol["baseAsset"].ToStringUpperInvariant()
+                    MarketSymbol = marketSymbolToken["symbol"].ToStringUpperInvariant(),
+                    IsActive = ParseMarketStatus(marketSymbolToken["status"].ToStringUpperInvariant()),
+                    QuoteCurrency = marketSymbolToken["quoteAsset"].ToStringUpperInvariant(),
+                    BaseCurrency = marketSymbolToken["baseAsset"].ToStringUpperInvariant()
                 };
 
                 // "LOT_SIZE"
-                JToken filters = symbol["filters"];
+                JToken filters = marketSymbolToken["filters"];
                 JToken lotSizeFilter = filters?.FirstOrDefault(x => string.Equals(x["filterType"].ToStringUpperInvariant(), "LOT_SIZE"));
                 if (lotSizeFilter != null)
                 {
@@ -221,21 +221,21 @@ namespace ExchangeSharp
             return allCoins;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr?symbol=" + symbol);
-            return ParseTicker(symbol, obj);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr?symbol=" + marketSymbol);
+            return ParseTicker(marketSymbol, obj);
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            string symbol;
+            string marketSymbol;
             JToken obj = await MakeJsonRequestAsync<JToken>("/ticker/24hr");
             foreach (JToken child in obj)
             {
-                symbol = child["symbol"].ToStringInvariant();
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTicker(symbol, child)));
+                marketSymbol = child["symbol"].ToStringInvariant();
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ParseTicker(marketSymbol, child)));
             }
             return tickers;
         }
@@ -260,7 +260,7 @@ namespace ExchangeSharp
             });
         }
 
-        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             /*
             {
@@ -278,38 +278,38 @@ namespace ExchangeSharp
             }
             */
 
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = GetSymbolsAsync().Sync().ToArray();
+                marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
-            string url = GetWebSocketStreamUrlForSymbols("@trade", symbols);
+            string url = GetWebSocketStreamUrlForSymbols("@trade", marketSymbols);
             return ConnectWebSocket(url, (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
                 string name = token["stream"].ToStringInvariant();
                 token = token["data"];
-                string symbol = NormalizeSymbol(name.Substring(0, name.IndexOf('@')));
+                string marketSymbol = NormalizeMarketSymbol(name.Substring(0, name.IndexOf('@')));
 
                 // buy=0 -> m = true (The buyer is maker, while the seller is taker).
                 // buy=1 -> m = false(The seller is maker, while the buyer is taker).
-                callback(new KeyValuePair<string, ExchangeTrade>(symbol, token.ParseTrade("q", "p", "m", "E", TimestampType.UnixMilliseconds, "t", "false")));
+                callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, token.ParseTrade("q", "p", "m", "E", TimestampType.UnixMilliseconds, "t", "false")));
                 return Task.CompletedTask;
             });
         }
 
-        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = GetSymbolsAsync().Sync().ToArray();
+                marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
-            string combined = string.Join("/", symbols.Select(s => this.NormalizeSymbol(s).ToLowerInvariant() + "@depth"));
+            string combined = string.Join("/", marketSymbols.Select(s => this.NormalizeMarketSymbol(s).ToLowerInvariant() + "@depth"));
             return ConnectWebSocket($"/stream?streams={combined}", (_socket, msg) =>
             {
                 string json = msg.ToStringFromUTF8();
                 var update = JsonConvert.DeserializeObject<MultiDepthStream>(json);
-                string symbol = update.Data.Symbol;
-                ExchangeOrderBook book = new ExchangeOrderBook { SequenceId = update.Data.FinalUpdate, Symbol = symbol };
+                string marketSymbol = update.Data.MarketSymbol;
+                ExchangeOrderBook book = new ExchangeOrderBook { SequenceId = update.Data.FinalUpdate, MarketSymbol = marketSymbol };
                 foreach (List<object> ask in update.Data.Asks)
                 {
                     var depth = new ExchangeOrderPrice { Price = ask[0].ConvertInvariant<decimal>(), Amount = ask[1].ConvertInvariant<decimal>() };
@@ -325,13 +325,13 @@ namespace ExchangeSharp
             });
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/depth?symbol=" + symbol + "&limit=" + maxCount);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/depth?symbol=" + marketSymbol + "&limit=" + maxCount);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj, sequence: "lastUpdateId", maxCount: maxCount);
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             /* [ {
             "a": 26129,         // Aggregate tradeId
@@ -350,14 +350,14 @@ namespace ExchangeSharp
                 EndDate = endDate,
                 ParseFunction = (JToken token) => token.ParseTrade("q", "p", "m", "T", TimestampType.UnixMilliseconds, "a", "false"),
                 StartDate = startDate,
-                Symbol = symbol,
+                MarketSymbol = marketSymbol,
                 TimestampFunction = (DateTime dt) => ((long)CryptoUtility.UnixTimestampFromDateTimeMilliseconds(dt)).ToStringInvariant(),
-                Url = "/aggTrades?symbol=[symbol]&startTime={0}&endTime={1}",
+                Url = "/aggTrades?symbol=[marketSymbol]&startTime={0}&endTime={1}",
             };
             await state.ProcessHistoricalTrades();
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /* [
             [
@@ -376,7 +376,7 @@ namespace ExchangeSharp
 		    ]] */
 
             List<MarketCandle> candles = new List<MarketCandle>();
-            string url = "/klines?symbol=" + symbol;
+            string url = "/klines?symbol=" + marketSymbol;
             if (startDate != null)
             {
                 url += "&startTime=" + (long)startDate.Value.UnixTimestampFromDateTimeMilliseconds();
@@ -390,7 +390,7 @@ namespace ExchangeSharp
             JToken obj = await MakeJsonRequestAsync<JToken>(url);
             foreach (JToken token in obj)
             {
-                candles.Add(this.ParseCandle(token, symbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixMilliseconds, 5, 7));
+                candles.Add(this.ParseCandle(token, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixMilliseconds, 5, 7));
             }
 
             return candles;
@@ -429,7 +429,7 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["symbol"] = order.Symbol;
+            payload["symbol"] = order.MarketSymbol;
             payload["side"] = order.IsBuy ? "BUY" : "SELL";
             if (order.OrderType == OrderType.Stop)
                 payload["type"] = "STOP_LOOSE";//if order type is stop loose/limit, then binance expect word 'STOP_LOOSE' inestead of 'STOP'
@@ -437,8 +437,8 @@ namespace ExchangeSharp
                 payload["type"] = order.OrderType.ToStringUpperInvariant();
 
             // Binance has strict rules on which prices and quantities are allowed. They have to match the rules defined in the market definition.
-            decimal outputQuantity = await ClampOrderQuantity(order.Symbol, order.Amount);
-            decimal outputPrice = await ClampOrderPrice(order.Symbol, order.Price);
+            decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
 
             // Binance does not accept quantities with more than 20 decimal places.
             payload["quantity"] = Math.Round(outputQuantity, 20);
@@ -455,21 +455,21 @@ namespace ExchangeSharp
             return ParseOrder(token);
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (string.IsNullOrEmpty(symbol))
+            if (string.IsNullOrEmpty(marketSymbol))
             {
                 throw new InvalidOperationException("Binance single order details request requires symbol");
             }
-            payload["symbol"] = symbol;
+            payload["symbol"] = marketSymbol;
             payload["orderId"] = orderId;
             JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrlPrivate, payload);
             ExchangeOrderResult result = ParseOrder(token);
 
             // Add up the fees from each trade in the order
             Dictionary<string, object> feesPayload = await GetNoncePayloadAsync();
-            feesPayload["symbol"] = symbol;
+            feesPayload["symbol"] = marketSymbol;
             JToken feesToken = await MakeJsonRequestAsync<JToken>("/myTrades", BaseUrlPrivate, feesPayload);
             ParseFees(feesToken, result);
 
@@ -497,13 +497,13 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (symbol.Length != 0)
+            if (marketSymbol.Length != 0)
             {
-                payload["symbol"] = symbol;
+                payload["symbol"] = marketSymbol;
             }
             JToken token = await MakeJsonRequestAsync<JToken>("/openOrders", BaseUrlPrivate, payload);
             foreach (JToken order in token)
@@ -520,7 +520,7 @@ namespace ExchangeSharp
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Exception ex = null;
             string failedSymbol = null;
-            Parallel.ForEach((await GetSymbolsAsync()).Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), async (s) =>
+            Parallel.ForEach((await GetMarketSymbolsAsync()).Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), async (s) =>
             {
                 try
                 {
@@ -552,17 +552,17 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
                 orders.AddRange(await GetCompletedOrdersForAllSymbolsAsync(afterDate));
             }
             else
             {
                 Dictionary<string, object> payload = await GetNoncePayloadAsync();
-                payload["symbol"] = symbol;
+                payload["symbol"] = marketSymbol;
                 if (afterDate != null)
                 {
                     payload["startTime"] = afterDate.Value.UnixTimestampFromDateTimeMilliseconds();
@@ -582,7 +582,7 @@ namespace ExchangeSharp
             List<ExchangeOrderResult> trades = new List<ExchangeOrderResult>();
             Exception ex = null;
             string failedSymbol = null;
-            Parallel.ForEach((await GetSymbolsAsync()).Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), async (s) =>
+            Parallel.ForEach((await GetMarketSymbolsAsync()).Where(s => s.IndexOf("BTC", StringComparison.OrdinalIgnoreCase) >= 0), async (s) =>
             {
                 try
                 {
@@ -614,17 +614,17 @@ namespace ExchangeSharp
             return trades;
         }
 
-        private async Task<IEnumerable<ExchangeOrderResult>> OnGetMyTradesAsync(string symbol = null, DateTime? afterDate = null)
+        private async Task<IEnumerable<ExchangeOrderResult>> OnGetMyTradesAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> trades = new List<ExchangeOrderResult>();
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
                 trades.AddRange(await GetCompletedOrdersForAllSymbolsAsync(afterDate));
             }
             else
             {
                 Dictionary<string, object> payload = await GetNoncePayloadAsync();
-                payload["symbol"] = symbol;
+                payload["symbol"] = marketSymbol;
                 if (afterDate != null)
                 {
                     payload["timestamp"] = afterDate.Value.UnixTimestampFromDateTimeMilliseconds();
@@ -632,20 +632,20 @@ namespace ExchangeSharp
                 JToken token = await MakeJsonRequestAsync<JToken>("/myTrades", BaseUrlPrivate, payload);
                 foreach (JToken trade in token)
                 {
-                    trades.Add(ParseTrade(trade, symbol));
+                    trades.Add(ParseTrade(trade, marketSymbol));
                 }
             }
             return trades;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
                 throw new InvalidOperationException("Binance cancel order request requires symbol");
             }
-            payload["symbol"] = symbol;
+            payload["symbol"] = marketSymbol;
             payload["orderId"] = orderId;
             JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrlPrivate, payload, "DELETE");
         }
@@ -720,8 +720,8 @@ namespace ExchangeSharp
 
         private ExchangeTicker ParseTickerWebSocket(JToken token)
         {
-            string symbol = token["s"].ToStringInvariant();
-            return this.ParseTicker(token, symbol, "a", "b", "c", "v", "q", "E", TimestampType.UnixMilliseconds);
+            string marketSymbol = token["s"].ToStringInvariant();
+            return this.ParseTicker(token, marketSymbol, "a", "b", "c", "v", "q", "E", TimestampType.UnixMilliseconds);
         }
 
         private ExchangeOrderResult ParseOrder(JToken token)
@@ -779,7 +779,7 @@ namespace ExchangeSharp
                 IsBuy = token["side"].ToStringInvariant() == "BUY",
                 OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(token["time"].ConvertInvariant<long>(token["transactTime"].ConvertInvariant<long>())),
                 OrderId = token["orderId"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant()
+                MarketSymbol = token["symbol"].ToStringInvariant()
             };
 
             switch (token["status"].ToStringInvariant())
@@ -843,7 +843,7 @@ namespace ExchangeSharp
                 OrderId = token["orderId"].ToStringInvariant(),
                 Fees = token["commission"].ConvertInvariant<decimal>(),
                 FeesCurrency = token["commissionAsset"].ToStringInvariant(),
-                Symbol = symbol
+                MarketSymbol = symbol
             };
 
             return result;
@@ -933,7 +933,7 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="currency">The symbol to check. Null for all symbols.</param>
+        /// <param name="currency">The currency to check. Null for all symbols.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
         protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {

--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -933,15 +933,15 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="symbol">The symbol to check. Null for all symbols.</param>
+        /// <param name="currency">The symbol to check. Null for all symbols.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             // TODO: API supports searching on status, startTime, endTime
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (symbol.Length != 0)
+            if (currency.Length != 0)
             {
-                payload["asset"] = symbol;
+                payload["asset"] = currency;
             }
 
             JToken response = await MakeJsonRequestAsync<JToken>("/depositHistory.html", WithdrawalUrlPrivate, payload);
@@ -952,7 +952,7 @@ namespace ExchangeSharp
                 {
                     Timestamp = token["insertTime"].ConvertInvariant<double>().UnixTimeStampToDateTimeMilliseconds(),
                     Amount = token["amount"].ConvertInvariant<decimal>(),
-                    Symbol = token["asset"].ToStringUpperInvariant(),
+                    Currency = token["asset"].ToStringUpperInvariant(),
                     Address = token["address"].ToStringInvariant(),
                     AddressTag = token["addressTag"].ToStringInvariant(),
                     BlockchainTxId = token["txId"].ToStringInvariant()

--- a/ExchangeSharp/API/Exchanges/Binance/Models/MarketDepthDiffUpdate.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/Models/MarketDepthDiffUpdate.cs
@@ -25,7 +25,7 @@ namespace ExchangeSharp.Binance
         public long EventTime { get; set; }
 
         [JsonProperty("s")]
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
 
         [JsonProperty("U")]
         public int FirstUpdate { get; set; }

--- a/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -201,8 +201,8 @@ namespace ExchangeSharp
                 {
                     MarketName = symbol["symbol"].ToStringUpperInvariant(),
                     IsActive = symbol["status"].ToStringInvariant().EqualsWithOption("Open"),
-                    BaseCurrency = symbol["quoteCurrency"].ToStringUpperInvariant(),
-                    MarketCurrency = symbol["underlying"].ToStringUpperInvariant(),
+                    QuoteCurrency = symbol["quoteCurrency"].ToStringUpperInvariant(),
+                    BaseCurrency = symbol["underlying"].ToStringUpperInvariant(),
                 };
 
                 try

--- a/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -42,19 +42,19 @@ namespace ExchangeSharp
             // this will give us an api-expires 60 seconds into the future
             NonceOffset = TimeSpan.FromSeconds(-60.0);
 
-            SymbolSeparator = string.Empty;
+            MarketSymbolSeparator = string.Empty;
             RequestContentType = "application/json";
             WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
 
             RateLimit = new RateGate(300, TimeSpan.FromMinutes(5));
         }
 
-        public override string ExchangeSymbolToGlobalSymbol(string symbol)
+        public override string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
             throw new NotImplementedException();
         }
 
-        public override string GlobalSymbolToExchangeSymbol(string symbol)
+        public override string GlobalMarketSymbolToExchangeMarketSymbol(string marketSymbol)
         {
             throw new NotImplementedException();
         }
@@ -78,14 +78,14 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
-            var m = await GetSymbolsMetadataAsync();
-            return m.Select(x => x.MarketName);
+            var m = await GetMarketSymbolsMetadataAsync();
+            return m.Select(x => x.MarketSymbol);
         }
 
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             /*
              {{
@@ -195,23 +195,23 @@ namespace ExchangeSharp
 
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             JToken allSymbols = await MakeJsonRequestAsync<JToken>("/instrument");
-            foreach (JToken symbol in allSymbols)
+            foreach (JToken marketSymbolToken in allSymbols)
             {
                 var market = new ExchangeMarket
                 {
-                    MarketName = symbol["symbol"].ToStringUpperInvariant(),
-                    IsActive = symbol["status"].ToStringInvariant().EqualsWithOption("Open"),
-                    QuoteCurrency = symbol["quoteCurrency"].ToStringUpperInvariant(),
-                    BaseCurrency = symbol["underlying"].ToStringUpperInvariant(),
+                    MarketSymbol = marketSymbolToken["symbol"].ToStringUpperInvariant(),
+                    IsActive = marketSymbolToken["status"].ToStringInvariant().EqualsWithOption("Open"),
+                    QuoteCurrency = marketSymbolToken["quoteCurrency"].ToStringUpperInvariant(),
+                    BaseCurrency = marketSymbolToken["underlying"].ToStringUpperInvariant(),
                 };
 
                 try
                 {
-                    market.PriceStepSize = symbol["tickSize"].ConvertInvariant<decimal>();
-                    market.MaxPrice = symbol["maxPrice"].ConvertInvariant<decimal>();
+                    market.PriceStepSize = marketSymbolToken["tickSize"].ConvertInvariant<decimal>();
+                    market.MaxPrice = marketSymbolToken["maxPrice"].ConvertInvariant<decimal>();
                     //market.MinPrice = symbol["minPrice"].ConvertInvariant<decimal>();
 
-                    market.MaxTradeSize = symbol["maxOrderQty"].ConvertInvariant<decimal>();
+                    market.MaxTradeSize = marketSymbolToken["maxOrderQty"].ConvertInvariant<decimal>();
                     //market.MinTradeSize = symbol["minQty"].ConvertInvariant<decimal>();
                     //market.QuantityStepSize = symbol["stepSize"].ConvertInvariant<decimal>();
                 }
@@ -224,7 +224,7 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             /*
 {"table":"trade","action":"partial","keys":[],
@@ -249,21 +249,21 @@ namespace ExchangeSharp
                 JArray data = token["data"] as JArray;
                 foreach (var t in data)
                 {
-                    var symbol = t["symbol"].ToStringInvariant();
-                    callback(new KeyValuePair<string, ExchangeTrade>(symbol, t.ParseTrade("size", "price", "size", "timestamp", TimestampType.Iso8601, "trdMatchID")));
+                    var marketSymbol = t["symbol"].ToStringInvariant();
+                    callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, t.ParseTrade("size", "price", "size", "timestamp", TimestampType.Iso8601, "trdMatchID")));
                 }
                 return Task.CompletedTask;
             }, async (_socket) =>
             {
-                if (symbols == null || symbols.Length == 0)
+                if (marketSymbols == null || marketSymbols.Length == 0)
                 {
-                    symbols = (await GetSymbolsAsync()).ToArray();
+                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
-                await _socket.SendMessageAsync(new { op = "subscribe", args = symbols.Select(s => "\"trade:" + this.NormalizeSymbol(s) + "\"").ToArray() });
+                await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "\"trade:" + this.NormalizeMarketSymbol(s) + "\"").ToArray() });
             });
         }
 
-        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             /*
 {"info":"Welcome to the BitMEX Realtime API.","version":"2018-06-29T18:05:14.000Z","timestamp":"2018-07-05T14:22:26.267Z","docs":"https://www.bitmex.com/app/wsAPI","limit":{"remaining":39}}
@@ -271,9 +271,9 @@ namespace ExchangeSharp
 {"table":"orderBookL2","action":"update","data":[{"symbol":"XBTUSD","id":8799343000,"side":"Buy","size":350544}]}
              */
 
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = GetSymbolsAsync().Sync().ToArray();
+                marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
             return ConnectWebSocket(string.Empty, (_socket, msg) =>
             {
@@ -293,7 +293,7 @@ namespace ExchangeSharp
                 var size = 0m;
                 foreach (var d in data)
                 {
-                    var symbol = d["symbol"].ToStringInvariant();
+                    var marketSymbol = d["symbol"].ToStringInvariant();
                     var id = d["id"].ConvertInvariant<long>();
                     if (d["price"] == null)
                     {
@@ -330,25 +330,25 @@ namespace ExchangeSharp
                     {
                         book.Asks[depth.Price] = depth;
                     }
-                    book.Symbol = symbol;
+                    book.MarketSymbol = marketSymbol;
                 }
 
-                if (!string.IsNullOrEmpty(book.Symbol))
+                if (!string.IsNullOrEmpty(book.MarketSymbol))
                 {
                     callback(book);
                 }
                 return Task.CompletedTask;
             }, async (_socket) =>
             {
-                if (symbols.Length == 0)
+                if (marketSymbols.Length == 0)
                 {
-                    symbols = (await GetSymbolsAsync()).ToArray();
+                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
-                await _socket.SendMessageAsync(new { op = "subscribe", args = symbols.Select(s => "\"orderBookL2:" + this.NormalizeSymbol(s) + "\"").ToArray() });
+                await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "\"orderBookL2:" + this.NormalizeMarketSymbol(s) + "\"").ToArray() });
             });
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /*
              [
@@ -358,7 +358,7 @@ namespace ExchangeSharp
 
             List<MarketCandle> candles = new List<MarketCandle>();
             string periodString = PeriodSecondsToString(periodSeconds);
-            string url = $"/trade/bucketed?binSize={periodString}&partial=false&symbol={symbol}&reverse=true" + symbol;
+            string url = $"/trade/bucketed?binSize={periodString}&partial=false&symbol={marketSymbol}&reverse=true" + marketSymbol;
             if (startDate != null)
             {
                 url += "&startTime=" + startDate.Value.ToString("yyyy-MM-dd");
@@ -375,7 +375,7 @@ namespace ExchangeSharp
             var obj = await MakeJsonRequestAsync<JToken>(url);
             foreach (var t in obj)
             {
-                candles.Add(this.ParseCandle(t, symbol, periodSeconds, "open", "high", "low", "close", "timestamp", TimestampType.Iso8601, "volume", "turnover", "vwap"));
+                candles.Add(this.ParseCandle(t, marketSymbol, periodSeconds, "open", "high", "low", "close", "timestamp", TimestampType.Iso8601, "volume", "turnover", "vwap"));
             }
             candles.Reverse();
 
@@ -475,15 +475,15 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
             //string query = "/order";
             string query = "/order?filter={\"open\": true}";
-            if (!string.IsNullOrWhiteSpace(symbol))
+            if (!string.IsNullOrWhiteSpace(marketSymbol))
             {
-                query += "&symbol=" + NormalizeSymbol(symbol);
+                query += "&symbol=" + NormalizeMarketSymbol(marketSymbol);
             }
             JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "GET");
             foreach (JToken order in token)
@@ -494,7 +494,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
@@ -508,7 +508,7 @@ namespace ExchangeSharp
             return orders[0];
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
             payload["orderID"] = orderId;
@@ -545,7 +545,7 @@ namespace ExchangeSharp
 
         private void AddOrderToPayload(ExchangeOrderRequest order, Dictionary<string, object> payload)
         {
-            payload["symbol"] = order.Symbol;
+            payload["symbol"] = order.MarketSymbol;
             payload["ordType"] = order.OrderType.ToStringInvariant();
             payload["side"] = order.IsBuy ? "Buy" : "Sell";
             payload["orderQty"] = order.Amount;
@@ -601,7 +601,7 @@ namespace ExchangeSharp
                 IsBuy = token["side"].ToStringInvariant().EqualsWithOption("Buy"),
                 OrderDate = token["transactTime"].ConvertInvariant<DateTime>(),
                 OrderId = token["orderID"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant()
+                MarketSymbol = token["symbol"].ToStringInvariant()
             };
 
             // http://www.onixs.biz/fix-dictionary/5.0.SP2/tagNum_39.html

--- a/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -532,23 +532,23 @@ namespace ExchangeSharp
             await MakeJsonRequestAsync<JToken>("/order/cancel", BaseUrlV1, payload);
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            if (symbol.Length == 0)
+            if (currency.Length == 0)
             {
-                throw new ArgumentNullException(nameof(symbol));
+                throw new ArgumentNullException(nameof(currency));
             }
 
             // IOTA addresses should never be used more than once
-            if (symbol.Equals("MIOTA", StringComparison.OrdinalIgnoreCase))
+            if (currency.Equals("MIOTA", StringComparison.OrdinalIgnoreCase))
             {
                 forceRegenerate = true;
             }
 
             // symbol needs to be translated to full name of coin: bitcoin/litecoin/ethereum
-            if (!DepositMethodLookup.TryGetValue(symbol, out string fullName))
+            if (!DepositMethodLookup.TryGetValue(currency, out string fullName))
             {
-                fullName = symbol.ToLowerInvariant();
+                fullName = currency.ToLowerInvariant();
             }
 
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
@@ -559,7 +559,7 @@ namespace ExchangeSharp
             JToken result = await MakeJsonRequestAsync<JToken>("/deposit/new", BaseUrlV1, payload, "POST");
             var details = new ExchangeDepositDetails
             {
-                Symbol = result["currency"].ToStringInvariant(),
+                Currency = result["currency"].ToStringInvariant(),
             };
             if (result["address_pool"] != null)
             {

--- a/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -115,29 +115,31 @@ namespace ExchangeSharp
                 var market = new ExchangeMarket
                 {
                     IsActive = true,
-                    MarketName = NormalizeSymbol(pair["pair"].ToStringInvariant()),
+                    MarketName = pair["pair"].ToStringInvariant(),
                     MinTradeSize = pair["minimum_order_size"].ConvertInvariant<decimal>(),
-                    MaxTradeSize = pair["maximum_order_size"].ConvertInvariant<decimal>()
+                    MaxTradeSize = pair["maximum_order_size"].ConvertInvariant<decimal>(),
+                    MarginEnabled = pair["margin"].ConvertInvariant<bool>(false)
                 };
-                m = Regex.Match(market.MarketName, "^(BTC|USD|ETH|GBP|JPY|EUR|EOS)");
+                var pairPropertyVal = pair["pair"].ToStringUpperInvariant();
+                m = Regex.Match(pairPropertyVal, "^(BTC|USD|ETH|GBP|JPY|EUR|EOS)");
                 if (m.Success)
                 {
-                    market.MarketCurrency = m.Value;
-                    market.BaseCurrency = market.MarketName.Substring(m.Length);
+                    market.BaseCurrency = m.Value;
+                    market.QuoteCurrency = pairPropertyVal.Substring(m.Length);
                 }
                 else
                 {
-                    m = Regex.Match(market.MarketName, "(BTC|USD|ETH|GBP|JPY|EUR|EOS)$");
+                    m = Regex.Match(pairPropertyVal, "(BTC|USD|ETH|GBP|JPY|EUR|EOS)$");
                     if (m.Success)
                     {
-                        market.MarketCurrency = market.MarketName.Substring(0, m.Index);
-                        market.BaseCurrency = m.Value;
+                        market.BaseCurrency = pairPropertyVal.Substring(0, m.Index);
+                        market.QuoteCurrency = m.Value;
                     }
                     else
                     {
                         // TODO: Figure out a nicer way to handle newly added pairs
-                        market.MarketCurrency = market.MarketName.Substring(0, 3);
-                        market.BaseCurrency = market.MarketName.Substring(3);
+                        market.BaseCurrency = pairPropertyVal.Substring(0, 3);
+                        market.QuoteCurrency = pairPropertyVal.Substring(3);
                     }
                 }
                 int pricePrecision = pair["price_precision"].ConvertInvariant<int>();

--- a/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -575,17 +575,17 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="symbol">The symbol to check. Must be specified.</param>
+        /// <param name="currency">The symbol to check. Must be specified.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
-            if (symbol.Length == 0)
+            if (currency.Length == 0)
             {
-                throw new ArgumentNullException(nameof(symbol));
+                throw new ArgumentNullException(nameof(currency));
             }
 
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["currency"] = symbol;
+            payload["currency"] = currency;
 
             JToken result = await MakeJsonRequestAsync<JToken>("/history/movements", BaseUrlV1, payload, "POST");
             var transactions = new List<ExchangeTransaction>();
@@ -600,7 +600,7 @@ namespace ExchangeSharp
                 {
                     PaymentId = token["id"].ToStringInvariant(),
                     BlockchainTxId = token["txid"].ToStringInvariant(),
-                    Symbol = token["currency"].ToStringUpperInvariant(),
+                    Currency = token["currency"].ToStringUpperInvariant(),
                     Notes = token["description"].ToStringInvariant() + ", method: " + token["method"].ToStringInvariant(),
                     Amount = token["amount"].ConvertInvariant<decimal>(),
                     Address = token["address"].ToStringInvariant()

--- a/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
@@ -24,28 +24,28 @@ namespace ExchangeSharp
 
         public ExchangeBithumbAPI()
         {
-            SymbolIsUppercase = true;
+            MarketSymbolIsUppercase = true;
         }
 
-        public override string NormalizeSymbol(string symbol)
+        public override string NormalizeMarketSymbol(string marketSymbol)
         {
-            symbol = base.NormalizeSymbol(symbol);
-            int pos = symbol.IndexOf(SymbolSeparator);
+            marketSymbol = base.NormalizeMarketSymbol(marketSymbol);
+            int pos = marketSymbol.IndexOf(MarketSymbolSeparator);
             if (pos >= 0)
             {
-                symbol = symbol.Substring(0, pos);
+                marketSymbol = marketSymbol.Substring(0, pos);
             }
-            return symbol;
+            return marketSymbol;
         }
 
-        public override string ExchangeSymbolToGlobalSymbol(string symbol)
+        public override string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
-            return "KRW" + GlobalSymbolSeparator + symbol;
+            return "KRW" + GlobalMarketSymbolSeparator + marketSymbol;
         }
 
-        public override string GlobalSymbolToExchangeSymbol(string symbol)
+        public override string GlobalMarketSymbolToExchangeMarketSymbol(string marketSymbol)
         {
-            return symbol.Substring(symbol.IndexOf(GlobalSymbolSeparator) + 1);
+            return marketSymbol.Substring(marketSymbol.IndexOf(GlobalMarketSymbolSeparator) + 1);
         }
 
         private string StatusToError(string status)
@@ -73,36 +73,36 @@ namespace ExchangeSharp
             return result["data"];
         }
 
-        private async Task<Tuple<JToken, string>> MakeRequestBithumbAsync(string symbol, string subUrl)
+        private async Task<Tuple<JToken, string>> MakeRequestBithumbAsync(string marketSymbol, string subUrl)
         {
-            symbol = NormalizeSymbol(symbol);
-            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", symbol ?? string.Empty));
-            return new Tuple<JToken, string>(obj, symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", marketSymbol ?? string.Empty));
+            return new Tuple<JToken, string>(obj, marketSymbol);
         }
 
-        private ExchangeTicker ParseTicker(string symbol, JToken data)
+        private ExchangeTicker ParseTicker(string marketSymbol, JToken data)
         {
-            return this.ParseTicker(data, symbol, "sell_price", "buy_price", "buy_price", "average_price", "units_traded", "date", TimestampType.UnixMilliseconds);
+            return this.ParseTicker(data, marketSymbol, "sell_price", "buy_price", "buy_price", "average_price", "units_traded", "date", TimestampType.UnixMilliseconds);
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
-            List<string> symbols = new List<string>();
-            string symbol = "all";
-            var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
+            List<string> marketSymbols = new List<string>();
+            string marketSymbol = "all";
+            var data = await MakeRequestBithumbAsync(marketSymbol, "/public/ticker/$SYMBOL$");
             foreach (JProperty token in data.Item1)
             {
                 if (token.Name != "date")
                 {
-                    symbols.Add(token.Name);
+                    marketSymbols.Add(token.Name);
                 }
             }
-            return symbols;
+            return marketSymbols;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            var data = await MakeRequestBithumbAsync(symbol, "/public/ticker/$SYMBOL$");
+            var data = await MakeRequestBithumbAsync(marketSymbol, "/public/ticker/$SYMBOL$");
             return ParseTicker(data.Item2, data.Item1);
         }
 
@@ -124,9 +124,9 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            var data = await MakeRequestBithumbAsync(symbol, "/public/orderbook/$SYMBOL$");
+            var data = await MakeRequestBithumbAsync(marketSymbol, "/public/orderbook/$SYMBOL$");
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(data.Item1, amount: "quantity", sequence: "timestamp", maxCount: maxCount);
         }
 

--- a/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -42,8 +42,8 @@ namespace ExchangeSharp
         {
             RequestContentType = "application/x-www-form-urlencoded";
             NonceStyle = NonceStyle.UnixMilliseconds;
-            SymbolIsUppercase = false;
-            SymbolSeparator = string.Empty;
+            MarketSymbolIsUppercase = false;
+            MarketSymbolSeparator = string.Empty;
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace ExchangeSharp
             return token;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             foreach (JToken token in (await MakeBitstampRequestAsync("/trading-pairs-info")))
@@ -95,23 +95,23 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
             // {"high": "0.10948945", "last": "0.10121817", "timestamp": "1513387486", "bid": "0.10112165", "vwap": "0.09958913", "volume": "9954.37332614", "low": "0.09100000", "ask": "0.10198408", "open": "0.10250028"}
-            JToken token = await MakeBitstampRequestAsync("/ticker/" + symbol);
-            return this.ParseTicker(token, symbol, "ask", "bid", "last", "volume", null, "timestamp", TimestampType.UnixSeconds);
+            JToken token = await MakeBitstampRequestAsync("/ticker/" + marketSymbol);
+            return this.ParseTicker(token, marketSymbol, "ask", "bid", "last", "volume", null, "timestamp", TimestampType.UnixSeconds);
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken token = await MakeBitstampRequestAsync("/order_book/" + symbol);
+            JToken token = await MakeBitstampRequestAsync("/order_book/" + marketSymbol);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, maxCount: maxCount);
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             // [{"date": "1513387997", "tid": "33734815", "price": "0.01724547", "type": "1", "amount": "5.56481714"}]
-            JToken token = await MakeBitstampRequestAsync("/transactions/" + symbol);
+            JToken token = await MakeBitstampRequestAsync("/transactions/" + marketSymbol);
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             foreach (JToken trade in token)
             {
@@ -169,7 +169,7 @@ namespace ExchangeSharp
         {
             string action = order.IsBuy ? "buy" : "sell";
             string market = order.OrderType == OrderType.Market ? "/market" : "";
-            string url = $"/{action}{market}/{order.Symbol}/";
+            string url = $"/{action}{market}/{order.MarketSymbol}/";
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
 
             if (order.OrderType != OrderType.Market)
@@ -192,11 +192,11 @@ namespace ExchangeSharp
                 OrderDate = CryptoUtility.UtcNow,
                 OrderId = responseObject["id"].ToStringInvariant(),
                 IsBuy = order.IsBuy,
-                Symbol = order.Symbol
+                MarketSymbol = order.MarketSymbol
             };
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             //{
             //    "status": "Finished",
@@ -265,13 +265,13 @@ namespace ExchangeSharp
             return new ExchangeOrderResult()
             {
                 AmountFilled = amountFilled,
-                Symbol = _symbol,
+                MarketSymbol = _symbol,
                 AveragePrice = spentQuoteCurrency / amountFilled,
                 Price = price,
             };
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             // TODO: Bitstamp bug: bad request if url contains symbol, so temporarily using url for all symbols 
@@ -282,7 +282,7 @@ namespace ExchangeSharp
             {
                 //This request doesn't give info about amount filled, use GetOrderDetails(orderId)
                 string tokenSymbol = token["currency_pair"].ToStringLowerInvariant().Replace("/", "");
-                if (!string.IsNullOrWhiteSpace(tokenSymbol) && !string.IsNullOrWhiteSpace(symbol) && !tokenSymbol.Equals(symbol, StringComparison.InvariantCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(tokenSymbol) && !string.IsNullOrWhiteSpace(marketSymbol) && !tokenSymbol.Equals(marketSymbol, StringComparison.InvariantCultureIgnoreCase))
                 {
                     continue;
                 }
@@ -293,13 +293,13 @@ namespace ExchangeSharp
                     IsBuy = token["type"].ConvertInvariant<int>() == 0,
                     Price = token["price"].ConvertInvariant<decimal>(),
                     Amount = token["amount"].ConvertInvariant<decimal>(),
-                    Symbol = tokenSymbol ?? symbol
+                    MarketSymbol = tokenSymbol ?? marketSymbol
                 });
             }
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             // TODO: Bitstamp bug: bad request if url contains symbol, so temporarily using url for all symbols
             // string url = string.IsNullOrWhiteSpace(symbol) ? "/user_transactions/" : "/user_transactions/" + symbol;
@@ -315,7 +315,7 @@ namespace ExchangeSharp
                 string tradingPair = ((JObject)transaction).Properties().FirstOrDefault(p =>
                     !p.Name.Equals("order_id", StringComparison.InvariantCultureIgnoreCase)
                     && p.Name.Contains("_"))?.Name.Replace("_", "-");
-                if (!string.IsNullOrWhiteSpace(tradingPair) && !string.IsNullOrWhiteSpace(symbol) && !NormalizeSymbol(tradingPair).Equals(symbol))
+                if (!string.IsNullOrWhiteSpace(tradingPair) && !string.IsNullOrWhiteSpace(marketSymbol) && !NormalizeMarketSymbol(tradingPair).Equals(marketSymbol))
                 {
                     continue;
                 }
@@ -330,7 +330,7 @@ namespace ExchangeSharp
                     IsBuy = resultBaseCurrency > 0,
                     Fees = transaction["fee"].ConvertInvariant<decimal>(),
                     FeesCurrency = quoteCurrency.ToStringUpperInvariant(),
-                    Symbol = NormalizeSymbol(tradingPair),
+                    MarketSymbol = NormalizeMarketSymbol(tradingPair),
                     OrderDate = transaction["datetime"].ToDateTimeInvariant(),
                     AmountFilled = Math.Abs(resultBaseCurrency),
                     AveragePrice = transaction[$"{baseCurrency}_{quoteCurrency}"].ConvertInvariant<decimal>()
@@ -354,7 +354,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -513,28 +513,28 @@ namespace ExchangeSharp
         /// Gets the address to deposit to and applicable details.
         /// If one does not exist, the call will fail and return ADDRESS_GENERATING until one is available.
         /// </summary>
-        /// <param name="symbol">Symbol to get address for.</param>
+        /// <param name="currency">Currency to get address for.</param>
         /// <param name="forceRegenerate">(ignored) Bittrex does not support regenerating deposit addresses.</param>
         /// <returns>
         /// Deposit address details (including tag if applicable, such as with XRP)
         /// </returns>
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             IReadOnlyDictionary<string, ExchangeCurrency> updatedCurrencies = (await GetCurrenciesAsync());
 
-            string url = "/account/getdepositaddress?currency=" + NormalizeSymbol(symbol);
+            string url = "/account/getdepositaddress?currency=" + NormalizeSymbol(currency);
             JToken result = await MakeJsonRequestAsync<JToken>(url, null, await GetNoncePayloadAsync());
 
             // NOTE API 1.1 does not include the the static wallet address for currencies with tags such as XRP & NXT (API 2.0 does!)
             // We are getting the static addresses via the GetCurrencies() api.
             ExchangeDepositDetails depositDetails = new ExchangeDepositDetails
             {
-                Symbol = result["Currency"].ToStringInvariant(),
+                Currency = result["Currency"].ToStringInvariant(),
             };
 
-            if (!updatedCurrencies.TryGetValue(depositDetails.Symbol, out ExchangeCurrency coin))
+            if (!updatedCurrencies.TryGetValue(depositDetails.Currency, out ExchangeCurrency coin))
             {
-                Logger.Warn($"Unable to find {depositDetails.Symbol} in existing list of coins.");
+                Logger.Warn($"Unable to find {depositDetails.Currency} in existing list of coins.");
                 return null;
             }
 

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -368,7 +368,8 @@ namespace ExchangeSharp
             {
                 foreach (JToken jsonCandle in array)
                 {
-                    MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "O", "H", "L", "C", "T", TimestampType.Iso8601, "BV", "V");
+                    //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
+                    MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "O", "H", "L", "C", "T", TimestampType.Iso8601, "V", "BV");
                     if (candle.Timestamp >= startDate && candle.Timestamp <= endDate)
                     {
                         candles.Add(candle);

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -65,7 +65,7 @@ namespace ExchangeSharp
                 "WAVES_ASSET",
             };
 
-            SymbolIsReversed = true;
+            MarketSymbolIsReversed = true;
             WebSocketOrderBookType = WebSocketOrderBookType.DeltasOnly;
         }
 
@@ -124,7 +124,7 @@ namespace ExchangeSharp
                 order.Result = ExchangeAPIOrderResult.FilledPartially;
             }
             order.OrderDate = token["Opened"].ToDateTimeInvariant(token["TimeStamp"].ToDateTimeInvariant());
-            order.Symbol = token["Exchange"].ToStringInvariant();
+            order.MarketSymbol = token["Exchange"].ToStringInvariant();
             order.Fees = token["Commission"].ConvertInvariant<decimal>(); // This is always in the base pair (e.g. BTC, ETH, USDT)
 
             string exchangePair = token["Exchange"].ToStringInvariant();
@@ -198,7 +198,7 @@ namespace ExchangeSharp
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
         /// <returns>Collection of ExchangeMarkets</returns>
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             var markets = new List<ExchangeMarket>();
             JToken array = await MakeJsonRequestAsync<JToken>("/public/getmarkets");
@@ -214,7 +214,7 @@ namespace ExchangeSharp
                     IsActive = token["IsActive"].ConvertInvariant<bool>(),
                     BaseCurrency = token["MarketCurrency"].ToStringUpperInvariant(),
                     //NOTE: They also reverse the order of the currencies in the MarketName
-                    MarketName = token["MarketName"].ToStringUpperInvariant(),
+                    MarketSymbol = token["MarketName"].ToStringUpperInvariant(),
                     MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
                     MinPrice = StepSize,
                     PriceStepSize = StepSize,
@@ -227,36 +227,36 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
-            return (await GetSymbolsMetadataAsync()).Select(x => x.MarketName);
+            return (await GetMarketSymbolsMetadataAsync()).Select(x => x.MarketSymbol);
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken ticker = await MakeJsonRequestAsync<JToken>("/public/getmarketsummary?market=" + symbol);
+            JToken ticker = await MakeJsonRequestAsync<JToken>("/public/getmarketsummary?market=" + marketSymbol);
             //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
-            return this.ParseTicker(ticker[0], symbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
+            return this.ParseTicker(ticker[0], marketSymbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             JToken tickers = await MakeJsonRequestAsync<JToken>("public/getmarketsummaries");
-            string symbol;
+            string marketSymbol;
             List<KeyValuePair<string, ExchangeTicker>> tickerList = new List<KeyValuePair<string, ExchangeTicker>>();
             foreach (JToken ticker in tickers)
             {
-                symbol = ticker["MarketName"].ToStringInvariant();
+                marketSymbol = ticker["MarketName"].ToStringInvariant();
                 //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
-                ExchangeTicker tickerObj = this.ParseTicker(ticker, symbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
-                tickerList.Add(new KeyValuePair<string, ExchangeTicker>(symbol, tickerObj));
+                ExchangeTicker tickerObj = this.ParseTicker(ticker, marketSymbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
+                tickerList.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, tickerObj));
             }
             return tickerList;
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("public/getorderbook?market=" + symbol + "&type=both&limit_bids=" + maxCount + "&limit_asks=" + maxCount);
+            JToken token = await MakeJsonRequestAsync<JToken>("public/getorderbook?market=" + marketSymbol + "&type=both&limit_bids=" + maxCount + "&limit_asks=" + maxCount);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, "sell", "buy", "Rate", "Quantity", maxCount: maxCount);
         }
 
@@ -289,11 +289,11 @@ namespace ExchangeSharp
             return transactions;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             // TODO: sinceDateTime is ignored
             // https://bittrex.com/Api/v2.0/pub/market/GetTicks?marketName=BTC-WAVES&tickInterval=oneMin&_=1499127220008
-            string baseUrl = "/pub/market/GetTicks?marketName=" + symbol + "&tickInterval=oneMin";
+            string baseUrl = "/pub/market/GetTicks?marketName=" + marketSymbol + "&tickInterval=oneMin";
             string url;
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             while (true)
@@ -338,10 +338,10 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            string baseUrl = "/public/getmarkethistory?market=" + symbol;
+            string baseUrl = "/public/getmarkethistory?market=" + marketSymbol;
             JToken array = await MakeJsonRequestAsync<JToken>(baseUrl);
             foreach (JToken token in array)
             {
@@ -350,7 +350,7 @@ namespace ExchangeSharp
             return trades;
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -363,13 +363,13 @@ namespace ExchangeSharp
             List<MarketCandle> candles = new List<MarketCandle>();
             endDate = endDate ?? CryptoUtility.UtcNow;
             startDate = startDate ?? endDate.Value.Subtract(TimeSpan.FromDays(1.0));
-            JToken result = await MakeJsonRequestAsync<JToken>("pub/market/GetTicks?marketName=" + symbol + "&tickInterval=" + periodString, BaseUrl2);
+            JToken result = await MakeJsonRequestAsync<JToken>("pub/market/GetTicks?marketName=" + marketSymbol + "&tickInterval=" + periodString, BaseUrl2);
             if (result is JArray array)
             {
                 foreach (JToken jsonCandle in array)
                 {
                     //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
-                    MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "O", "H", "L", "C", "T", TimestampType.Iso8601, "V", "BV");
+                    MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, "O", "H", "L", "C", "T", TimestampType.Iso8601, "V", "BV");
                     if (candle.Timestamp >= startDate && candle.Timestamp <= endDate)
                     {
                         candles.Add(candle);
@@ -419,9 +419,9 @@ namespace ExchangeSharp
                 throw new NotSupportedException("Order type " + order.OrderType + " not supported");
             }
 
-            decimal orderAmount = await ClampOrderQuantity(order.Symbol, order.Amount);
-            decimal orderPrice = await ClampOrderPrice(order.Symbol, order.Price);
-            string url = (order.IsBuy ? "/market/buylimit" : "/market/selllimit") + "?market=" + order.Symbol + "&quantity=" +
+            decimal orderAmount = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+            decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+            string url = (order.IsBuy ? "/market/buylimit" : "/market/selllimit") + "?market=" + order.MarketSymbol + "&quantity=" +
                 orderAmount.ToStringInvariant() + "&rate=" + orderPrice.ToStringInvariant();
             foreach (var kv in order.ExtraParameters)
             {
@@ -436,12 +436,12 @@ namespace ExchangeSharp
                 OrderDate = CryptoUtility.UtcNow,
                 OrderId = orderId,
                 Result = ExchangeAPIOrderResult.Pending,
-                Symbol = order.Symbol,
+                MarketSymbol = order.MarketSymbol,
                 Price = order.Price
             };
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -453,10 +453,10 @@ namespace ExchangeSharp
             return ParseOrder(result);
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            string url = "/market/getopenorders" + (string.IsNullOrWhiteSpace(symbol) ? string.Empty : "?market=" + NormalizeSymbol(symbol));
+            string url = "/market/getopenorders" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "?market=" + NormalizeMarketSymbol(marketSymbol));
             JToken result = await MakeJsonRequestAsync<JToken>(url, null, await GetNoncePayloadAsync());
             foreach (JToken token in result.Children())
             {
@@ -466,10 +466,10 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            string url = "/account/getorderhistory" + (string.IsNullOrWhiteSpace(symbol) ? string.Empty : "?market=" + NormalizeSymbol(symbol));
+            string url = "/account/getorderhistory" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "?market=" + NormalizeMarketSymbol(marketSymbol));
             JToken result = await MakeJsonRequestAsync<JToken>(url, null, await GetNoncePayloadAsync());
             foreach (JToken token in result.Children())
             {
@@ -489,7 +489,7 @@ namespace ExchangeSharp
         {
             // Example: https://bittrex.com/api/v1.1/account/withdraw?apikey=API_KEY&currency=EAC&quantity=20.40&address=EAC_ADDRESS   
 
-            string url = $"/account/withdraw?currency={NormalizeSymbol(withdrawalRequest.Currency)}&quantity={withdrawalRequest.Amount.ToStringInvariant()}&address={withdrawalRequest.Address}";
+            string url = $"/account/withdraw?currency={NormalizeMarketSymbol(withdrawalRequest.Currency)}&quantity={withdrawalRequest.Amount.ToStringInvariant()}&address={withdrawalRequest.Address}";
             if (!string.IsNullOrWhiteSpace(withdrawalRequest.AddressTag))
             {
                 url += $"&paymentid={withdrawalRequest.AddressTag}";
@@ -505,7 +505,7 @@ namespace ExchangeSharp
             return withdrawalResponse;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             await MakeJsonRequestAsync<JToken>("/market/cancel?uuid=" + orderId, null, await GetNoncePayloadAsync());
         }
@@ -523,7 +523,7 @@ namespace ExchangeSharp
         {
             IReadOnlyDictionary<string, ExchangeCurrency> updatedCurrencies = (await GetCurrenciesAsync());
 
-            string url = "/account/getdepositaddress?currency=" + NormalizeSymbol(currency);
+            string url = "/account/getdepositaddress?currency=" + NormalizeMarketSymbol(currency);
             JToken result = await MakeJsonRequestAsync<JToken>(url, null, await GetNoncePayloadAsync());
 
             // NOTE API 1.1 does not include the the static wallet address for currencies with tags such as XRP & NXT (API 2.0 does!)

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -209,9 +209,11 @@ namespace ExchangeSharp
             {
                 var market = new ExchangeMarket
                 {
-                    BaseCurrency = token["BaseCurrency"].ToStringUpperInvariant(),
+                    //NOTE: Bittrex is weird in that they call the QuoteCurrency the "BaseCurrency" and the BaseCurrency the "MarketCurrency".
+                    QuoteCurrency = token["BaseCurrency"].ToStringUpperInvariant(),
                     IsActive = token["IsActive"].ConvertInvariant<bool>(),
-                    MarketCurrency = token["MarketCurrency"].ToStringUpperInvariant(),
+                    BaseCurrency = token["MarketCurrency"].ToStringUpperInvariant(),
+                    //NOTE: They also reverse the order of the currencies in the MarketName
                     MarketName = token["MarketName"].ToStringUpperInvariant(),
                     MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
                     MinPrice = StepSize,

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -235,7 +235,8 @@ namespace ExchangeSharp
         protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
         {
             JToken ticker = await MakeJsonRequestAsync<JToken>("/public/getmarketsummary?market=" + symbol);
-            return this.ParseTicker(ticker[0], symbol, "Ask", "Bid", "Last", "BaseVolume", "Volume", "Timestamp", TimestampType.Iso8601);
+            //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
+            return this.ParseTicker(ticker[0], symbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
@@ -246,7 +247,8 @@ namespace ExchangeSharp
             foreach (JToken ticker in tickers)
             {
                 symbol = ticker["MarketName"].ToStringInvariant();
-                ExchangeTicker tickerObj = this.ParseTicker(ticker, symbol, "Ask", "Bid", "Last", "BaseVolume", "Volume", "Timestamp", TimestampType.Iso8601);
+                //NOTE: Bittrex uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
+                ExchangeTicker tickerObj = this.ParseTicker(ticker, symbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
                 tickerList.Add(new KeyValuePair<string, ExchangeTicker>(symbol, tickerObj));
             }
             return tickerList;

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -261,12 +261,12 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="symbol">The symbol to check. May be null.</param>
+        /// <param name="currency">The symbol to check. May be null.</param>
         /// <returns>Collection of ExchangeTransactions</returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             var transactions = new List<ExchangeTransaction>();
-            string url = $"/account/getdeposithistory{(string.IsNullOrWhiteSpace(symbol) ? string.Empty : $"?currency={symbol}")}";
+            string url = $"/account/getdeposithistory{(string.IsNullOrWhiteSpace(currency) ? string.Empty : $"?currency={currency}")}";
             JToken result = await MakeJsonRequestAsync<JToken>(url, null, await GetNoncePayloadAsync());
             foreach (JToken token in result)
             {
@@ -274,7 +274,7 @@ namespace ExchangeSharp
                 {
                     Amount = token["Amount"].ConvertInvariant<decimal>(),
                     Address = token["CryptoAddress"].ToStringInvariant(),
-                    Symbol = token["Currency"].ToStringInvariant(),
+                    Currency = token["Currency"].ToStringInvariant(),
                     PaymentId = token["Id"].ToStringInvariant(),
                     BlockchainTxId = token["TxId"].ToStringInvariant(),
                     Status = TransactionStatus.Complete // As soon as it shows up in this list it is complete (verified manually)

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
@@ -120,23 +120,25 @@ namespace ExchangeSharp
                 foreach (JToken ticker in token)
                 {
                     string marketName = ticker["M"].ToStringInvariant();
+                    var (baseCurrency, quoteCurrency) = ExchangeSymbolToCurrencies(marketName);
                     decimal last = ticker["l"].ConvertInvariant<decimal>();
                     decimal ask = ticker["A"].ConvertInvariant<decimal>();
                     decimal bid = ticker["B"].ConvertInvariant<decimal>();
-                    decimal volume = ticker["V"].ConvertInvariant<decimal>();
-                    decimal baseVolume = ticker["m"].ConvertInvariant<decimal>();
+                    decimal baseCurrencyVolume = ticker["V"].ConvertInvariant<decimal>();
+                    decimal quoteCurrencyVolume = ticker["m"].ConvertInvariant<decimal>();//NOTE: Bittrex uses the term BaseVolume when referring to QuoteCurrencyVolume
                     DateTime timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(ticker["T"].ConvertInvariant<long>());
                     var t = new ExchangeTicker
                     {
+                        Symbol = marketName,
                         Ask = ask,
                         Bid = bid,
                         Last = last,
                         Volume = new ExchangeVolume
                         {
-                            ConvertedVolume = volume,
-                            ConvertedSymbol = marketName,
-                            BaseVolume = baseVolume,
-                            BaseSymbol = marketName,
+                            BaseCurrencyVolume = baseCurrencyVolume,
+                            BaseCurrency = baseCurrency,
+                            QuoteCurrencyVolume = quoteCurrencyVolume,
+                            QuoteCurrency = quoteCurrency,
                             Timestamp = timestamp
                         }
                     };

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
@@ -63,15 +63,15 @@ namespace ExchangeSharp
             /// Subscribe to order book updates
             /// </summary>
             /// <param name="callback">Callback</param>
-            /// <param name="symbols">The ticker to subscribe to</param>
+            /// <param name="marketSymbols">The market symbols to subscribe to</param>
             /// <returns>IDisposable to close the socket</returns>
-            public IWebSocket SubscribeToExchangeDeltas(Action<string> callback, params string[] symbols)
+            public IWebSocket SubscribeToExchangeDeltas(Action<string> callback, params string[] marketSymbols)
             {
                 SignalrManager.SignalrSocketConnection conn = new SignalrManager.SignalrSocketConnection(this);
                 List<object[]> paramList = new List<object[]>();
-                foreach (string symbol in symbols)
+                foreach (string marketSymbol in marketSymbols)
                 {
-                    paramList.Add(new object[] { symbol });
+                    paramList.Add(new object[] { marketSymbol });
                 }
                 Task.Run(async () => await conn.OpenAsync("uE", (s) =>
                 {
@@ -120,7 +120,7 @@ namespace ExchangeSharp
                 foreach (JToken ticker in token)
                 {
                     string marketName = ticker["M"].ToStringInvariant();
-                    var (baseCurrency, quoteCurrency) = ExchangeSymbolToCurrencies(marketName);
+                    var (baseCurrency, quoteCurrency) = ExchangeMarketSymbolToCurrencies(marketName);
                     decimal last = ticker["l"].ConvertInvariant<decimal>();
                     decimal ask = ticker["A"].ConvertInvariant<decimal>();
                     decimal bid = ticker["B"].ConvertInvariant<decimal>();
@@ -129,7 +129,7 @@ namespace ExchangeSharp
                     DateTime timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(ticker["T"].ConvertInvariant<long>());
                     var t = new ExchangeTicker
                     {
-                        Symbol = marketName,
+                        MarketSymbol = marketName,
                         Ask = ask,
                         Bid = bid,
                         Last = last,
@@ -154,12 +154,12 @@ namespace ExchangeSharp
         (
             Action<ExchangeOrderBook> callback,
             int maxCount = 20,
-            params string[] symbols
+            params string[] marketSymbols
         )
         {
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = GetSymbolsAsync().Sync().ToArray();
+                marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
             }
             void innerCallback(string json)
             {
@@ -212,19 +212,19 @@ namespace ExchangeSharp
                     book.Bids[depth.Price] = depth;
                 }
 
-                book.Symbol = ordersUpdates.MarketName;
+                book.MarketSymbol = ordersUpdates.MarketName;
                 book.SequenceId = ordersUpdates.Nonce;
                 callback(book);
             }
 
-            return this.SocketManager.SubscribeToExchangeDeltas(innerCallback, symbols);
+            return this.SocketManager.SubscribeToExchangeDeltas(innerCallback, marketSymbols);
         }
 
-		protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+		protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
 		{
-			if (symbols == null || symbols.Length == 0)
+			if (marketSymbols == null || marketSymbols.Length == 0)
 			{
-				symbols = GetSymbolsAsync().Sync().ToArray();
+				marketSymbols = GetMarketSymbolsAsync().Sync().ToArray();
 			}
 			void innerCallback(string json)
 			{
@@ -245,7 +245,7 @@ namespace ExchangeSharp
 				}
 			}
 
-			return this.SocketManager.SubscribeToExchangeDeltas(innerCallback, symbols);
+			return this.SocketManager.SubscribeToExchangeDeltas(innerCallback, marketSymbols);
 		}
 
 		/// <summary>

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -149,7 +149,8 @@ namespace ExchangeSharp
             JToken result = await MakeJsonRequestAsync<JToken>("/public/getcandles?market=" + symbol + "&period=" + periodString + (limit == null ? string.Empty : "&lasthours=" + limit));
             foreach (JToken jsonCandle in result)
             {
-                MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "Open", "High", "Low", "Close", "Timestamp", TimestampType.Iso8601, "BaseVolume", "Volume");
+                //NOTE: Bleutrade uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
+                MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "Open", "High", "Low", "Close", "Timestamp", TimestampType.Iso8601, "Volume", "BaseVolume");
                 if (candle.Timestamp >= startDate && candle.Timestamp <= endDate)
                 {
                     candles.Add(candle);

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -275,15 +275,15 @@ namespace ExchangeSharp
             await MakeJsonRequestAsync<JToken>("/market/cancel?orderid=" + orderId, null, await GetNoncePayloadAsync());
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/account/getdepositaddress?" + "currency=" + NormalizeSymbol(symbol), BaseUrl, await GetNoncePayloadAsync());
-            if (token["Currency"].ToStringInvariant().Equals(symbol) && token["Address"] != null)
+            JToken token = await MakeJsonRequestAsync<JToken>("/account/getdepositaddress?" + "currency=" + NormalizeSymbol(currency), BaseUrl, await GetNoncePayloadAsync());
+            if (token["Currency"].ToStringInvariant().Equals(currency) && token["Address"] != null)
             {
                 // At this time, according to Bleutrade support, they don't support any currency requiring an Address Tag, but they will add this feature in the future
                 return new ExchangeDepositDetails()
                 {
-                    Symbol = token["Currency"].ToStringInvariant(),
+                    Currency = token["Currency"].ToStringInvariant(),
                     Address = token["Address"].ToStringInvariant()
                 };
             }

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -130,7 +130,7 @@ namespace ExchangeSharp
             JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarketsummaries");
             foreach (JToken token in result)
             {
-                var ticker = this.ParseTicker(result, token["MarketName"].ToStringInvariant(), "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
+                var ticker = this.ParseTicker(token, token["MarketName"].ToStringInvariant(), "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
                 tickers.Add(new KeyValuePair<string, ExchangeTicker>(token["MarketName"].ToStringInvariant(), ticker));
             }
             return tickers;

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -290,7 +290,7 @@ namespace ExchangeSharp
             return null;
         }
 
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> transactions = new List<ExchangeTransaction>();
 
@@ -303,7 +303,7 @@ namespace ExchangeSharp
                     PaymentId = token["Id"].ToStringInvariant(),
                     BlockchainTxId = token["TransactionId"].ToStringInvariant(),
                     Timestamp = token["TimeStamp"].ToDateTimeInvariant(),
-                    Symbol = token["Coin"].ToStringInvariant(),
+                    Currency = token["Coin"].ToStringInvariant(),
                     Amount = token["Amount"].ConvertInvariant<decimal>(),
                     Notes = token["Label"].ToStringInvariant(),
                     TxFee = token["fee"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -36,7 +36,7 @@ namespace ExchangeSharp
         public ExchangeBleutradeAPI()
         {
             NonceStyle = NonceStyle.UnixMillisecondsString;
-            SymbolSeparator = "_";
+            MarketSymbolSeparator = "_";
         }
 
         #region ProcessRequest 
@@ -89,7 +89,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkets", null, null);
@@ -97,7 +97,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             // "result" : [{"MarketCurrency" : "DOGE","BaseCurrency" : "BTC","MarketCurrencyLong" : "Dogecoin","BaseCurrencyLong" : "Bitcoin", "MinTradeSize" : 0.10000000, "MarketName" : "DOGE_BTC", "IsActive" : true, }, ...
@@ -109,7 +109,7 @@ namespace ExchangeSharp
                     //NOTE: Bleutrade is another weird one that calls the QuoteCurrency the "BaseCurrency" and the BaseCurrency the "MarketCurrency".
                     QuoteCurrency = token["BaseCurrency"].ToStringInvariant(),
                     BaseCurrency = token["MarketCurrency"].ToStringInvariant(),
-                    MarketName = token["MarketName"].ToStringInvariant(),
+                    MarketSymbol = token["MarketName"].ToStringInvariant(),
                     IsActive = token["IsActive"].ToStringInvariant().Equals("true"),
                     MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
                 });
@@ -117,10 +117,10 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarketsummary?market=" + symbol);
-            return this.ParseTicker(result, symbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarketsummary?market=" + marketSymbol);
+            return this.ParseTicker(result, marketSymbol, "Ask", "Bid", "Last", "Volume", "BaseVolume", "Timestamp", TimestampType.Iso8601);
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
@@ -136,7 +136,7 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             List<MarketCandle> candles = new List<MarketCandle>();
             string periodString = PeriodSecondsToString(periodSeconds);
@@ -146,11 +146,11 @@ namespace ExchangeSharp
 
             //market period(15m, 20m, 30m, 1h, 2h, 3h, 4h, 6h, 8h, 12h, 1d) count(default: 1000, max: 999999) lasthours(default: 24, max: 2160) 
             //"result":[{"TimeStamp":"2014-07-31 10:15:00","Open":"0.00000048","High":"0.00000050","Low":"0.00000048","Close":"0.00000049","Volume":"594804.73036048","BaseVolume":"0.11510368" }, ...
-            JToken result = await MakeJsonRequestAsync<JToken>("/public/getcandles?market=" + symbol + "&period=" + periodString + (limit == null ? string.Empty : "&lasthours=" + limit));
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getcandles?market=" + marketSymbol + "&period=" + periodString + (limit == null ? string.Empty : "&lasthours=" + limit));
             foreach (JToken jsonCandle in result)
             {
                 //NOTE: Bleutrade uses the term "BaseVolume" when referring to the QuoteCurrencyVolume
-                MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, "Open", "High", "Low", "Close", "Timestamp", TimestampType.Iso8601, "Volume", "BaseVolume");
+                MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, "Open", "High", "Low", "Close", "Timestamp", TimestampType.Iso8601, "Volume", "BaseVolume");
                 if (candle.Timestamp >= startDate && candle.Timestamp <= endDate)
                 {
                     candles.Add(candle);
@@ -160,20 +160,20 @@ namespace ExchangeSharp
         }
 
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             //"result" : [{ "TimeStamp" : "2014-07-29 18:08:00","Quantity" : 654971.69417461,"Price" : 0.00000055,"Total" : 0.360234432,"OrderType" : "BUY"}, ...  ]
-            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkethistory?market=" + symbol);
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkethistory?market=" + marketSymbol);
             foreach (JToken token in result) trades.Add(ParseTrade(token));
             return trades;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             // TODO: Not directly supported so the best we can do is get their Max 200 and check the timestamp if necessary
-            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkethistory?market=" + symbol + "&count=200");
+            JToken result = await MakeJsonRequestAsync<JToken>("/public/getmarkethistory?market=" + marketSymbol + "&count=200");
             foreach (JToken token in result)
             {
                 ExchangeTrade trade = ParseTrade(token);
@@ -188,10 +188,10 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             //"result" : { "buy" : [{"Quantity" : 4.99400000,"Rate" : 3.00650900}, {"Quantity" : 50.00000000, "Rate" : 3.50000000 }  ] ...
-            JToken token = await MakeJsonRequestAsync<JToken>("/public/getorderbook?market=" + symbol + "&type=ALL&depth=" + maxCount);
+            JToken token = await MakeJsonRequestAsync<JToken>("/public/getorderbook?market=" + marketSymbol + "&type=ALL&depth=" + maxCount);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, "sell", "buy", "Rate", "Quantity", maxCount: maxCount);
         }
 
@@ -225,17 +225,17 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             // "result" : { "OrderId" : "65489","Exchange" : "LTC_BTC", "Type" : "BUY", "Quantity" : 20.00000000, "QuantityRemaining" : 5.00000000, "QuantityBaseTraded" : "0.16549400", "Price" : 0.01268311, "Status" : "OPEN", "Created" : "2014-08-03 13:55:20", "Comments" : "My optional comment, eg function id #123"  }
             JToken result = await MakeJsonRequestAsync<JToken>("/account/getorder?orderid=" + orderId, null, await GetNoncePayloadAsync());
             return ParseOrder(result);
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JToken result = await MakeJsonRequestAsync<JToken>("/account/getorders?market=" + (string.IsNullOrEmpty(symbol) ? "ALL" : symbol) + "&orderstatus=OK&ordertype=ALL", null, await GetNoncePayloadAsync());
+            JToken result = await MakeJsonRequestAsync<JToken>("/account/getorders?market=" + (string.IsNullOrEmpty(marketSymbol) ? "ALL" : marketSymbol) + "&orderstatus=OK&ordertype=ALL", null, await GetNoncePayloadAsync());
             foreach (JToken token in result)
             {
                 ExchangeOrderResult order = ParseOrder(token);
@@ -245,7 +245,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             JToken result = await MakeJsonRequestAsync<JToken>("/market/getopenorders", null, await GetNoncePayloadAsync());
@@ -260,7 +260,7 @@ namespace ExchangeSharp
             order.ExtraParameters.CopyTo(payload);
 
             // Only limit order is supported - no indication on how it is filled
-            JToken token = await MakeJsonRequestAsync<JToken>((order.IsBuy ? "/market/buylimit?" : "market/selllimit?") + "market=" + order.Symbol +
+            JToken token = await MakeJsonRequestAsync<JToken>((order.IsBuy ? "/market/buylimit?" : "market/selllimit?") + "market=" + order.MarketSymbol +
                 "&rate=" + order.Price.ToStringInvariant() + "&quantity=" + order.RoundAmount().ToStringInvariant(), null, payload);
             if (token.HasValues)
             {
@@ -271,14 +271,14 @@ namespace ExchangeSharp
             return result;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             await MakeJsonRequestAsync<JToken>("/market/cancel?orderid=" + orderId, null, await GetNoncePayloadAsync());
         }
 
         protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/account/getdepositaddress?" + "currency=" + NormalizeSymbol(currency), BaseUrl, await GetNoncePayloadAsync());
+            JToken token = await MakeJsonRequestAsync<JToken>("/account/getdepositaddress?" + "currency=" + NormalizeMarketSymbol(currency), BaseUrl, await GetNoncePayloadAsync());
             if (token["Currency"].ToStringInvariant().Equals(currency) && token["Address"] != null)
             {
                 // At this time, according to Bleutrade support, they don't support any currency requiring an Address Tag, but they will add this feature in the future
@@ -344,7 +344,7 @@ namespace ExchangeSharp
             {
                 OrderId = token["OrderId"].ToStringInvariant(),
                 IsBuy = token["Type"].ToStringInvariant().Equals("BUY"),
-                Symbol = token["Exchange"].ToStringInvariant(),
+                MarketSymbol = token["Exchange"].ToStringInvariant(),
                 Amount = token["Quantity"].ConvertInvariant<decimal>(),
                 OrderDate = token["Created"].ToDateTimeInvariant(),
                 AveragePrice = token["Price"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bleutrade/ExchangeBleutradeAPI.cs
@@ -106,9 +106,10 @@ namespace ExchangeSharp
             {
                 markets.Add(new ExchangeMarket()
                 {
+                    //NOTE: Bleutrade is another weird one that calls the QuoteCurrency the "BaseCurrency" and the BaseCurrency the "MarketCurrency".
+                    QuoteCurrency = token["BaseCurrency"].ToStringInvariant(),
+                    BaseCurrency = token["MarketCurrency"].ToStringInvariant(),
                     MarketName = token["MarketName"].ToStringInvariant(),
-                    BaseCurrency = token["BaseCurrency"].ToStringInvariant(),
-                    MarketCurrency = token["MarketCurrency"].ToStringInvariant(),
                     IsActive = token["IsActive"].ToStringInvariant().Equals("true"),
                     MinTradeSize = token["MinTradeSize"].ConvertInvariant<decimal>(),
                 });

--- a/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -174,10 +174,11 @@ namespace ExchangeSharp
                 var market = new ExchangeMarket
                 {
                     MarketName = product["id"].ToStringUpperInvariant(),
-                    BaseCurrency = product["quote_currency"].ToStringUpperInvariant(),
-                    MarketCurrency = product["base_currency"].ToStringUpperInvariant(),
+                    QuoteCurrency = product["quote_currency"].ToStringUpperInvariant(),
+                    BaseCurrency = product["base_currency"].ToStringUpperInvariant(),
                     IsActive = string.Equals(product["status"].ToStringInvariant(), "online", StringComparison.OrdinalIgnoreCase),
                     MinTradeSize = product["base_min_size"].ConvertInvariant<decimal>(),
+                    MaxTradeSize = product["base_max_size"].ConvertInvariant<decimal>(),
                     PriceStepSize = product["quote_increment"].ConvertInvariant<decimal>()
                 };
                 markets.Add(market);

--- a/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
@@ -31,14 +31,14 @@ namespace ExchangeSharp
         {
             RequestContentType = "application/json";
             NonceStyle = NonceStyle.UnixMillisecondsString;
-            SymbolSeparator = "/";
+            MarketSymbolSeparator = "/";
         }
 
         #region ProcessRequest 
 
         public string NormalizeSymbolForUrl(string symbol)
         {
-            return NormalizeSymbol(symbol).Replace(SymbolSeparator, "_");
+            return NormalizeMarketSymbol(symbol).Replace(MarketSymbolSeparator, "_");
         }
 
         protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
@@ -98,7 +98,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             JToken result = await MakeJsonRequestAsync<JToken>("/GetTradePairs");
@@ -109,7 +109,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             //[{ "Id":104, "Label":"LTC/BTC", "Currency":"Litecoin", "Symbol":"LTC", "BaseCurrency":"Bitcoin", "BaseSymbol":"BTC", "Status":"OK", "StatusMessage":"", "TradeFee":"0.20000000", "MinimumTrade":"0.00000001, "MaximumTrade":"1000000000.00000000", "MinimumBaseTrade":"0.00000500", "MaximumBaseTrade":"1000000000.00000000", "MinimumPrice":"0.00000001", "MaximumPrice":"1000000000.00000000" }, ... ]
@@ -119,7 +119,7 @@ namespace ExchangeSharp
                 markets.Add(new ExchangeMarket()
                 {
                     MarketId = token["Id"].ToStringInvariant(),
-                    MarketName = token["Label"].ToStringInvariant(),
+                    MarketSymbol = token["Label"].ToStringInvariant(),
                     //NOTE: Cryptopia is calls the QuoteCurrency the "BaseSymbol" and the BaseCurrency the "Symbol".. not confusing at all!
                     QuoteCurrency = token["BaseSymbol"].ToStringInvariant(),
                     BaseCurrency = token["Symbol"].ToStringInvariant(),
@@ -135,9 +135,9 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken result = await MakeJsonRequestAsync<JToken>("/GetMarket/" + NormalizeSymbolForUrl(symbol));
+            JToken result = await MakeJsonRequestAsync<JToken>("/GetMarket/" + NormalizeSymbolForUrl(marketSymbol));
             return ParseTicker(result);
         }
 
@@ -149,27 +149,27 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             // {"TradePairId":100,"Label":"DOT/BTC","Price":0.00000317,"Volume":333389.57231468,"Total":1.05684494}
-            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketOrders/" + NormalizeSymbolForUrl(symbol) + "/" + maxCount.ToStringInvariant());
+            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketOrders/" + NormalizeSymbolForUrl(marketSymbol) + "/" + maxCount.ToStringInvariant());
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, "Sell", "Buy", "Price", "Volume", maxCount: maxCount);
         }
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             // [{ "TradePairId":100,"Label":"LTC/BTC","Type":"Sell","Price":0.00006000, "Amount":499.99640000,"Total":0.02999978,"Timestamp": 1418297368}, ...]
-            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketHistory/" + NormalizeSymbolForUrl(symbol));      // Default is last 24 hours
+            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketHistory/" + NormalizeSymbolForUrl(marketSymbol));      // Default is last 24 hours
             foreach (JToken trade in token) trades.Add(ParseTrade(trade));
             return trades;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             string hours = startDate == null ? "24" : ((CryptoUtility.UtcNow - startDate.Value.ToUniversalTime()).TotalHours).ToStringInvariant();
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketHistory/" + NormalizeSymbolForUrl(symbol) + "/" + hours);
+            JToken token = await MakeJsonRequestAsync<JToken>("/GetMarketHistory/" + NormalizeSymbolForUrl(marketSymbol) + "/" + hours);
             foreach (JToken trade in token) trades.Add(ParseTrade(trade));
             var rc = callback?.Invoke(trades);
             // should we loop here to get additional more recent trades after a delay? 
@@ -180,13 +180,13 @@ namespace ExchangeSharp
         /// Cryptopia doesn't support GetCandles. It is possible to get all trades since startdate (filter by enddate if needed) and then aggregate into MarketCandles by periodSeconds 
         /// TODO: Aggregate Cryptopia Trades into Candles
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="periodSeconds"></param>
         /// <param name="startDate"></param>
         /// <param name="endDate"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             throw new NotImplementedException();
         }
@@ -235,14 +235,14 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
 
             var payload = await GetNoncePayloadAsync();
-            if (symbol.Length != 0)
+            if (marketSymbol.Length != 0)
             {
-                payload["Market"] = symbol;
+                payload["Market"] = marketSymbol;
             }
             else
             {
@@ -256,7 +256,7 @@ namespace ExchangeSharp
                 orders.Add(new ExchangeOrderResult()
                 {
                     OrderId = order["TradeId"].ConvertInvariant<int>().ToStringInvariant(),
-                    Symbol = order["Market"].ToStringInvariant(),
+                    MarketSymbol = order["Market"].ToStringInvariant(),
                     Amount = order["Amount"].ConvertInvariant<decimal>(),
                     AmountFilled = order["Amount"].ConvertInvariant<decimal>(),       // It doesn't look like partial fills are supplied on closed orders
                     Price = order["Rate"].ConvertInvariant<decimal>(),
@@ -270,12 +270,12 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
 
             var payload = await GetNoncePayloadAsync();
-            payload["Market"] = string.IsNullOrEmpty(symbol) ? string.Empty : NormalizeSymbol(symbol);
+            payload["Market"] = string.IsNullOrEmpty(marketSymbol) ? string.Empty : NormalizeMarketSymbol(marketSymbol);
 
             //[ {"OrderId": 23467,"TradePairId": 100,"Market": "DOT/BTC","Type": "Buy","Rate": 0.00000034,"Amount": 145.98000000, "Total": "0.00004963", "Remaining": "23.98760000", "TimeStamp":"2014-12-07T20:04:05.3947572" }, ... ]
             JToken token = await MakeJsonRequestAsync<JToken>("/GetOpenOrders", null, payload, "POST");
@@ -285,7 +285,7 @@ namespace ExchangeSharp
                 {
                     OrderId = data["OrderId"].ConvertInvariant<int>().ToStringInvariant(),
                     OrderDate = data["TimeStamp"].ToDateTimeInvariant(),
-                    Symbol = data["Market"].ToStringInvariant(),
+                    MarketSymbol = data["Market"].ToStringInvariant(),
                     Amount = data["Amount"].ConvertInvariant<decimal>(),
                     Price = data["Rate"].ConvertInvariant<decimal>(),
                     IsBuy = data["Type"].ToStringInvariant() == "Buy"
@@ -308,9 +308,9 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
-            var orders = await GetCompletedOrderDetailsAsync(symbol);
+            var orders = await GetCompletedOrderDetailsAsync(marketSymbol);
             return orders.Where(o => o.OrderId == orderId).FirstOrDefault();
         }
 
@@ -319,7 +319,7 @@ namespace ExchangeSharp
             ExchangeOrderResult newOrder = new ExchangeOrderResult() { Result = ExchangeAPIOrderResult.Error };
 
             var payload = await GetNoncePayloadAsync();
-            payload["Market"] = order.Symbol;
+            payload["Market"] = order.MarketSymbol;
             payload["Type"] = order.IsBuy ? "Buy" : "Sell";
             payload["Rate"] = order.Price;
             payload["Amount"] = order.Amount;
@@ -336,7 +336,7 @@ namespace ExchangeSharp
         }
 
         // This should have a return value for success
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             var payload = await GetNoncePayloadAsync();
             payload["Type"] = "Trade";          // Cancel All by Market is supported. Here we're canceling by single Id
@@ -428,8 +428,8 @@ namespace ExchangeSharp
         private ExchangeTicker ParseTicker(JToken token)
         {
             // [{ "TradePairId":100,"Label":"LTC/BTC","AskPrice":0.00006000,"BidPrice":0.02000000,"Low":0.00006000,"High":0.00006000,"Volume":1000.05639978,"LastPrice":0.00006000,"BuyVolume":34455.678,"SellVolume":67003436.37658233,"Change":-400.00000000,"Open": 0.00000500,"Close": 0.00000600, "BaseVolume": 3.58675866,"BaseBuyVolume": 11.25364758, "BaseSellVolume": 3456.06746543 }, ... ]
-            string symbol = token["Label"].ToStringInvariant();
-            return this.ParseTicker(token, symbol, "AskPrice", "BidPrice", "LastPrice", "Volume", "BaseVolume");
+            string marketSymbol = token["Label"].ToStringInvariant();
+            return this.ParseTicker(token, marketSymbol, "AskPrice", "BidPrice", "LastPrice", "Volume", "BaseVolume");
         }
 
         private ExchangeTrade ParseTrade(JToken token)

--- a/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
@@ -391,15 +391,15 @@ namespace ExchangeSharp
             return deposits;
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             var payload = await GetNoncePayloadAsync();
-            payload["Currency"] = symbol;
+            payload["Currency"] = currency;
             JToken token = await MakeJsonRequestAsync<JToken>("/GetDepositAddress", null, payload, "POST");
             if (token["Address"] == null) return null;
             return new ExchangeDepositDetails()
             {
-                Symbol = symbol,
+                Currency = currency,
                 Address = token["Address"].ToStringInvariant(),
                 AddressTag = token["BaseAddress"].ToStringInvariant()
             };

--- a/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
@@ -349,9 +349,9 @@ namespace ExchangeSharp
         /// Cryptopia does support filtering by Transaction Type (deposits and withdraws), but here we're returning both. The Tx Type will be returned in the Message field
         /// By Symbol isn't supported, so we'll filter. Also, the default limit is 100 transactions, we could possibly increase this to support the extra data we have to return for Symbol
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="currency"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> deposits = new List<ExchangeTransaction>();
             var payload = await GetNoncePayloadAsync();
@@ -365,7 +365,7 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/GetTransactions", null, payload, "POST");
             foreach (JToken data in token)
             {
-                if (data["Currency"].ToStringInvariant().Equals(symbol))
+                if (data["Currency"].ToStringInvariant().Equals(currency))
                 {
                     ExchangeTransaction tx = new ExchangeTransaction()
                     {
@@ -375,7 +375,7 @@ namespace ExchangeSharp
                         Notes = data["Type"].ToStringInvariant(),
                         PaymentId = data["Id"].ToStringInvariant(),
                         Timestamp = data["TimeStamp"].ToDateTimeInvariant(),
-                        Symbol = data["Currency"].ToStringInvariant(),
+                        Currency = data["Currency"].ToStringInvariant(),
                         TxFee = data["Fee"].ConvertInvariant<decimal>()
                     };
                     // They may support more status types, but it's not documented

--- a/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
@@ -118,12 +118,16 @@ namespace ExchangeSharp
             {
                 markets.Add(new ExchangeMarket()
                 {
+                    MarketId = token["Id"].ToStringInvariant(),
                     MarketName = token["Label"].ToStringInvariant(),
-                    BaseCurrency = token["BaseSymbol"].ToStringInvariant(),
-                    MarketCurrency = token["Symbol"].ToStringInvariant(),
+                    //NOTE: Cryptopia is calls the QuoteCurrency the "BaseSymbol" and the BaseCurrency the "Symbol".. not confusing at all!
+                    QuoteCurrency = token["BaseSymbol"].ToStringInvariant(),
+                    BaseCurrency = token["Symbol"].ToStringInvariant(),
                     MaxTradeSize = token["MaximumTrade"].ConvertInvariant<decimal>(),
+                    MaxTradeSizeInQuoteCurrency = token["MaximumBaseTrade"].ConvertInvariant<decimal>(),
                     MaxPrice = token["MaximumPrice"].ConvertInvariant<decimal>(),
                     MinTradeSize = token["MinimumTrade"].ConvertInvariant<decimal>(),
+                    MinTradeSizeInQuoteCurrency = token["MinimumBaseTrade"].ConvertInvariant<decimal>(),
                     MinPrice = token["MinimumPrice"].ConvertInvariant<decimal>(),
                     IsActive = token["Status"].ToStringInvariant().Equals("OK")
                 });

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -358,10 +358,10 @@ namespace ExchangeSharp
             result.AveragePrice = (totalQuantity == 0 ? 0 : totalCost / totalQuantity);
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            ExchangeDepositDetails deposit = new ExchangeDepositDetails() { Symbol = symbol };
-            JToken token = await MakeJsonRequestAsync<JToken>("/payment/address/" + symbol, null, await GetNoncePayloadAsync());
+            ExchangeDepositDetails deposit = new ExchangeDepositDetails() { Currency = currency };
+            JToken token = await MakeJsonRequestAsync<JToken>("/payment/address/" + currency, null, await GetNoncePayloadAsync());
             if (token != null)
             {
                 deposit.Address = token["address"].ToStringInvariant();

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -480,7 +480,7 @@ namespace ExchangeSharp
         private ExchangeTicker ParseTicker(JToken token, string symbol)
         {
             // [ {"ask": "0.050043","bid": "0.050042","last": "0.050042","open": "0.047800","low": "0.047052","high": "0.051679","volume": "36456.720","volumeQuote": "1782.625000","timestamp": "2017-05-12T14:57:19.999Z","symbol": "ETHBTC"} ]
-            return this.ParseTicker(token, symbol, "ask", "bid", "last", "volumeQuote", "volume", "timestamp", TimestampType.Iso8601);
+            return this.ParseTicker(token, symbol, "ask", "bid", "last", "volume", "volumeQuote", "timestamp", TimestampType.Iso8601);
         }
 
         private ExchangeTrade ParseExchangeTrade(JToken token)

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -379,9 +379,9 @@ namespace ExchangeSharp
         /// This returns both Deposit and Withdawl history for the Bank and Trading Accounts. Currently returning everything and not filtering. 
         /// There is no support for retrieving by Symbol, so we'll filter that after reteiving all symbols
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="currency"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> transactions = new List<ExchangeTransaction>();
             // [ {"id": "6a2fb54d-7466-490c-b3a6-95d8c882f7f7","index": 20400458,"currency": "ETH","amount": "38.616700000000000000000000","fee": "0.000880000000000000000000", "address": "0xfaEF4bE10dDF50B68c220c9ab19381e20B8EEB2B", "hash": "eece4c17994798939cea9f6a72ee12faa55a7ce44860cfb95c7ed71c89522fe8","status": "pending","type": "payout", "createdAt": "2017-05-18T18:05:36.957Z", "updatedAt": "2017-05-18T19:21:05.370Z" }, ... ]
@@ -390,12 +390,12 @@ namespace ExchangeSharp
             {
                 foreach (JToken token in result)
                 {
-                    if (token["currency"].ToStringInvariant().Equals(symbol))
+                    if (token["currency"].ToStringInvariant().Equals(currency))
                     {
                         ExchangeTransaction transaction = new ExchangeTransaction
                         {
                             PaymentId = token["id"].ToStringInvariant(),
-                            Symbol = token["currency"].ToStringInvariant(),
+                            Currency = token["currency"].ToStringInvariant(),
                             Address = token["address"].ToStringInvariant(),               // Address Tag isn't returned
                             BlockchainTxId = token["hash"].ToStringInvariant(),           // not sure about this
                             Amount = token["amount"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -32,7 +32,7 @@ namespace ExchangeSharp
         {
             RequestContentType = "application/json";
             NonceStyle = NonceStyle.UnixMillisecondsString;
-            SymbolSeparator = string.Empty;
+            MarketSymbolSeparator = string.Empty;
         }
 
         public override string PeriodSecondsToString(int seconds)
@@ -98,7 +98,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             // [ {"id": "ETHBTC","baseCurrency": "ETH","quoteCurrency": "BTC", "quantityIncrement": "0.001", "tickSize": "0.000001", "takeLiquidityRate": "0.001", "provideLiquidityRate": "-0.0001", "feeCurrency": "BTC"  } ... ]
@@ -107,7 +107,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             // [ {"id": "ETHBTC","baseCurrency": "ETH","quoteCurrency": "BTC", "quantityIncrement": "0.001", "tickSize": "0.000001", "takeLiquidityRate": "0.001", "provideLiquidityRate": "-0.0001", "feeCurrency": "BTC"  } ... ]
@@ -116,7 +116,7 @@ namespace ExchangeSharp
             {
                 markets.Add(new ExchangeMarket()
                 {
-                    MarketName = token["id"].ToStringInvariant(),
+                    MarketSymbol = token["id"].ToStringInvariant(),
                     BaseCurrency = token["baseCurrency"].ToStringInvariant(),
                     QuoteCurrency = token["quoteCurrency"].ToStringInvariant(),
                     QuantityStepSize = token["quantityIncrement"].ConvertInvariant<decimal>(),
@@ -128,10 +128,10 @@ namespace ExchangeSharp
         }
 
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/public/ticker/" + symbol);
-            return ParseTicker(obj, symbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/ticker/" + marketSymbol);
+            return ParseTicker(obj, marketSymbol);
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
@@ -140,48 +140,48 @@ namespace ExchangeSharp
             JToken obj = await MakeJsonRequestAsync<JToken>("/public/ticker");
             foreach (JToken token in obj)
             {
-                string symbol = NormalizeSymbol(token["symbol"].ToStringInvariant());
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTicker(token, symbol)));
+                string marketSymbol = NormalizeMarketSymbol(token["symbol"].ToStringInvariant());
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ParseTicker(token, marketSymbol)));
             }
             return tickers;
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             // [ {"timestamp": "2017-10-20T20:00:00.000Z","open": "0.050459","close": "0.050087","min": "0.050000","max": "0.050511","volume": "1326.628", "volumeQuote": "66.555987736"}, ... ]
             List<MarketCandle> candles = new List<MarketCandle>();
             string periodString = PeriodSecondsToString(periodSeconds);
             limit = limit ?? 100;
-            JToken obj = await MakeJsonRequestAsync<JToken>("/public/candles/" + symbol + "?period=" + periodString + "&limit=" + limit);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/candles/" + marketSymbol + "?period=" + periodString + "&limit=" + limit);
             foreach (JToken token in obj)
             {
-                candles.Add(this.ParseCandle(token, symbol, periodSeconds, "open", "max", "min", "close", "timestamp", TimestampType.Iso8601, "volume", "volumeQuote"));
+                candles.Add(this.ParseCandle(token, marketSymbol, periodSeconds, "open", "max", "min", "close", "timestamp", TimestampType.Iso8601, "volume", "volumeQuote"));
             }
             return candles;
         }
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             // Putting an arbitrary limit of 10 for 'recent'
-            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + symbol + "?limit=10");
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol + "?limit=10");
             foreach (JToken token in obj) trades.Add(ParseExchangeTrade(token));
             return trades;
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/public/orderbook/" + symbol + "?limit=" + maxCount.ToStringInvariant());
+            JToken token = await MakeJsonRequestAsync<JToken>("/public/orderbook/" + marketSymbol + "?limit=" + maxCount.ToStringInvariant());
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, asks: "ask", bids: "bid", amount: "size", maxCount: maxCount);
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             long? lastTradeID = null;
             // TODO: Can't get Hitbtc to return other than the last 50 trades even though their API says it should (by orderid or timestamp). When passing either of these parms, it still returns the last 50
             // So until there is an update, that's what we'll go with
-            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + symbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol);
             if (obj.HasValues)
             {
                 foreach (JToken token in obj)
@@ -238,20 +238,20 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="orderId"></param>
         /// <returns></returns>
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             JToken obj = await MakeJsonRequestAsync<JToken>("/history/order/" + orderId + "/trades", null, await GetNoncePayloadAsync());
             if (obj != null && obj.HasValues) return ParseCompletedOrder(obj);
             return null;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
-            if (!string.IsNullOrEmpty(symbol))
+            if (!string.IsNullOrEmpty(marketSymbol))
             {
-                payload["symbol"] = symbol;
+                payload["symbol"] = marketSymbol;
             }
             if (afterDate != null)
             {
@@ -268,13 +268,13 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
-            if (!string.IsNullOrEmpty(symbol))
+            if (!string.IsNullOrEmpty(marketSymbol))
             {
-                payload["symbol"] = symbol;
+                payload["symbol"] = marketSymbol;
             }
             JToken obj = await MakeJsonRequestAsync<JToken>("/order", null, payload);
             if (obj != null && obj.HasValues)
@@ -292,7 +292,7 @@ namespace ExchangeSharp
             var payload = await GetNoncePayloadAsync();
             //payload["clientOrderId"] = "neuMedia" + payload["nonce"];     Currently letting hitbtc assign this, but may not be unique for more than 24 hours
             payload["quantity"] = order.Amount;
-            payload["symbol"] = order.Symbol;
+            payload["symbol"] = order.MarketSymbol;
             payload["side"] = order.IsBuy ? "buy" : "sell";
             payload["type"] = order.OrderType == OrderType.Limit ? "limit" : "market";
             if (order.OrderType == OrderType.Limit)
@@ -307,7 +307,7 @@ namespace ExchangeSharp
             ExchangeOrderResult result = new ExchangeOrderResult
             {
                 OrderId = token["clientOrderId"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant(),
+                MarketSymbol = token["symbol"].ToStringInvariant(),
                 OrderDate = token["createdAt"].ToDateTimeInvariant(),
                 Amount = token["quantity"].ConvertInvariant<decimal>(),
                 Price = token["price"].ConvertInvariant<decimal>(),
@@ -331,7 +331,7 @@ namespace ExchangeSharp
             return result;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             // this call returns info about the success of the cancel. Sure would be nice have a return type on this method.
             JToken token = await MakeJsonRequestAsync<JToken>("/order/" + orderId, null, await GetNoncePayloadAsync(), "DELETE");
@@ -495,7 +495,7 @@ namespace ExchangeSharp
             return new ExchangeOrderResult()
             {
                 OrderId = token["orderId"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant(),
+                MarketSymbol = token["symbol"].ToStringInvariant(),
                 IsBuy = token["side"].ToStringInvariant().Equals("buy"),
                 Amount = token["quantity"].ConvertInvariant<decimal>(),
                 AmountFilled = token["quantity"].ConvertInvariant<decimal>(), // these are closed, so I guess the filled quantity matches the order quantiity
@@ -512,7 +512,7 @@ namespace ExchangeSharp
             ExchangeOrderResult result = new ExchangeOrderResult()
             {
                 OrderId = token["clientOrderId"].ToStringInvariant(),        // here we're using ClientOrderId in order to get order details by open orders
-                Symbol = token["symbol"].ToStringInvariant(),
+                MarketSymbol = token["symbol"].ToStringInvariant(),
                 IsBuy = token["side"].ToStringInvariant().Equals("buy"),
                 Amount = token["quantity"].ConvertInvariant<decimal>(),
                 AmountFilled = token["cumQuantity"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -155,7 +155,7 @@ namespace ExchangeSharp
             JToken obj = await MakeJsonRequestAsync<JToken>("/public/candles/" + symbol + "?period=" + periodString + "&limit=" + limit);
             foreach (JToken token in obj)
             {
-                candles.Add(this.ParseCandle(token, symbol, periodSeconds, "open", "max", "min", "close", "timestamp", TimestampType.Iso8601, "volumeQuote", "volume"));
+                candles.Add(this.ParseCandle(token, symbol, periodSeconds, "open", "max", "min", "close", "timestamp", TimestampType.Iso8601, "volume", "volumeQuote"));
             }
             return candles;
         }

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -117,8 +117,8 @@ namespace ExchangeSharp
                 markets.Add(new ExchangeMarket()
                 {
                     MarketName = token["id"].ToStringInvariant(),
-                    MarketCurrency = token["baseCurrency"].ToStringInvariant(), // should be LTC in BTC-LTC.  Hitbtc & ExchangeSharp definitions of base are reversed.
-                    BaseCurrency = token["quoteCurrency"].ToStringInvariant(), // should be BTC in BTC-LTC
+                    BaseCurrency = token["baseCurrency"].ToStringInvariant(),
+                    QuoteCurrency = token["quoteCurrency"].ToStringInvariant(),
                     QuantityStepSize = token["quantityIncrement"].ConvertInvariant<decimal>(),
                     PriceStepSize = token["tickSize"].ConvertInvariant<decimal>(),
                     IsActive = true

--- a/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -148,25 +148,25 @@ namespace ExchangeSharp
             JToken allSymbols = await MakeJsonRequestAsync<JToken>("/common/symbols", BaseUrlV1, null);
             foreach (var symbol in allSymbols)
             {
-                var marketCurrency = symbol["base-currency"].ToStringLowerInvariant();
-                var baseCurrency = symbol["quote-currency"].ToStringLowerInvariant();
-                var price_precision = symbol["price-precision"].ConvertInvariant<double>();
-                var priceStepSize = Math.Pow(10, -price_precision);
-                var amount_precision = symbol["amount-precision"].ConvertInvariant<double>();
-                var quantityStepSize = Math.Pow(10, -amount_precision);
+                var baseCurrency = symbol["base-currency"].ToStringLowerInvariant();
+                var quoteCurrency = symbol["quote-currency"].ToStringLowerInvariant();
+                var pricePrecision = symbol["price-precision"].ConvertInvariant<double>();
+                var priceStepSize = Math.Pow(10, -pricePrecision).ConvertInvariant<decimal>();
+                var amountPrecision = symbol["amount-precision"].ConvertInvariant<double>();
+                var quantityStepSize = Math.Pow(10, -amountPrecision).ConvertInvariant<decimal>();
 
-                var market = new ExchangeMarket()
-                {
-                    MarketCurrency = marketCurrency,
-                    BaseCurrency = baseCurrency,
-                    MarketName = marketCurrency + baseCurrency,
-                    IsActive = true,
-                };
+                var market = new ExchangeMarket
+                             {
+                                 BaseCurrency = baseCurrency,
+                                 QuoteCurrency = quoteCurrency,
+                                 MarketName = baseCurrency + quoteCurrency,
+                                 IsActive = true,
+                                 PriceStepSize = priceStepSize,
+                                 QuantityStepSize = quantityStepSize,
+                                 MinPrice = priceStepSize,
+                                 MinTradeSize = quantityStepSize,
+                             };
 
-                market.PriceStepSize = priceStepSize.ConvertInvariant<decimal>();
-                market.QuantityStepSize = quantityStepSize.ConvertInvariant<decimal>();
-                market.MinPrice = market.PriceStepSize.Value;
-                market.MinTradeSize = market.QuantityStepSize.Value;
 
                 markets.Add(market);
             }

--- a/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -680,7 +680,7 @@ namespace ExchangeSharp
             throw new NotImplementedException("Huobi does not provide a deposit API");
         }
 
-        protected override Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             throw new NotImplementedException("Huobi does not provide a deposit API");
 

--- a/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -675,7 +675,7 @@ namespace ExchangeSharp
             await MakeJsonRequestAsync<JToken>($"/order/orders/{orderId}/submitcancel", PrivateUrlV1, payload, "POST");
         }
 
-        protected override Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             throw new NotImplementedException("Huobi does not provide a deposit API");
         }

--- a/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -37,22 +37,22 @@ namespace ExchangeSharp
         {
             RequestContentType = "application/x-www-form-urlencoded";
             NonceStyle = NonceStyle.UnixMilliseconds;
-            SymbolSeparator = string.Empty;
-            SymbolIsUppercase = false;
+            MarketSymbolSeparator = string.Empty;
+            MarketSymbolIsUppercase = false;
             WebSocketOrderBookType = WebSocketOrderBookType.FullBookAlways;
         }
 
-        public override string ExchangeSymbolToGlobalSymbol(string symbol)
+        public override string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
-            if (symbol.Length < 6)
+            if (marketSymbol.Length < 6)
             {
-                throw new ArgumentException("Invalid symbol " + symbol);
+                throw new ArgumentException("Invalid market symbol " + marketSymbol);
             }
-            else if (symbol.Length == 6)
+            else if (marketSymbol.Length == 6)
             {
-                return ExchangeSymbolToGlobalSymbolWithSeparator(symbol.Substring(0, 3) + GlobalSymbolSeparator + symbol.Substring(3, 3), GlobalSymbolSeparator);
+                return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(marketSymbol.Substring(0, 3) + GlobalMarketSymbolSeparator + marketSymbol.Substring(3, 3), GlobalMarketSymbolSeparator);
             }
-            return ExchangeSymbolToGlobalSymbolWithSeparator(symbol.Substring(3) + GlobalSymbolSeparator + symbol.Substring(0, 3), GlobalSymbolSeparator);
+            return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(marketSymbol.Substring(3) + GlobalMarketSymbolSeparator + marketSymbol.Substring(0, 3), GlobalMarketSymbolSeparator);
         }
 
         public override string PeriodSecondsToString(int seconds)
@@ -115,13 +115,13 @@ namespace ExchangeSharp
 
         #region Public APIs
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
-            var m = await GetSymbolsMetadataAsync();
-            return m.Select(x => x.MarketName);
+            var m = await GetMarketSymbolsMetadataAsync();
+            return m.Select(x => x.MarketSymbol);
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             /*
              {
@@ -145,21 +145,21 @@ namespace ExchangeSharp
              
              */
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
-            JToken allSymbols = await MakeJsonRequestAsync<JToken>("/common/symbols", BaseUrlV1, null);
-            foreach (var symbol in allSymbols)
+            JToken allMarketSymbols = await MakeJsonRequestAsync<JToken>("/common/symbols", BaseUrlV1, null);
+            foreach (var marketSymbol in allMarketSymbols)
             {
-                var baseCurrency = symbol["base-currency"].ToStringLowerInvariant();
-                var quoteCurrency = symbol["quote-currency"].ToStringLowerInvariant();
-                var pricePrecision = symbol["price-precision"].ConvertInvariant<double>();
+                var baseCurrency = marketSymbol["base-currency"].ToStringLowerInvariant();
+                var quoteCurrency = marketSymbol["quote-currency"].ToStringLowerInvariant();
+                var pricePrecision = marketSymbol["price-precision"].ConvertInvariant<double>();
                 var priceStepSize = Math.Pow(10, -pricePrecision).ConvertInvariant<decimal>();
-                var amountPrecision = symbol["amount-precision"].ConvertInvariant<double>();
+                var amountPrecision = marketSymbol["amount-precision"].ConvertInvariant<double>();
                 var quantityStepSize = Math.Pow(10, -amountPrecision).ConvertInvariant<decimal>();
 
                 var market = new ExchangeMarket
                              {
                                  BaseCurrency = baseCurrency,
                                  QuoteCurrency = quoteCurrency,
-                                 MarketName = baseCurrency + quoteCurrency,
+                                 MarketSymbol = baseCurrency + quoteCurrency,
                                  IsActive = true,
                                  PriceStepSize = priceStepSize,
                                  QuantityStepSize = quantityStepSize,
@@ -173,7 +173,7 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
             /*
              {{
@@ -201,8 +201,8 @@ namespace ExchangeSharp
               }
             }}
              */
-            JToken ticker = await MakeJsonRequestAsync<JToken>("/market/detail/merged?symbol=" + symbol);
-            return this.ParseTicker(ticker["tick"], symbol, "ask", "bid", "close", "amount", "vol", "ts", TimestampType.UnixMillisecondsDouble, idKey: "id");
+            JToken ticker = await MakeJsonRequestAsync<JToken>("/market/detail/merged?symbol=" + marketSymbol);
+            return this.ParseTicker(ticker["tick"], marketSymbol, "ask", "bid", "close", "amount", "vol", "ts", TimestampType.UnixMillisecondsDouble, idKey: "id");
         }
 
         protected override Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
@@ -210,7 +210,7 @@ namespace ExchangeSharp
             throw new NotImplementedException("Too many pairs and this exchange does not support a single call to get all the tickers");
         }
 
-        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             return ConnectWebSocket(string.Empty, async (_socket, msg) =>
             {
@@ -251,7 +251,7 @@ namespace ExchangeSharp
 
                 var ch = token["ch"].ToStringInvariant();
                 var sArray = ch.Split('.');
-                var symbol = sArray[1];
+                var marketSymbol = sArray[1];
 
                 var tick = token["tick"];
                 var id = tick["id"].ConvertInvariant<long>();
@@ -261,24 +261,24 @@ namespace ExchangeSharp
                 foreach (var trade in trades)
                 {
                     trade.Id = id;
-                    callback(new KeyValuePair<string, ExchangeTrade>(symbol, trade));
+                    callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
                 }
             }, async (_socket) =>
             {
-                if (symbols == null || symbols.Length == 0)
+                if (marketSymbols == null || marketSymbols.Length == 0)
                 {
-                    symbols = (await GetSymbolsAsync()).ToArray();
+                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
-                foreach (string symbol in symbols)
+                foreach (string marketSymbol in marketSymbols)
                 {
                     long id = System.Threading.Interlocked.Increment(ref webSocketId);
-                    string channel = $"market.{symbol}.trade.detail";
+                    string channel = $"market.{marketSymbol}.trade.detail";
                     await _socket.SendMessageAsync(new { sub = channel, id = "id" + id.ToStringInvariant() });
                 }
             });
         }
 
-        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             return ConnectWebSocket(string.Empty, async (_socket, msg) =>
             {
@@ -336,27 +336,27 @@ namespace ExchangeSharp
                 }
                 var ch = token["ch"].ToStringInvariant();
                 var sArray = ch.Split('.');
-                var symbol = sArray[1].ToStringInvariant();
+                var marketSymbol = sArray[1].ToStringInvariant();
                 ExchangeOrderBook book = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token["tick"], maxCount: maxCount);
-                book.Symbol = symbol;
+                book.MarketSymbol = marketSymbol;
                 callback(book);
             }, async (_socket) =>
             {
-                if (symbols == null || symbols.Length == 0)
+                if (marketSymbols == null || marketSymbols.Length == 0)
                 {
-                    symbols = (await GetSymbolsAsync()).ToArray();
+                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
-                foreach (string symbol in symbols)
+                foreach (string symbol in marketSymbols)
                 {
                     long id = System.Threading.Interlocked.Increment(ref webSocketId);
-                    var normalizedSymbol = NormalizeSymbol(symbol);
+                    var normalizedSymbol = NormalizeMarketSymbol(symbol);
                     string channel = $"market.{normalizedSymbol}.depth.step0";
                     await _socket.SendMessageAsync(new { sub = channel, id = "id" + id.ToStringInvariant() });
                 }
             });
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             /*
              {
@@ -397,11 +397,11 @@ namespace ExchangeSharp
       [7995, 0.88],
              */
             ExchangeOrderBook orders = new ExchangeOrderBook();
-            JToken obj = await MakeJsonRequestAsync<JToken>("/market/depth?symbol=" + symbol + "&type=step0", BaseUrl, null);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/market/depth?symbol=" + marketSymbol + "&type=step0", BaseUrl, null);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj["tick"], sequence: "ts", maxCount: maxCount);
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /*
             {
@@ -422,7 +422,7 @@ namespace ExchangeSharp
              */
 
             List<MarketCandle> candles = new List<MarketCandle>();
-            string url = "/market/history/kline?symbol=" + symbol;
+            string url = "/market/history/kline?symbol=" + marketSymbol;
             if (limit != null)
             {
                 // default is 150, max: 2000
@@ -433,7 +433,7 @@ namespace ExchangeSharp
             JToken allCandles = await MakeJsonRequestAsync<JToken>(url, BaseUrl, null);
             foreach (var token in allCandles)
             {
-                candles.Add(this.ParseCandle(token, symbol, periodSeconds, "open", "high", "low", "close", "id", TimestampType.UnixSeconds, null, "vol"));
+                candles.Add(this.ParseCandle(token, marketSymbol, periodSeconds, "open", "high", "low", "close", "id", TimestampType.UnixSeconds, null, "vol"));
             }
 
             candles.Reverse();
@@ -572,7 +572,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             /*
              {{
@@ -600,13 +600,13 @@ namespace ExchangeSharp
             return ParseOrder(data);
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
-            if (symbol == null) { throw new APIException("symbol cannot be null"); }
+            if (marketSymbol == null) { throw new APIException("symbol cannot be null"); }
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
-            payload.Add("symbol", symbol);
+            payload.Add("symbol", marketSymbol);
             payload.Add("states", "partial-canceled,filled,canceled");
             if (afterDate != null)
             {
@@ -620,13 +620,13 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
-            if (symbol == null) { throw new APIException("symbol cannot be null"); }
+            if (marketSymbol == null) { throw new APIException("symbol cannot be null"); }
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
-            payload.Add("symbol", symbol);
+            payload.Add("symbol", marketSymbol);
             payload.Add("states", "pre-submitted,submitting,submitted,partial-filled");
             JToken data = await MakeJsonRequestAsync<JToken>("/order/orders", PrivateUrlV1, payload);
             foreach (var prop in data)
@@ -638,16 +638,16 @@ namespace ExchangeSharp
 
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
-            var account_id = await GetAccountID(order.IsMargin, order.Symbol);
+            var account_id = await GetAccountID(order.IsMargin, order.MarketSymbol);
 
             var payload = await GetNoncePayloadAsync();
             payload.Add("account-id", account_id);
-            payload.Add("symbol", order.Symbol);
+            payload.Add("symbol", order.MarketSymbol);
             payload.Add("type", order.IsBuy ? "buy" : "sell");
             payload.Add("source", order.IsMargin ? "margin-api" : "api");
 
-            decimal outputQuantity = await ClampOrderQuantity(order.Symbol, order.Amount);
-            decimal outputPrice = await ClampOrderPrice(order.Symbol, order.Price);
+            decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
 
             payload["amount"] = outputQuantity.ToStringInvariant();
 
@@ -669,7 +669,7 @@ namespace ExchangeSharp
             return ParsePlaceOrder(obj, order);
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             var payload = await GetNoncePayloadAsync();
             await MakeJsonRequestAsync<JToken>($"/order/orders/{orderId}/submitcancel", PrivateUrlV1, payload, "POST");
@@ -733,7 +733,7 @@ namespace ExchangeSharp
                 Price = order.Price,
                 IsBuy = order.IsBuy,
                 OrderId = token.ToStringInvariant(),
-                Symbol = order.Symbol
+                MarketSymbol = order.MarketSymbol
             };
             result.AveragePrice = result.Price;
             result.Result = ExchangeAPIOrderResult.Pending;
@@ -766,7 +766,7 @@ namespace ExchangeSharp
             ExchangeOrderResult result = new ExchangeOrderResult()
             {
                 OrderId = token["id"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant(),
+                MarketSymbol = token["symbol"].ToStringInvariant(),
                 Amount = token["amount"].ConvertInvariant<decimal>(),
                 AmountFilled = token["field-amount"].ConvertInvariant<decimal>(),
                 Price = token["price"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -43,35 +43,35 @@ namespace ExchangeSharp
         {
             RequestMethod = "POST";
             RequestContentType = "application/x-www-form-urlencoded";
-            SymbolSeparator = string.Empty;
+            MarketSymbolSeparator = string.Empty;
             NonceStyle = NonceStyle.UnixMilliseconds;
         }
 
-        public override string ExchangeSymbolToGlobalSymbol(string symbol)
+        public override string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
-            if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
+            if (exchangeSymbolToNormalizedSymbol.TryGetValue(marketSymbol, out string normalizedSymbol))
             {
-                return base.ExchangeSymbolToGlobalSymbolWithSeparator(normalizedSymbol.Substring(0, 3) + GlobalSymbolSeparator + normalizedSymbol.Substring(3), GlobalSymbolSeparator);
+                return base.ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(normalizedSymbol.Substring(0, 3) + GlobalMarketSymbolSeparator + normalizedSymbol.Substring(3), GlobalMarketSymbolSeparator);
             }
-            throw new ArgumentException($"Symbol {symbol} not found in Kraken lookup table");
+            throw new ArgumentException($"Symbol {marketSymbol} not found in Kraken lookup table");
         }
 
-        public override string GlobalSymbolToExchangeSymbol(string symbol)
+        public override string GlobalMarketSymbolToExchangeMarketSymbol(string marketSymbol)
         {
-            if (normalizedSymbolToExchangeSymbol.TryGetValue(symbol.Replace(GlobalSymbolSeparator.ToString(), string.Empty), out string exchangeSymbol))
+            if (normalizedSymbolToExchangeSymbol.TryGetValue(marketSymbol.Replace(GlobalMarketSymbolSeparator.ToString(), string.Empty), out string exchangeSymbol))
             {
                 return exchangeSymbol;
             }
 
             // not found, reverse the pair
-            int idx = symbol.IndexOf(GlobalSymbolSeparator);
-            symbol = symbol.Substring(idx + 1) + symbol.Substring(0, idx);
-            if (normalizedSymbolToExchangeSymbol.TryGetValue(symbol.Replace(GlobalSymbolSeparator.ToString(), string.Empty), out exchangeSymbol))
+            int idx = marketSymbol.IndexOf(GlobalMarketSymbolSeparator);
+            marketSymbol = marketSymbol.Substring(idx + 1) + marketSymbol.Substring(0, idx);
+            if (normalizedSymbolToExchangeSymbol.TryGetValue(marketSymbol.Replace(GlobalMarketSymbolSeparator.ToString(), string.Empty), out exchangeSymbol))
             {
                 return exchangeSymbol;
             }
 
-            throw new ArgumentException($"Symbol {symbol} not found in Kraken lookup table");
+            throw new ArgumentException($"Symbol {marketSymbol} not found in Kraken lookup table");
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace ExchangeSharp
             }
             orderResult.Message = (orderResult.Message ?? order["reason"].ToStringInvariant());
             orderResult.OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["opentm"].ConvertInvariant<double>());
-            orderResult.Symbol = order["descr"]["pair"].ToStringInvariant();
+            orderResult.MarketSymbol = order["descr"]["pair"].ToStringInvariant();
             orderResult.IsBuy = (order["descr"]["type"].ToStringInvariant() == "buy");
             orderResult.Amount = order["vol"].ConvertInvariant<decimal>();
             orderResult.AmountFilled = order["vol_exec"].ConvertInvariant<decimal>();
@@ -250,13 +250,13 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             JToken result = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
             return (from prop in result.Children<JProperty>() where !prop.Name.Contains(".d") select prop.Name).ToArray();
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             //  {
             //  "BCHEUR": {
@@ -363,7 +363,7 @@ namespace ExchangeSharp
                 var market = new ExchangeMarket
                              {
                                  IsActive = !prop.Name.Contains(".d"),
-                                 MarketName = prop.Name,
+                                 MarketSymbol = prop.Name,
                                  MinTradeSize = quantityStepSize,
                                  MarginEnabled = pair["leverage_buy"].Children().Any() || pair["leverage_sell"].Children().Any(),
                                  BaseCurrency = pair["base"].ToStringInvariant(),
@@ -381,33 +381,33 @@ namespace ExchangeSharp
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
-            var symbols = await GetSymbolsAsync();
-            var normalizedPairsList = symbols.Select(symbol => NormalizeSymbol(symbol)).ToList();
+            var marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
+            var normalizedPairsList = marketSymbols.Select(symbol => NormalizeMarketSymbol(symbol)).ToList();
             var csvPairsList = string.Join(",", normalizedPairsList);
             JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", csvPairsList } });
             var tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            foreach (string symbol in symbols)
+            foreach (string marketSymbol in marketSymbols)
             {
-                JToken ticker = apiTickers[symbol];
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ConvertToExchangeTicker(symbol, ticker)));
+                JToken ticker = apiTickers[marketSymbol];
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ConvertToExchangeTicker(marketSymbol, ticker)));
             }
             return tickers;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeSymbol(symbol) } });
-            JToken ticker = apiTickers[symbol];
-            return ConvertToExchangeTicker(symbol, ticker);
+            JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeMarketSymbol(marketSymbol) } });
+            JToken ticker = apiTickers[marketSymbol];
+            return ConvertToExchangeTicker(marketSymbol, ticker);
         }
 
         private ExchangeTicker ConvertToExchangeTicker(string symbol, JToken ticker)
         {
             decimal last = ticker["c"][0].ConvertInvariant<decimal>();
-            var (baseCurrency, quoteCurrency) = ExchangeSymbolToCurrencies(symbol);
+            var (baseCurrency, quoteCurrency) = ExchangeMarketSymbolToCurrencies(symbol);
             return new ExchangeTicker
             {
-                Symbol = symbol,
+                MarketSymbol = symbol,
                 Ask = ticker["a"][0].ConvertInvariant<decimal>(),
                 Bid = ticker["b"][0].ConvertInvariant<decimal>(),
                 Last = last,
@@ -422,15 +422,15 @@ namespace ExchangeSharp
             };
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/0/public/Depth?pair=" + symbol + "&count=" + maxCount);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj[symbol], maxCount: maxCount);
+            JToken obj = await MakeJsonRequestAsync<JToken>("/0/public/Depth?pair=" + marketSymbol + "&count=" + maxCount);
+            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj[marketSymbol], maxCount: maxCount);
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
-            string baseUrl = "/0/public/Trades?pair=" + symbol;
+            string baseUrl = "/0/public/Trades?pair=" + marketSymbol;
             string url;
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             while (true)
@@ -445,7 +445,7 @@ namespace ExchangeSharp
                 {
                     break;
                 }
-                if (!(result[symbol] is JArray outerArray) || outerArray.Count == 0)
+                if (!(result[marketSymbol] is JArray outerArray) || outerArray.Count == 0)
                 {
                     break;
                 }
@@ -471,7 +471,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -483,14 +483,14 @@ namespace ExchangeSharp
             // array of array entries(<time>, <open>, <high>, <low>, <close>, <vwap>, <volume>, <count>)
             startDate = startDate ?? CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(1.0));
             endDate = endDate ?? CryptoUtility.UtcNow;
-            JToken json = await MakeJsonRequestAsync<JToken>("/0/public/OHLC?pair=" + symbol + "&interval=" + (periodSeconds / 60).ToStringInvariant() + "&since=" + startDate);
+            JToken json = await MakeJsonRequestAsync<JToken>("/0/public/OHLC?pair=" + marketSymbol + "&interval=" + (periodSeconds / 60).ToStringInvariant() + "&since=" + startDate);
             List<MarketCandle> candles = new List<MarketCandle>();
             if (json.Children().Count() != 0)
             {
                 JProperty prop = json.Children().First() as JProperty;
                 foreach (JToken jsonCandle in prop.Value)
                 {
-                    MarketCandle candle = this.ParseCandle(jsonCandle, symbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5);
+                    MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5);
                     if (candle.Timestamp >= startDate.Value && candle.Timestamp <= endDate.Value)
                     {
                         candles.Add(candle);
@@ -536,7 +536,7 @@ namespace ExchangeSharp
             object nonce = await GenerateNonceAsync();
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
             {
-                { "pair", order.Symbol },
+                { "pair", order.MarketSymbol },
                 { "type", (order.IsBuy ? "buy" : "sell") },
                 { "ordertype", order.OrderType.ToString().ToLowerInvariant() },
                 { "volume", order.RoundAmount().ToStringInvariant() },
@@ -560,7 +560,7 @@ namespace ExchangeSharp
             return result;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             if (string.IsNullOrWhiteSpace(orderId))
             {
@@ -584,22 +584,22 @@ namespace ExchangeSharp
             return ParseOrder(orderId, result[orderId]); ;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
-            return await QueryOrdersAsync(symbol, "/0/private/OpenOrders");
+            return await QueryOrdersAsync(marketSymbol, "/0/private/OpenOrders");
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             string path = "/0/private/ClosedOrders";
             if (afterDate != null)
             {
                 path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
             }
-            return await QueryOrdersAsync(symbol, path);
+            return await QueryOrdersAsync(marketSymbol, path);
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             object nonce = await GenerateNonceAsync();
             Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)

--- a/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -335,20 +335,18 @@ namespace ExchangeSharp
 
             foreach (JToken pair in res)
             {
-                
+                var quantityStepSize = Math.Pow(0.1, pair["lot_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>();
                 var market = new ExchangeMarket
-                {
-                    IsActive = true,
-                    MarketName = NormalizeSymbol(pair["altname"].ToStringInvariant()),
-                    MinTradeSize = pair["lot_decimals"].ConvertInvariant<decimal>()
-
-                };
-                market.MarketCurrency = pair["quote"].ToStringInvariant();
-                market.BaseCurrency = pair["base"].ToStringInvariant();
-                int quantityPrecision = pair["lot_decimals"].ConvertInvariant<int>();
-                market.QuantityStepSize = (decimal)Math.Pow(0.1, quantityPrecision);
-                int pricePrecision = pair["pair_decimals"].ConvertInvariant<int>();
-                market.PriceStepSize = (decimal)Math.Pow(0.1, pricePrecision);
+                             {
+                                 IsActive = true,
+                                 MarketName = NormalizeSymbol(pair["altname"].ToStringInvariant()),
+                                 MinTradeSize = quantityStepSize,
+                                 MarginEnabled = pair["leverage_buy"].Children().Any() || pair["leverage_sell"].Children().Any(),
+                                 BaseCurrency = pair["base"].ToStringInvariant(),
+                                 QuoteCurrency = pair["quote"].ToStringInvariant(),
+                                 QuantityStepSize = quantityStepSize,
+                                 PriceStepSize = Math.Pow(0.1, pair["pair_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>()
+                             };
                 markets.Add(market);
             }
 

--- a/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
@@ -121,17 +121,17 @@ namespace ExchangeSharp
         protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
-            // [ { "coinType": "KCS", "trading": true, "lastDealPrice": 4500,"buy": 4120, "sell": 4500, "coinTypePair": "BTC", "sort": 0,"feeRate": 0.001,"volValue": 324866889, "high": 6890, "datetime": 1506051488000, "vol": 5363831663913, "low": 4500, "changeRate": -0.3431 }, ... ]
+            // [ { "coinType": "ETH", "trading": true, "symbol": "ETH-BTC", "lastDealPrice": 0.03169122, "buy": 0.03165041, "sell": 0.03168714, "change": -0.00004678, "coinTypePair": "BTC", "sort": 100, "feeRate": 0.001, "volValue": 121.99939218, "plus": true, "high": 0.03203444, "datetime": 1539730948000, "vol": 3847.9028281, "low": 0.03153312, "changeRate": -0.0015 }, ... ]
             JToken token = await MakeJsonRequestAsync<JToken>("/market/open/symbols");
             foreach (JToken symbol in token)
             {
                 ExchangeMarket market = new ExchangeMarket()
                 {
                     IsActive = symbol["trading"].ConvertInvariant<bool>(),
-                    MarketCurrency = symbol["coinType"].ToStringInvariant(),
-                    BaseCurrency = symbol["coinTypePair"].ToStringInvariant(),
+                    BaseCurrency = symbol["coinType"].ToStringInvariant(),
+                    QuoteCurrency = symbol["coinTypePair"].ToStringInvariant(),
+                    MarketName = symbol["symbol"].ToStringInvariant()
                 };
-                market.MarketName = market.MarketCurrency + "-" + market.BaseCurrency;
                 markets.Add(market);
             }
             return markets;

--- a/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
@@ -357,15 +357,15 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/cancel-order?" + CryptoUtility.GetFormForPayload(payload, false), null, payload, "POST");
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             // { "oid": "598aeb627da3355fa3e851ca", "address": "598aeb627da3355fa3e851ca", "context": null, "userOid": "5969ddc96732d54312eb960e", "coinType": "KCS", "createdAt": 1502276446000, "deletedAt": null, "updatedAt": 1502276446000,    "lastReceivedAt": 1502276446000   }
-            JToken token = await MakeJsonRequestAsync<JToken>("/account/" + symbol + "/wallet/address", null, await GetNoncePayloadAsync());
+            JToken token = await MakeJsonRequestAsync<JToken>("/account/" + currency + "/wallet/address", null, await GetNoncePayloadAsync());
             if (token != null && token.HasValues)
             {
                 return new ExchangeDepositDetails()
                 {
-                    Symbol = symbol,
+                    Currency = currency,
                     Address = token["address"].ToStringInvariant(),
                     AddressTag = token["userOid"].ToStringInvariant()           // this isn't in their documentation, but is how it's being used on other interfaces
                 };

--- a/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
@@ -231,8 +231,8 @@ namespace ExchangeSharp
                         HighPrice = token["h"][i].ConvertInvariant<decimal>(),
                         LowPrice = token["l"][i].ConvertInvariant<decimal>(),
                         OpenPrice = token["o"][i].ConvertInvariant<decimal>(),
-                        ConvertedVolume = token["v"][i].ConvertInvariant<double>(),
-                        BaseVolume = token["v"][i].ConvertInvariant<double>() * token["c"][i].ConvertInvariant<double>()
+                        BaseCurrencyVolume = token["v"][i].ConvertInvariant<double>(),
+                        QuoteCurrencyVolume = token["v"][i].ConvertInvariant<double>() * token["c"][i].ConvertInvariant<double>()
                     });
                 }
             }

--- a/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -26,7 +26,7 @@ namespace ExchangeSharp
         public ExchangeLivecoinAPI()
         {
             RequestContentType = "application/x-www-form-urlencoded";
-            SymbolSeparator = "/";
+            MarketSymbolSeparator = "/";
         }
 
         #region ProcessRequest 
@@ -70,7 +70,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             // {"success": true,"minBtcVolume": 0.0005,"restrictions": [{"currencyPair": "BTC/USD","priceScale": 5}, ... ]}
@@ -79,7 +79,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             // {"success": true,"minBtcVolume": 0.0005,"restrictions": [{"currencyPair": "BTC/USD","priceScale": 5}, ... ]}
@@ -89,7 +89,7 @@ namespace ExchangeSharp
                 var split = market["currencyPair"].ToStringInvariant().Split('/');
                 var exchangeMarket = new ExchangeMarket
                 {
-                    MarketName = market["currencyPair"].ToStringInvariant(),
+                    MarketSymbol = market["currencyPair"].ToStringInvariant(),
                     BaseCurrency = split[0],
                     QuoteCurrency = split[1],
                     IsActive = true,
@@ -102,9 +102,9 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/ticker?currencyPair=" + symbol.UrlEncode());
+            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/ticker?currencyPair=" + marketSymbol.UrlEncode());
             return ParseTicker(token);
         }
 
@@ -116,21 +116,21 @@ namespace ExchangeSharp
             return tickers;
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/order_book?currencyPair=" + symbol.UrlEncode() + "&depth=" + maxCount.ToStringInvariant());
+            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/order_book?currencyPair=" + marketSymbol.UrlEncode() + "&depth=" + maxCount.ToStringInvariant());
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token);
         }
 
         /// <summary>
         /// Returns trades from the last minute
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/last_trades?currencyPair=" + symbol.UrlEncode());
+            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/last_trades?currencyPair=" + marketSymbol.UrlEncode());
             foreach (JToken trade in token)
             {
                 trades.Add(ParseTrade(trade));
@@ -142,14 +142,14 @@ namespace ExchangeSharp
         /// Max returns is trades from the last hour only
         /// </summary>
         /// <param name="callback"></param>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="startDate"></param>
         /// <returns></returns>
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             // Not directly supported so we'll return what they have and filter if necessary
-            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/last_trades?currencyPair=" + symbol.UrlEncode() + "&minutesOrHour=false");
+            JToken token = await MakeJsonRequestAsync<JToken>("/exchange/last_trades?currencyPair=" + marketSymbol.UrlEncode() + "&minutesOrHour=false");
             foreach (JToken trade in token)
             {
                 ExchangeTrade rc = ParseTrade(trade);
@@ -163,13 +163,13 @@ namespace ExchangeSharp
         /// Yobit Livecoin support GetCandles. It is possible to get all trades since startdate (filter by enddate if needed) and then aggregate into MarketCandles by periodSeconds 
         /// TODO: Aggregate Livecoin Trades into Candles. 
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="periodSeconds"></param>
         /// <param name="startDate"></param>
         /// <param name="endDate"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             throw new NotImplementedException();
         }
@@ -214,19 +214,19 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/exchange/order?orderId=" + orderId, null, await GetNoncePayloadAsync());
             return ParseOrder(token);
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             // We can increase the number of orders returned by including a limit parameter if desired
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
             payload.Add("openClosed", "CLOSED");   // returns both closed and cancelled
-            if (symbol != null) payload.Add("currencyPair", symbol);
+            if (marketSymbol != null) payload.Add("currencyPair", marketSymbol);
             if (afterDate != null) payload.Add("issuedFrom", ((DateTime)afterDate).UnixTimestampFromDateTimeMilliseconds());
 
             JToken token = await MakeJsonRequestAsync<JToken>("/exchange/client_orders?" + CryptoUtility.GetFormForPayload(payload, false), null, await GetNoncePayloadAsync());
@@ -240,14 +240,14 @@ namespace ExchangeSharp
         /// <summary>
         /// Limited to the last 100 open orders
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
             payload.Add("openClosed", "OPEM"); 
-            if (symbol != null) payload.Add("currencyPair", symbol);
+            if (marketSymbol != null) payload.Add("currencyPair", marketSymbol);
 
             JToken token = await MakeJsonRequestAsync<JToken>("/exchange/client_orders?" + CryptoUtility.GetFormForPayload(payload, false), null, await GetNoncePayloadAsync());
             foreach (JToken order in token)
@@ -270,7 +270,7 @@ namespace ExchangeSharp
                 orderType += order.IsBuy ? "buylimit" : "selllimit";
                 payload["price"] = order.Price;
             }
-            payload["currencyPair"] = order.Symbol;
+            payload["currencyPair"] = order.MarketSymbol;
             payload["quantity"] = order.Amount;
             order.ExtraParameters.CopyTo(payload);
 
@@ -279,7 +279,7 @@ namespace ExchangeSharp
             return new ExchangeOrderResult() { OrderId = token["orderId"].ToStringInvariant(), Result = ExchangeAPIOrderResult.Pending };
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             // can only cancel limit orders, which kinda makes sense, but we also need the currency pair, which requires a lookup
             var order = await OnGetOrderDetailsAsync(orderId);
@@ -287,7 +287,7 @@ namespace ExchangeSharp
             {
                 // { "success": true,"cancelled": true,"message": null,"quantity": 0.0005,"tradeQuantity": 0}
                 await MakeJsonRequestAsync<JToken>("/exchange/cancel_limit?currencyPair=" +
-                    NormalizeSymbol(order.Symbol).UrlEncode() + "&orderId=" + orderId, null, await GetNoncePayloadAsync());
+                    NormalizeMarketSymbol(order.MarketSymbol).UrlEncode() + "&orderId=" + orderId, null, await GetNoncePayloadAsync());
             }
         }
 
@@ -345,8 +345,8 @@ namespace ExchangeSharp
         private ExchangeTicker ParseTicker(JToken token)
         {
             // [{"symbol": "LTC/BTC","last": 0.00805061,"high": 0.00813633,"low": 0.00784855,"volume": 14729.48452951,"vwap": 0.00795126,"max_bid": 0.00813633,"min_ask": 0.00784855,"best_bid": 0.00798,"best_ask": 0.00811037}, ... ]
-            string symbol = token["symbol"].ToStringInvariant();
-            return this.ParseTicker(token, symbol, "best_ask", "best_bid", "last", "volume");
+            string marketSymbol = token["symbol"].ToStringInvariant();
+            return this.ParseTicker(token, marketSymbol, "best_ask", "best_bid", "last", "volume");
         }
 
         private ExchangeTrade ParseTrade(JToken token)
@@ -376,7 +376,7 @@ namespace ExchangeSharp
             ExchangeOrderResult order = new ExchangeOrderResult()
             {
                  OrderId = token["id"].ToStringInvariant(),
-                 Symbol = token["currencyPair"].ToStringInvariant(),
+                 MarketSymbol = token["currencyPair"].ToStringInvariant(),
                  OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(token["issueTime"].ConvertInvariant<long>()),
                  IsBuy = token["type"].ToStringInvariant().Contains("BUY"),
                  Price = token["price"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -307,12 +307,12 @@ namespace ExchangeSharp
             return deposits;
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/payment/get/address?" + "currency=" + symbol.UrlEncode(), BaseUrl, await GetNoncePayloadAsync());
-            if (token != null && token.HasValues && token["currency"].ToStringInvariant() == symbol && token["wallet"].ToStringInvariant().Length != 0)
+            JToken token = await MakeJsonRequestAsync<JToken>("/payment/get/address?" + "currency=" + currency.UrlEncode(), BaseUrl, await GetNoncePayloadAsync());
+            if (token != null && token.HasValues && token["currency"].ToStringInvariant() == currency && token["wallet"].ToStringInvariant().Length != 0)
             {
-                ExchangeDepositDetails address = new ExchangeDepositDetails() {Symbol = symbol };
+                ExchangeDepositDetails address = new ExchangeDepositDetails() {Currency = currency };
                 if (token["wallet"].ToStringInvariant().Contains("::"))
                 {
                     // address tags are separated with a '::'

--- a/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -291,7 +291,7 @@ namespace ExchangeSharp
             }
         }
 
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> deposits = new List<ExchangeTransaction>();
 

--- a/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -90,11 +90,11 @@ namespace ExchangeSharp
                 var exchangeMarket = new ExchangeMarket
                 {
                     MarketName = market["currencyPair"].ToStringInvariant(),
-                    BaseCurrency = split[1],
-                    MarketCurrency = split[0],
+                    BaseCurrency = split[0],
+                    QuoteCurrency = split[1],
                     IsActive = true,
-                    MinTradeSize = (decimal) market["minLimitQuantity"],
-                    PriceStepSize = (decimal?) (1 / Math.Pow(10, (int) market["priceScale"]))
+                    MinTradeSize = market["minLimitQuantity"].ConvertInvariant<decimal>(),
+                    PriceStepSize = Math.Pow(.1, market["priceScale"].ConvertInvariant<int>()).ConvertInvariant<decimal>()
                 };
 
                 markets.Add(exchangeMarket);

--- a/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
@@ -128,14 +128,15 @@ namespace ExchangeSharp
             JToken allSymbols = await MakeJsonRequestAsync<JToken>("/markets/products", BaseUrlV2);
             foreach (JToken symbol in allSymbols)
             {
-                var marketName = symbol["symbol"].ToStringLowerInvariant();
-                string[] pieces = marketName.Split('_');
+                var marketName = symbol["symbol"].ToStringInvariant();
+                string[] pieces = marketName.ToStringUpperInvariant().Split('_');
                 var market = new ExchangeMarket
                 {
                     MarketName = marketName,
                     IsActive = symbol["online"].ConvertInvariant<bool>(),
-                    BaseCurrency = pieces[1],
-                    MarketCurrency = pieces[0],
+                    QuoteCurrency = pieces[1],
+                    BaseCurrency = pieces[0],
+                    MarginEnabled = symbol["isMarginOpen"].ConvertInvariant(false)
                 };
 
                 var quotePrecision = symbol["quotePrecision"].ConvertInvariant<double>();

--- a/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
@@ -33,8 +33,8 @@ namespace ExchangeSharp
         public ExchangeOkexAPI()
         {
             RequestContentType = "application/x-www-form-urlencoded";
-            SymbolSeparator = "_";
-            SymbolIsUppercase = false;
+            MarketSymbolSeparator = "_";
+            MarketSymbolIsUppercase = false;
             WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
         }
 
@@ -90,21 +90,21 @@ namespace ExchangeSharp
             }
         }
 
-        private async Task<Tuple<JToken, string>> MakeRequestOkexAsync(string symbol, string subUrl, string baseUrl = null)
+        private async Task<Tuple<JToken, string>> MakeRequestOkexAsync(string marketSymbol, string subUrl, string baseUrl = null)
         {
-            symbol = NormalizeSymbol(symbol);
-            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", symbol ?? string.Empty), baseUrl);
-            return new Tuple<JToken, string>(obj, symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", marketSymbol ?? string.Empty), baseUrl);
+            return new Tuple<JToken, string>(obj, marketSymbol);
         }
         #endregion
 
         #region Public APIs
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
-            var m = await GetSymbolsMetadataAsync();
-            return m.Select(x => x.MarketName);
+            var m = await GetMarketSymbolsMetadataAsync();
+            return m.Select(x => x.MarketSymbol);
         }
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             /*
              {"code":0,"data":[{"baseCurrency":1,"collect":"0","isMarginOpen":false,"listDisplay": 0,
@@ -125,31 +125,31 @@ namespace ExchangeSharp
 },
              */
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
-            JToken allSymbols = await MakeJsonRequestAsync<JToken>("/markets/products", BaseUrlV2);
-            foreach (JToken symbol in allSymbols)
+            JToken allMarketSymbolTokens = await MakeJsonRequestAsync<JToken>("/markets/products", BaseUrlV2);
+            foreach (JToken marketSymbolToken in allMarketSymbolTokens)
             {
-                var marketName = symbol["symbol"].ToStringInvariant();
+                var marketName = marketSymbolToken["symbol"].ToStringInvariant();
                 string[] pieces = marketName.ToStringUpperInvariant().Split('_');
                 var market = new ExchangeMarket
                 {
-                    MarketName = marketName,
-                    IsActive = symbol["online"].ConvertInvariant<bool>(),
+                    MarketSymbol = marketName,
+                    IsActive = marketSymbolToken["online"].ConvertInvariant<bool>(),
                     QuoteCurrency = pieces[1],
                     BaseCurrency = pieces[0],
-                    MarginEnabled = symbol["isMarginOpen"].ConvertInvariant(false)
+                    MarginEnabled = marketSymbolToken["isMarginOpen"].ConvertInvariant(false)
                 };
 
-                var quotePrecision = symbol["quotePrecision"].ConvertInvariant<double>();
+                var quotePrecision = marketSymbolToken["quotePrecision"].ConvertInvariant<double>();
                 var quantityStepSize = Math.Pow(10, -quotePrecision);
                 market.QuantityStepSize = quantityStepSize.ConvertInvariant<decimal>();
-                var maxSizeDigit = symbol["maxSizeDigit"].ConvertInvariant<double>();
+                var maxSizeDigit = marketSymbolToken["maxSizeDigit"].ConvertInvariant<double>();
                 var maxTradeSize = Math.Pow(10, maxSizeDigit);
                 market.MaxTradeSize = maxTradeSize.ConvertInvariant<decimal>() - 1.0m;
-                market.MinTradeSize = symbol["minTradeSize"].ConvertInvariant<decimal>();
+                market.MinTradeSize = marketSymbolToken["minTradeSize"].ConvertInvariant<decimal>();
 
-                market.PriceStepSize = symbol["quoteIncrement"].ConvertInvariant<decimal>();
+                market.PriceStepSize = marketSymbolToken["quoteIncrement"].ConvertInvariant<decimal>();
                 market.MinPrice = market.PriceStepSize.Value;
-                var maxPriceDigit = symbol["maxPriceDigit"].ConvertInvariant<double>();
+                var maxPriceDigit = marketSymbolToken["maxPriceDigit"].ConvertInvariant<double>();
                 var maxPrice = Math.Pow(10, maxPriceDigit);
                 market.MaxPrice = maxPrice.ConvertInvariant<decimal>() - 1.0m;
 
@@ -158,9 +158,9 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            var data = await MakeRequestOkexAsync(symbol, "/ticker.do?symbol=$SYMBOL$");
+            var data = await MakeRequestOkexAsync(marketSymbol, "/ticker.do?symbol=$SYMBOL$");
             return ParseTicker(data.Item2, data.Item1);
         }
 
@@ -168,16 +168,16 @@ namespace ExchangeSharp
         {
             var data = await MakeRequestOkexAsync(null, "/markets/index-tickers?limit=100000000", BaseUrlV2);
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            string symbol;
+            string marketSymbol;
             foreach (JToken token in data.Item1)
             {
-                symbol = token["symbol"].ToStringInvariant();
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTickerV2(symbol, token)));
+                marketSymbol = token["symbol"].ToStringInvariant();
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ParseTickerV2(marketSymbol, token)));
             }
             return tickers;
         }
 
-        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             /*
             {[
@@ -226,7 +226,7 @@ namespace ExchangeSharp
 
             return ConnectWebSocketOkex(async (_socket) =>
             {
-                symbols = await AddSymbolsToChannel(_socket, "ok_sub_spot_{0}_deals", symbols);
+                marketSymbols = await AddMarketSymbolsToChannel(_socket, "ok_sub_spot_{0}_deals", marketSymbols);
             }, (_socket, symbol, sArray, token) =>
             {
                 IEnumerable<ExchangeTrade> trades = ParseTradesWebSocket(token);
@@ -238,7 +238,7 @@ namespace ExchangeSharp
             });
         }
 
-        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+        protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             /*
 {[
@@ -285,26 +285,26 @@ namespace ExchangeSharp
 
             return ConnectWebSocketOkex(async (_socket) =>
             {
-                symbols = await AddSymbolsToChannel(_socket, $"ok_sub_spot_{{0}}_depth_{maxCount}", symbols);
+                marketSymbols = await AddMarketSymbolsToChannel(_socket, $"ok_sub_spot_{{0}}_depth_{maxCount}", marketSymbols);
             }, (_socket, symbol, sArray, token) =>
             {
                 ExchangeOrderBook book = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, sequence: "timestamp", maxCount: maxCount);
-                book.Symbol = symbol;
+                book.MarketSymbol = symbol;
                 callback(book);
                 return Task.CompletedTask;
             });
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            var token = await MakeRequestOkexAsync(symbol, "/depth.do?symbol=$SYMBOL$");
+            var token = await MakeRequestOkexAsync(marketSymbol, "/depth.do?symbol=$SYMBOL$");
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token.Item1, maxCount: maxCount);
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> allTrades = new List<ExchangeTrade>();
-            var trades = await MakeRequestOkexAsync(symbol, "/trades.do?symbol=$SYMBOL$");
+            var trades = await MakeRequestOkexAsync(marketSymbol, "/trades.do?symbol=$SYMBOL$");
             foreach (JToken trade in trades.Item1)
             {
                 // [ { "date": "1367130137", "date_ms": "1367130137000", "price": 787.71, "amount": 0.003, "tid": "230433", "type": "sell" } ]
@@ -313,7 +313,7 @@ namespace ExchangeSharp
             callback(allTrades);
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             /*
              [
@@ -327,7 +327,7 @@ namespace ExchangeSharp
             */
 
             List<MarketCandle> candles = new List<MarketCandle>();
-            string url = "/kline.do?symbol=" + symbol;
+            string url = "/kline.do?symbol=" + marketSymbol;
             if (startDate != null)
             {
                 url += "&since=" + (long)startDate.Value.UnixTimestampFromDateTimeMilliseconds();
@@ -341,7 +341,7 @@ namespace ExchangeSharp
             JToken obj = await MakeJsonRequestAsync<JToken>(url);
             foreach (JArray token in obj)
             {
-                candles.Add(this.ParseCandle(token, symbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixMilliseconds, 5));
+                candles.Add(this.ParseCandle(token, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixMilliseconds, 5));
             }
             return candles;
         }
@@ -407,12 +407,12 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["symbol"] = order.Symbol;
+            payload["symbol"] = order.MarketSymbol;
             payload["type"] = (order.IsBuy ? "buy" : "sell");
 
             // Okex has strict rules on which prices and quantities are allowed. They have to match the rules defined in the market definition.
-            decimal outputQuantity = await ClampOrderQuantity(order.Symbol, order.Amount);
-            decimal outputPrice = await ClampOrderPrice(order.Symbol, order.Price);
+            decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
 
             if (order.OrderType == OrderType.Market)
             {
@@ -447,27 +447,27 @@ namespace ExchangeSharp
             return ParsePlaceOrder(obj, order);
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
                 throw new InvalidOperationException("Okex cancel order request requires symbol");
             }
-            payload["symbol"] = symbol;
+            payload["symbol"] = marketSymbol;
             payload["order_id"] = orderId;
             await MakeJsonRequestAsync<JToken>("/cancel_order.do", BaseUrl, payload, "POST");
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
                 throw new InvalidOperationException("Okex single order details request requires symbol");
             }
-            payload["symbol"] = symbol;
+            payload["symbol"] = marketSymbol;
             payload["order_id"] = orderId;
             JToken token = await MakeJsonRequestAsync<JToken>("/order_info.do", BaseUrl, payload, "POST");
             foreach (JToken order in token["orders"])
@@ -479,12 +479,12 @@ namespace ExchangeSharp
             return orders[0];
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             Dictionary<string, object> payload = await GetNoncePayloadAsync();
 
-            payload["symbol"] = symbol;
+            payload["symbol"] = marketSymbol;
             // if order_id is -1, then return all unfilled orders, otherwise return the order specified
             payload["order_id"] = -1;
             JToken token = await MakeJsonRequestAsync<JToken>("/order_info.do", BaseUrl, payload, "POST");
@@ -542,7 +542,7 @@ namespace ExchangeSharp
                 Price = order.Price,
                 IsBuy = order.IsBuy,
                 OrderId = token["order_id"].ToStringInvariant(),
-                Symbol = order.Symbol
+                MarketSymbol = order.MarketSymbol
             };
             result.AveragePrice = result.Price;
             result.Result = ExchangeAPIOrderResult.Pending;
@@ -600,7 +600,7 @@ namespace ExchangeSharp
                 IsBuy = token["type"].ToStringInvariant().StartsWith("buy"),
                 OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(token["create_date"].ConvertInvariant<long>()),
                 OrderId = token["order_id"].ToStringInvariant(),
-                Symbol = token["symbol"].ToStringInvariant(),
+                MarketSymbol = token["symbol"].ToStringInvariant(),
                 Result = ParseOrderStatus(token["status"].ConvertInvariant<int>()),
             };
 
@@ -650,8 +650,8 @@ namespace ExchangeSharp
                 else
                 {
                     var sArray = channel.Split('_');
-                    string symbol = sArray[symbolArrayIndex] + SymbolSeparator + sArray[symbolArrayIndex + 1];
-                    await callback(_socket, symbol, sArray, token["data"]);
+                    string marketSymbol = sArray[symbolArrayIndex] + MarketSymbolSeparator + sArray[symbolArrayIndex + 1];
+                    await callback(_socket, marketSymbol, sArray, token["data"]);
                 }
             }, async (_socket) =>
             {
@@ -677,23 +677,23 @@ namespace ExchangeSharp
             }, 0);
         }
 
-        private async Task<string[]> AddSymbolsToChannel(IWebSocket socket, string channelFormat, string[] symbols, bool useJustFirstSymbol = false)
+        private async Task<string[]> AddMarketSymbolsToChannel(IWebSocket socket, string channelFormat, string[] marketSymbols, bool useJustFirstSymbol = false)
         {
-            if (symbols == null || symbols.Length == 0)
+            if (marketSymbols == null || marketSymbols.Length == 0)
             {
-                symbols = (await GetSymbolsAsync()).ToArray();
+                marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
             }
-            foreach (string symbol in symbols)
+            foreach (string marketSymbol in marketSymbols)
             {
-                string normalizedSymbol = NormalizeSymbol(symbol);
+                string normalizedSymbol = NormalizeMarketSymbol(marketSymbol);
                 if (useJustFirstSymbol)
                 {
-                    normalizedSymbol = normalizedSymbol.Substring(0, normalizedSymbol.IndexOf(SymbolSeparator[0]));
+                    normalizedSymbol = normalizedSymbol.Substring(0, normalizedSymbol.IndexOf(MarketSymbolSeparator[0]));
                 }
                 string channel = string.Format(channelFormat, normalizedSymbol);
                 await socket.SendMessageAsync(new { @event = "addChannel", channel });
             }
-            return symbols;
+            return marketSymbols;
         }
 
         #endregion

--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -54,8 +54,8 @@ namespace ExchangeSharp
         public ExchangePoloniexAPI()
         {
             RequestContentType = "application/x-www-form-urlencoded";
-            SymbolSeparator = "_";
-            SymbolIsReversed = true;
+            MarketSymbolSeparator = "_";
+            MarketSymbolIsReversed = true;
             WebSocketOrderBookType = WebSocketOrderBookType.DeltasOnly;
         }
 
@@ -100,9 +100,9 @@ namespace ExchangeSharp
         /// Parses an order which has not been filled.
         /// </summary>
         /// <param name="result">The JToken to parse.</param>
-        /// <param name="symbol">Symbol or null if it's in the result</param>
+        /// <param name="marketSymbol">Market symbol or null if it's in the result</param>
         /// <returns>ExchangeOrderResult with the open order and how much is remaining to fill</returns>
-        public ExchangeOrderResult ParseOpenOrder(JToken result, string symbol = null)
+        public ExchangeOrderResult ParseOpenOrder(JToken result, string marketSymbol = null)
         {
             ExchangeOrderResult order = new ExchangeOrderResult
             {
@@ -112,7 +112,7 @@ namespace ExchangeSharp
                 OrderId = result["orderNumber"].ToStringInvariant(),
                 Price = result["rate"].ConvertInvariant<decimal>(),
                 Result = ExchangeAPIOrderResult.Pending,
-                Symbol = (symbol ?? result.Parent.Path)
+                MarketSymbol = (marketSymbol ?? result.Parent.Path)
             };
 
             decimal amount = result["amount"].ConvertInvariant<decimal>();
@@ -137,13 +137,13 @@ namespace ExchangeSharp
                     {
                         parsedSymbol = trade.Parent.Path;
                     }
-                    if (order.Symbol == "all" || !string.IsNullOrWhiteSpace(parsedSymbol))
+                    if (order.MarketSymbol == "all" || !string.IsNullOrWhiteSpace(parsedSymbol))
                     {
-                        order.Symbol = parsedSymbol;
+                        order.MarketSymbol = parsedSymbol;
                     }
-                    if (!string.IsNullOrWhiteSpace(order.Symbol))
+                    if (!string.IsNullOrWhiteSpace(order.MarketSymbol))
                     {
-                        order.FeesCurrency = ParseFeesCurrency(order.IsBuy, order.Symbol);
+                        order.FeesCurrency = ParseFeesCurrency(order.IsBuy, order.MarketSymbol);
                     }
                     orderMetadataSet = true;
                 }
@@ -178,9 +178,9 @@ namespace ExchangeSharp
                 {
                     closePosition.IsBuy = trade["type"].ToStringLowerInvariant() != "sell";
 
-                    if (!string.IsNullOrWhiteSpace(closePosition.Symbol))
+                    if (!string.IsNullOrWhiteSpace(closePosition.MarketSymbol))
                     {
-                        closePosition.FeesCurrency = ParseFeesCurrency(closePosition.IsBuy, closePosition.Symbol);
+                        closePosition.FeesCurrency = ParseFeesCurrency(closePosition.IsBuy, closePosition.MarketSymbol);
                     }
 
                     closePositionMetadataSet = true;
@@ -212,13 +212,13 @@ namespace ExchangeSharp
             return Math.Round(amount, 8, MidpointRounding.AwayFromZero);
         }
 
-        private void ParseCompletedOrderDetails(List<ExchangeOrderResult> orders, JToken trades, string symbol)
+        private void ParseCompletedOrderDetails(List<ExchangeOrderResult> orders, JToken trades, string marketSymbol)
         {
             IEnumerable<string> orderNumsInTrades = trades.Select(x => x["orderNumber"].ToStringInvariant()).Distinct();
             foreach (string orderNum in orderNumsInTrades)
             {
                 IEnumerable<JToken> tradesForOrder = trades.Where(x => x["orderNumber"].ToStringInvariant() == orderNum);
-                ExchangeOrderResult order = new ExchangeOrderResult { OrderId = orderNum, Symbol = symbol };
+                ExchangeOrderResult order = new ExchangeOrderResult { OrderId = orderNum, MarketSymbol = marketSymbol };
                 ParseOrderTrades(tradesForOrder, order);
                 order.Price = order.AveragePrice;
                 order.Result = ExchangeAPIOrderResult.Filled;
@@ -291,7 +291,7 @@ namespace ExchangeSharp
             return currencies;
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             var tickers = await GetTickersAsync();
@@ -302,7 +302,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             //https://poloniex.com/public?command=returnOrderBook&currencyPair=all&depth=0
             /*
@@ -322,7 +322,7 @@ namespace ExchangeSharp
 
             foreach (var kvp in lookup)
             {
-                var market = new ExchangeMarket { MarketName = kvp.Key, IsActive = false };
+                var market = new ExchangeMarket { MarketSymbol = kvp.Key, IsActive = false };
 
                 string isFrozen = kvp.Value["isFrozen"].ToStringInvariant();
                 if (string.Equals(isFrozen, "0"))
@@ -347,12 +347,12 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
             IEnumerable<KeyValuePair<string, ExchangeTicker>> tickers = await GetTickersAsync();
             foreach (var kv in tickers)
             {
-                if (kv.Key == symbol)
+                if (kv.Key == marketSymbol)
                 {
                     return kv.Value;
                 }
@@ -367,11 +367,11 @@ namespace ExchangeSharp
             JToken obj = await MakeJsonRequestAsync<JToken>("/public?command=returnTicker");
             foreach (JProperty prop in obj.Children())
             {
-                string symbol = prop.Name;
+                string marketSymbol = prop.Name;
                 JToken values = prop.Value;
                 //NOTE: Poloniex uses the term "caseVolume" when referring to the QuoteCurrencyVolume
-                ExchangeTicker ticker = this.ParseTicker(values, symbol, "lowestAsk", "highestBid", "last", "quoteVolume", "baseVolume", idKey: "id");
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ticker));
+                ExchangeTicker ticker = this.ParseTicker(values, marketSymbol, "lowestAsk", "highestBid", "last", "quoteVolume", "baseVolume", idKey: "id");
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ticker));
             }
             return tickers;
         }
@@ -406,7 +406,7 @@ namespace ExchangeSharp
             });
         }
 
-		protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+		protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
 		{
 			Dictionary<int, Tuple<string, long>> messageIdToSymbol = new Dictionary<int, Tuple<string, long>>();
 			return ConnectWebSocket(string.Empty, (_socket, msg) =>
@@ -451,19 +451,19 @@ namespace ExchangeSharp
 				return Task.CompletedTask;
 			}, async (_socket) =>
 			{
-				if (symbols == null || symbols.Length == 0)
+				if (marketSymbols == null || marketSymbols.Length == 0)
 				{
-					symbols = (await GetSymbolsAsync()).ToArray();
+					marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 				}
 				// subscribe to order book and trades channel for each symbol
-				foreach (var sym in symbols)
+				foreach (var sym in marketSymbols)
 				{
-					await _socket.SendMessageAsync(new { command = "subscribe", channel = NormalizeSymbol(sym) });
+					await _socket.SendMessageAsync(new { command = "subscribe", channel = NormalizeMarketSymbol(sym) });
 				}
 			});
 		}
 
-		protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+		protected override IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             Dictionary<int, Tuple<string, long>> messageIdToSymbol = new Dictionary<int, Tuple<string, long>>();
             return ConnectWebSocket(string.Empty, (_socket, msg) =>
@@ -521,9 +521,9 @@ namespace ExchangeSharp
                             var depth = new ExchangeOrderPrice { Price = data[2].ConvertInvariant<decimal>(), Amount = data[3].ConvertInvariant<decimal>() };
                             var list = (type == 1 ? book.Bids : book.Asks);
                             list[depth.Price] = depth;
-                            book.Symbol = symbol.Item1;
+                            book.MarketSymbol = symbol.Item1;
                             book.SequenceId = symbol.Item2 + 1;
-                            messageIdToSymbol[msgId] = new Tuple<string, long>(book.Symbol, book.SequenceId);
+                            messageIdToSymbol[msgId] = new Tuple<string, long>(book.MarketSymbol, book.SequenceId);
                         }
                     }
                     else
@@ -538,22 +538,22 @@ namespace ExchangeSharp
                 return Task.CompletedTask;
             }, async (_socket) =>
             {
-                if (symbols == null || symbols.Length == 0)
+                if (marketSymbols == null || marketSymbols.Length == 0)
                 {
-                    symbols = (await GetSymbolsAsync()).ToArray();
+                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
                 // subscribe to order book and trades channel for each symbol
-                foreach (var sym in symbols)
+                foreach (var sym in marketSymbols)
                 {
-                    await _socket.SendMessageAsync(new { command = "subscribe", channel = NormalizeSymbol(sym) });
+                    await _socket.SendMessageAsync(new { command = "subscribe", channel = NormalizeMarketSymbol(sym) });
                 }
             });
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             // {"asks":[["0.01021997",22.83117932],["0.01022000",82.3204],["0.01022480",140],["0.01023054",241.06436945],["0.01023057",140]],"bids":[["0.01020233",164.195],["0.01020232",66.22565096],["0.01020200",5],["0.01020010",66.79296968],["0.01020000",490.19563761]],"isFrozen":"0","seq":147171861}
-            JToken token = await MakeJsonRequestAsync<JToken>("/public?command=returnOrderBook&currencyPair=" + symbol + "&depth=" + maxCount);
+            JToken token = await MakeJsonRequestAsync<JToken>("/public?command=returnOrderBook&currencyPair=" + marketSymbol + "&depth=" + maxCount);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token);
         }
 
@@ -579,7 +579,7 @@ namespace ExchangeSharp
             return books;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             // [{"globalTradeID":245321705,"tradeID":11501281,"date":"2017-10-20 17:39:17","type":"buy","rate":"0.01022188","amount":"0.00954454","total":"0.00009756"},...]
             ExchangeHistoricalTradeHelper state = new ExchangeHistoricalTradeHelper(this)
@@ -589,14 +589,14 @@ namespace ExchangeSharp
                 MillisecondGranularity = false,
                 ParseFunction = (JToken token) => token.ParseTrade("amount", "rate", "type", "date", TimestampType.Iso8601, "globalTradeID"),
                 StartDate = startDate,
-                Symbol = symbol,
+                MarketSymbol = marketSymbol,
                 TimestampFunction = (DateTime dt) => ((long)CryptoUtility.UnixTimestampFromDateTimeSeconds(dt)).ToStringInvariant(),
-                Url = "/public?command=returnTradeHistory&currencyPair=[symbol]&start={0}&end={1}"
+                Url = "/public?command=returnTradeHistory&currencyPair=[marketSymbol]&start={0}&end={1}"
             };
             await state.ProcessHistoricalTrades();
         }
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             if (limit != null)
             {
@@ -605,7 +605,7 @@ namespace ExchangeSharp
 
             // https://poloniex.com/public?command=returnChartData&currencyPair=BTC_XMR&start=1405699200&end=9999999999&period=14400
             // [{"date":1405699200,"high":0.0045388,"low":0.00403001,"open":0.00404545,"close":0.00435873,"volume":44.34555992,"quoteVolume":10311.88079097,"weightedAverage":0.00430043}]
-            string url = "/public?command=returnChartData&currencyPair=" + symbol;
+            string url = "/public?command=returnChartData&currencyPair=" + marketSymbol;
             if (startDate != null)
             {
                 url += "&start=" + (long)startDate.Value.UnixTimestampFromDateTimeSeconds();
@@ -616,7 +616,7 @@ namespace ExchangeSharp
             List<MarketCandle> candles = new List<MarketCandle>();
             foreach (JToken candle in token)
             {
-                candles.Add(this.ParseCandle(candle, symbol, periodSeconds, "open", "high", "low", "close", "date", TimestampType.UnixSeconds, "quoteVolume", "volume", "weightedAverage"));
+                candles.Add(this.ParseCandle(candle, marketSymbol, periodSeconds, "open", "high", "low", "close", "date", TimestampType.UnixSeconds, "quoteVolume", "volume", "weightedAverage"));
             }
             return candles;
         }
@@ -668,11 +668,11 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string symbol)
+        protected override async Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string marketSymbol)
         {
             List<object> orderParams = new List<object>
             {
-                "currencyPair", symbol
+                "currencyPair", marketSymbol
             };
 
             JToken result = await MakePrivateAPIRequestAsync("getMarginPosition", orderParams);
@@ -685,16 +685,16 @@ namespace ExchangeSharp
                 ProfitLoss = result["pl"].ConvertInvariant<decimal>(),
                 LendingFees = result["lendingFees"].ConvertInvariant<decimal>(),
                 Type = result["type"].ToStringInvariant(),
-                Symbol = symbol
+                MarketSymbol = marketSymbol
             };
             return marginPositionResult;
         }
 
-        protected override async Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string symbol)
+        protected override async Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string marketSymbol)
         {
             List<object> orderParams = new List<object>
             {
-                "currencyPair", symbol
+                "currencyPair", marketSymbol
             };
 
             JToken result = await MakePrivateAPIRequestAsync("closeMarginPosition", orderParams);
@@ -703,14 +703,14 @@ namespace ExchangeSharp
             {
                 Success = result["success"].ConvertInvariant<bool>(),
                 Message = result["message"].ToStringInvariant(),
-                Symbol = symbol
+                MarketSymbol = marketSymbol
             };
 
             JToken symbolTrades = result["resultingTrades"];
             if (symbolTrades == null || !symbolTrades.Any())
                 return closePositionResult;
 
-            JToken trades = symbolTrades[symbol];
+            JToken trades = symbolTrades[marketSymbol];
             if (trades != null && trades.Children().Count() != 0)
             {
                 ParseClosePositionTrades(trades, closePositionResult);
@@ -726,12 +726,12 @@ namespace ExchangeSharp
                 throw new NotSupportedException("Order type " + order.OrderType + " not supported");
             }
 
-            decimal orderAmount = await ClampOrderQuantity(order.Symbol, order.Amount);
-            decimal orderPrice = await ClampOrderPrice(order.Symbol, order.Price);
+            decimal orderAmount = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+            decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
 
             List<object> orderParams = new List<object>
             {
-                "currencyPair", order.Symbol,
+                "currencyPair", order.MarketSymbol,
                 "rate", orderPrice.ToStringInvariant(),
                 "amount", orderAmount.ToStringInvariant()
             };
@@ -743,21 +743,21 @@ namespace ExchangeSharp
 
             JToken result = await MakePrivateAPIRequestAsync(order.IsBuy ? (order.IsMargin ? "marginBuy" : "buy") : (order.IsMargin ? "marginSell" : "sell"), orderParams);
             ExchangeOrderResult exchangeOrderResult = ParsePlacedOrder(result);
-            exchangeOrderResult.Symbol = order.Symbol;
-            exchangeOrderResult.FeesCurrency = ParseFeesCurrency(order.IsBuy, order.Symbol);
+            exchangeOrderResult.MarketSymbol = order.MarketSymbol;
+            exchangeOrderResult.FeesCurrency = ParseFeesCurrency(order.IsBuy, order.MarketSymbol);
             return exchangeOrderResult;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
-            if (symbol.Length == 0)
+            if (marketSymbol.Length == 0)
             {
-                symbol = "all";
+                marketSymbol = "all";
             }
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JToken result = await MakePrivateAPIRequestAsync("returnOpenOrders", new object[] { "currencyPair", symbol });
-            if (symbol == "all")
+            JToken result = await MakePrivateAPIRequestAsync("returnOpenOrders", new object[] { "currencyPair", marketSymbol });
+            if (marketSymbol == "all")
             {
                 foreach (JProperty prop in result)
                 {
@@ -774,14 +774,14 @@ namespace ExchangeSharp
             {
                 foreach (JToken token in array)
                 {
-                    orders.Add(ParseOpenOrder(token, symbol));
+                    orders.Add(ParseOpenOrder(token, marketSymbol));
                 }
             }
 
             return orders;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             JToken resultArray = await MakePrivateAPIRequestAsync("returnOrderTrades", new object[] { "orderNumber", orderId });
             string tickerSymbol = resultArray[0]["currencyPair"].ToStringInvariant();
@@ -797,17 +797,17 @@ namespace ExchangeSharp
             return orders[0];
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
-            symbol = string.IsNullOrWhiteSpace(symbol) ? "all" : NormalizeSymbol(symbol);
+            marketSymbol = string.IsNullOrWhiteSpace(marketSymbol) ? "all" : NormalizeMarketSymbol(marketSymbol);
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             afterDate = afterDate ?? CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(365.0));
             long afterTimestamp = (long)afterDate.Value.UnixTimestampFromDateTimeSeconds();
-            JToken result = await MakePrivateAPIRequestAsync("returnTradeHistory", new object[] { "currencyPair", symbol, "limit", 10000, "start", afterTimestamp });
-            if (symbol != "all")
+            JToken result = await MakePrivateAPIRequestAsync("returnTradeHistory", new object[] { "currencyPair", marketSymbol, "limit", 10000, "start", afterTimestamp });
+            if (marketSymbol != "all")
             {
-                ParseCompletedOrderDetails(orders, result as JArray, symbol);
+                ParseCompletedOrderDetails(orders, result as JArray, marketSymbol);
             }
             else
             {
@@ -819,7 +819,7 @@ namespace ExchangeSharp
             return orders;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             await MakePrivateAPIRequestAsync("cancelOrder", new object[] { "orderNumber", orderId.ConvertInvariant<long>() });
         }
@@ -843,7 +843,7 @@ namespace ExchangeSharp
                 }
             }
 
-            var paramsList = new List<object> { "currency", NormalizeSymbol(withdrawalRequest.Currency), "amount", withdrawalRequest.Amount, "address", withdrawalRequest.Address };
+            var paramsList = new List<object> { "currency", NormalizeMarketSymbol(withdrawalRequest.Currency), "amount", withdrawalRequest.Amount, "address", withdrawalRequest.Address };
             if (!string.IsNullOrWhiteSpace(withdrawalRequest.AddressTag))
             {
                 paramsList.Add("paymentId");
@@ -879,7 +879,7 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="currency">(ignored) The symbol to check.</param>
+        /// <param name="currency">(ignored) The currency to check.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
         protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {

--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -369,7 +369,8 @@ namespace ExchangeSharp
             {
                 string symbol = prop.Name;
                 JToken values = prop.Value;
-                ExchangeTicker ticker = this.ParseTicker(values, symbol, "lowestAsk", "highestBid", "last", "baseVolume", "quoteVolume", idKey: "id");
+                //NOTE: Poloniex uses the term "caseVolume" when referring to the QuoteCurrencyVolume
+                ExchangeTicker ticker = this.ParseTicker(values, symbol, "lowestAsk", "highestBid", "last", "quoteVolume", "baseVolume", idKey: "id");
                 tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ticker));
             }
             return tickers;
@@ -615,7 +616,7 @@ namespace ExchangeSharp
             List<MarketCandle> candles = new List<MarketCandle>();
             foreach (JToken candle in token)
             {
-                candles.Add(this.ParseCandle(candle, symbol, periodSeconds, "open", "high", "low", "close", "date", TimestampType.UnixSeconds, "volume", "quoteVolume", "weightedAverage"));
+                candles.Add(this.ParseCandle(candle, symbol, periodSeconds, "open", "high", "low", "close", "date", TimestampType.UnixSeconds, "quoteVolume", "volume", "weightedAverage"));
             }
             return candles;
         }

--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -370,7 +370,7 @@ namespace ExchangeSharp
                 string symbol = prop.Name;
                 JToken values = prop.Value;
                 ExchangeTicker ticker = this.ParseTicker(values, symbol, "lowestAsk", "highestBid", "last", "baseVolume", "quoteVolume", idKey: "id");
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, this.ParseTicker(values, symbol, "lowestAsk", "highestBid", "last", "baseVolume", "quoteVolume", idKey: "id")));
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ticker));
             }
             return tickers;
         }

--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -333,8 +333,8 @@ namespace ExchangeSharp
                 string[] pairs = kvp.Key.Split('_');
                 if (pairs.Length == 2)
                 {
-                    market.BaseCurrency = pairs[0];
-                    market.MarketCurrency = pairs[1];
+                    market.QuoteCurrency = pairs[0];
+                    market.BaseCurrency = pairs[1];
                     market.PriceStepSize = StepSize;
                     market.QuantityStepSize = StepSize;
                     market.MinPrice = StepSize;

--- a/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -878,9 +878,9 @@ namespace ExchangeSharp
         }
 
         /// <summary>Gets the deposit history for a symbol</summary>
-        /// <param name="symbol">(ignored) The symbol to check.</param>
+        /// <param name="currency">(ignored) The symbol to check.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             JToken result = await MakePrivateAPIRequestAsync("returnDepositsWithdrawals",
                 new object[]
@@ -895,7 +895,7 @@ namespace ExchangeSharp
             {
                 var deposit = new ExchangeTransaction
                 {
-                    Symbol = token["currency"].ToStringUpperInvariant(),
+                    Currency = token["currency"].ToStringUpperInvariant(),
                     Address = token["address"].ToStringInvariant(),
                     Amount = token["amount"].ConvertInvariant<decimal>(),
                     BlockchainTxId = token["txid"].ToStringInvariant(),

--- a/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
@@ -350,19 +350,19 @@ namespace ExchangeSharp
         }
 
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "getmyaddresses");
 
             // "addresses": { "BTC": "14iuWRBwB35HYG98vBxmVJoJZG73BZy4bZ", "LTC": "LXLWHFLpPbcKx69diMVEXVLAzSMXsyrQH2", "DOGE": "DGon17FjjTTVXaHeotm1gvw6ewUZ49WeZr",  }
             JToken token = await MakeJsonRequestAsync<JToken>("/api", null, payload, "POST");
-            if (token != null && token.HasValues && token["addresses"][symbol] != null)
+            if (token != null && token.HasValues && token["addresses"][currency] != null)
             {
                 return new ExchangeDepositDetails()
                 {
-                    Symbol = symbol,
-                    Address = token["addresses"][symbol].ToStringInvariant()
+                    Currency = currency,
+                    Address = token["addresses"][currency].ToStringInvariant()
                 };
             }
             return null;

--- a/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
@@ -325,7 +325,7 @@ namespace ExchangeSharp
             // nothing is returned on this call
         }
 
-        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             List<ExchangeTransaction> deposits = new List<ExchangeTransaction>();
             var payload = await GetNoncePayloadAsync();
@@ -336,9 +336,9 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/api", null, payload, "POST");
             foreach (JToken deposit in token.First)
             {
-                if (deposit["symbol"].ToStringInvariant().Equals(symbol)) deposits.Add(new ExchangeTransaction()
+                if (deposit["symbol"].ToStringInvariant().Equals(currency)) deposits.Add(new ExchangeTransaction()
                 {
-                    Symbol = symbol,
+                    Currency = currency,
                     Timestamp = deposit["date"].ToDateTimeInvariant(),
                     Address = deposit["coin"].ToStringInvariant(),
                     BlockchainTxId = deposit["txid"].ToStringInvariant(),

--- a/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
@@ -33,8 +33,8 @@ namespace ExchangeSharp
         {
             RequestContentType = "application/x-www-form-urlencoded";
             NonceStyle = NonceStyle.UnixMillisecondsString;
-            SymbolSeparator = "_";
-            SymbolIsReversed = true;
+            MarketSymbolSeparator = "_";
+            MarketSymbolIsReversed = true;
         }
 
         #region ProcessRequest 
@@ -86,7 +86,7 @@ namespace ExchangeSharp
         /// Uses TuxExchange getticker method to return market names
         /// </summary>
         /// <returns></returns>
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             // {"BTC_LTC":{"id":"2","last":"0.0068","lowestAsk":0,"highestBid":0,"percentChange":"6.249999999999989","quoteVolume":"0.5550265","isFrozen":0,"baseVolume":0,"high24hr":"0.0068","low24hr":"0.0064"}, ...
             JToken token = await MakeJsonRequestAsync<JToken>("/api?method=getticker");
@@ -97,7 +97,7 @@ namespace ExchangeSharp
         /// Uses TuxExchange getticker method to get as much Market info as provided
         /// </summary>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             // {"BTC_LTC":{"id":"2","last":"0.0068","lowestAsk":0,"highestBid":0,"percentChange":"6.249999999999989","quoteVolume":"0.5550265","isFrozen":0,"baseVolume":0,"high24hr":"0.0068","low24hr":"0.0064"}, ...
@@ -107,7 +107,7 @@ namespace ExchangeSharp
                 var split = prop.Name.Split('_');
                 markets.Add(new ExchangeMarket()
                 {
-                    MarketName = prop.Name.ToStringInvariant(),
+                    MarketSymbol = prop.Name.ToStringInvariant(),
                     IsActive = prop.First["isFrozen"].ConvertInvariant<int>() == 0,
                     //NOTE: they list the quote currency first which is unusual
                     QuoteCurrency = split[0],
@@ -132,22 +132,22 @@ namespace ExchangeSharp
         /// <summary>
         /// Uses TuxExchange getticker method and filters by symbol
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <returns></returns>
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
             var tickers = await OnGetTickersAsync();
-            return tickers.Where(t => t.Key.Equals(symbol)).Select(t => t.Value).FirstOrDefault();
+            return tickers.Where(t => t.Key.Equals(marketSymbol)).Select(t => t.Value).FirstOrDefault();
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            var split = symbol.Split('_');
+            var split = marketSymbol.Split('_');
             JToken token = await MakeJsonRequestAsync<JToken>("/api?method=getorders&coin=" + split[1] + "&market=" + split[0]);
             return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token);
         }
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
 
@@ -157,7 +157,7 @@ namespace ExchangeSharp
             long end = (long)CryptoUtility.UtcNow.UnixTimestampFromDateTimeSeconds();
 
             // All TuxExchange Market Symbols begin with "BTC_" as a base-currency. They only support getting Trades for the Market Currency Symbol, so we split it for the call
-            string cur = symbol.Split(SymbolSeparator[0])[1];
+            string cur = marketSymbol.Split(MarketSymbolSeparator[0])[1];
 
             // [{"tradeid":"3375","date":"2016-08-26 18:53:38","type":"buy","rate":"0.00000041","amount":"420.00000000","total":"0.00017220"}, ... ]
             // https://tuxexchange.com/api?method=gettradehistory&coin=DOGE&start=1472237476&end=1472237618
@@ -171,12 +171,12 @@ namespace ExchangeSharp
             else return trades;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             long start = startDate == null ? (long)CryptoUtility.UtcNow.AddDays(-1).UnixTimestampFromDateTimeSeconds() : new DateTimeOffset((DateTime)startDate).ToUnixTimeSeconds();
             long end = (long)CryptoUtility.UtcNow.UnixTimestampFromDateTimeSeconds();
-            string coin = symbol.Split(SymbolSeparator[0])[1];
+            string coin = marketSymbol.Split(MarketSymbolSeparator[0])[1];
             string url = "/api?method=gettradehistory&coin=" + coin + "&start=" + start + "&end=" + end;
             JToken token = await MakeJsonRequestAsync<JToken>(url);
             foreach (JToken trade in token)
@@ -190,13 +190,13 @@ namespace ExchangeSharp
         /// TuxExchange doesn't support GetCandles. It is possible to get all trades since startdate (filter by enddate if needed) and then aggregate into MarketCandles by periodSeconds 
         /// TODO: Aggregate TuxExchange Trades into Candles
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="periodSeconds"></param>
         /// <param name="startDate"></param>
         /// <param name="endDate"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             throw new NotImplementedException();
         }
@@ -245,10 +245,10 @@ namespace ExchangeSharp
         /// <summary>
         /// TODO: Exchange API Documentation is missing the return values of this call
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="afterDate"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
 
@@ -266,9 +266,9 @@ namespace ExchangeSharp
         /// <summary>
         /// TODO: Exchange API Documentation is missing the return values of this call
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
 
@@ -280,7 +280,7 @@ namespace ExchangeSharp
             throw new NotImplementedException("API Interface Incomplete");
         }
 
-        protected override Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             // see OnGetCompletedOrderDetailsAsync
             throw new NotImplementedException("API Interface Incomplete");
@@ -289,7 +289,7 @@ namespace ExchangeSharp
 
         protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
         {
-            var split = order.Symbol.Split('_');
+            var split = order.MarketSymbol.Split('_');
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", order.IsBuy ? "buy" : "sell");
             payload.Add("market", split[0]);
@@ -315,7 +315,7 @@ namespace ExchangeSharp
         }
 
         // This should have a return value for success
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "cancelorder");

--- a/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/TuxExchange/ExchangeTuxExchangeAPI.cs
@@ -109,8 +109,9 @@ namespace ExchangeSharp
                 {
                     MarketName = prop.Name.ToStringInvariant(),
                     IsActive = prop.First["isFrozen"].ConvertInvariant<int>() == 0,
-                    BaseCurrency = split[0],
-                    MarketCurrency = split[1]
+                    //NOTE: they list the quote currency first which is unusual
+                    QuoteCurrency = split[0],
+                    BaseCurrency = split[1]
                 });
             }
             return markets;

--- a/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
@@ -285,7 +285,7 @@ namespace ExchangeSharp
             await MakeJsonRequestAsync<JToken>("/", PrivateURL, payload, "POST");
         }
 
-        protected override Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol)
+        protected override Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency)
         {
             throw new NotImplementedException("Yobit does not provide a deposit history via the API");  // I don't wonder why
         }

--- a/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
@@ -290,18 +290,18 @@ namespace ExchangeSharp
             throw new NotImplementedException("Yobit does not provide a deposit history via the API");  // I don't wonder why
         }
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("need_new", forceRegenerate ? 1 : 0);
             payload.Add("method", "GetDepositAddress");
-            payload.Add("coinName", symbol);
+            payload.Add("coinName", currency);
             // "return":{"address": 1UHAnAWvxDB9XXETsi7z483zRRBmcUZxb3,"processed_amount": 1.00000000,"server_time": 1437146228 }
             JToken token = await MakeJsonRequestAsync<JToken>("/", PrivateURL, payload, "POST");
             return new ExchangeDepositDetails()
             {
                 Address = token["address"].ToStringInvariant(),
-                Symbol = symbol
+                Currency = currency
             };
         }
 

--- a/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
@@ -90,12 +90,13 @@ namespace ExchangeSharp
                 markets.Add(new ExchangeMarket()
                 {
                     MarketName = prop.Name.ToStringInvariant(),
-                    MarketCurrency = split[0],
-                    BaseCurrency = split[1],
+                    BaseCurrency = split[0],
+                    QuoteCurrency = split[1],
                     IsActive = prop.First["hidden"].ConvertInvariant<int>().Equals(0),
                     MaxPrice = prop.First["max_price"].ConvertInvariant<decimal>(),
                     MinPrice = prop.First["min_price"].ConvertInvariant<decimal>(),
-                    MinTradeSize = prop.First["min_amount"].ConvertInvariant<decimal>()
+                    MinTradeSize = prop.First["min_amount"].ConvertInvariant<decimal>(),
+                    PriceStepSize = Math.Pow(.1, prop.First["decimal_places"].ConvertInvariant<int>()).ConvertInvariant<decimal>()
                 });
             }
             return markets;

--- a/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
@@ -42,8 +42,8 @@ namespace ExchangeSharp
             // to add insult to injury you must always increment by exactly one from the last use of your API key, even when rebooting the computer and restarting your process
             NonceStyle = NonceStyle.Int32File;
 
-            SymbolSeparator = "_";
-            SymbolIsUppercase = false;
+            MarketSymbolSeparator = "_";
+            MarketSymbolIsUppercase = false;
         }
 
         #region ProcessRequest 
@@ -71,7 +71,7 @@ namespace ExchangeSharp
             throw new NotSupportedException("Yobit does not provide data about its currencies via the API");
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             List<string> symbols = new List<string>();
             JToken token = await MakeJsonRequestAsync<JToken>("/info", BaseUrl, null);
@@ -79,7 +79,7 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync()
+        protected override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
         {
             List<ExchangeMarket> markets = new List<ExchangeMarket>();
             // "pairs":{"ltc_btc":{"decimal_places":8,"min_price":0.00000001,"max_price":10000,"min_amount":0.0001,"hidden":0,"fee":0.2} ... }
@@ -89,7 +89,7 @@ namespace ExchangeSharp
                 var split = prop.Name.ToUpperInvariant().Split('_');
                 markets.Add(new ExchangeMarket()
                 {
-                    MarketName = prop.Name.ToStringInvariant(),
+                    MarketSymbol = prop.Name.ToStringInvariant(),
                     BaseCurrency = split[0],
                     QuoteCurrency = split[1],
                     IsActive = prop.First["hidden"].ConvertInvariant<int>().Equals(0),
@@ -102,9 +102,9 @@ namespace ExchangeSharp
             return markets;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/ticker/" + NormalizeSymbol(symbol), null, null, "POST");
+            JToken token = await MakeJsonRequestAsync<JToken>("/ticker/" + NormalizeMarketSymbol(marketSymbol), null, null, "POST");
             if (token != null && token.HasValues) return ParseTicker(token.First as JProperty);
             return null;
         }
@@ -121,25 +121,25 @@ namespace ExchangeSharp
             return await base.OnGetTickersAsync();
         }
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100)
+        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            JToken token = await MakeJsonRequestAsync<JToken>("/depth/" + symbol + "?limit=" + maxCount, BaseUrl, null);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token[symbol]);
+            JToken token = await MakeJsonRequestAsync<JToken>("/depth/" + marketSymbol + "?limit=" + maxCount, BaseUrl, null);
+            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token[marketSymbol]);
         }
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            JToken token = await MakeJsonRequestAsync<JToken>("/trades/" + symbol + "?limit=10", null, null, "POST");    // default is 150, max: 2000, let's do another arbitrary 10 for consistency
+            JToken token = await MakeJsonRequestAsync<JToken>("/trades/" + marketSymbol + "?limit=10", null, null, "POST");    // default is 150, max: 2000, let's do another arbitrary 10 for consistency
             foreach (JToken prop in token.First.First) trades.Add(ParseTrade(prop));
             return trades;
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             // Not directly supported, but we'll return the max and filter if necessary
-            JToken token = await MakeJsonRequestAsync<JToken>("/trades/" + symbol + "?limit=2000", null, null, "POST");
+            JToken token = await MakeJsonRequestAsync<JToken>("/trades/" + marketSymbol + "?limit=2000", null, null, "POST");
             token = token.First.First;      // bunch of nested 
             foreach (JToken prop in token)
             {
@@ -154,13 +154,13 @@ namespace ExchangeSharp
         /// Yobit doesn't support GetCandles. It is possible to get all trades since startdate (filter by enddate if needed) and then aggregate into MarketCandles by periodSeconds 
         /// TODO: Aggregate Yobit Trades into Candles. This may not be worth the effort because the max we can retrieve is 2000 which may or may not be out of the range of start and end for aggregate
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="periodSeconds"></param>
         /// <param name="startDate"></param>
         /// <param name="endDate"></param>
         /// <param name="limit"></param>
         /// <returns></returns>
-        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        protected override Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
             throw new NotImplementedException();
         }
@@ -205,7 +205,7 @@ namespace ExchangeSharp
             return amounts;
         }
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null)
+        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "getInfo");
@@ -218,32 +218,32 @@ namespace ExchangeSharp
         /// <summary>
         /// Warning: Yobit will not return transactions over a week old via their api
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <param name="afterDate"></param>
         /// <returns></returns>
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
-            if (symbol == null) { throw new APIException("symbol cannot be null"); } // Seriously, they want you to loop through over 7500 symbol pairs to find your trades! Geez...
+            if (marketSymbol == null) { throw new APIException("market symbol cannot be null"); } // Seriously, they want you to loop through over 7500 symbol pairs to find your trades! Geez...
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
 
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "TradeHistory");
-            payload.Add("pair", symbol);
+            payload.Add("pair", marketSymbol);
             if (afterDate != null) payload.Add("since", new DateTimeOffset((DateTime)afterDate).ToUnixTimeSeconds());
             JToken token = await MakeJsonRequestAsync<JToken>("/", PrivateURL, payload, "POST");
             if (token != null) foreach (JProperty prop in token) orders.Add(ParseOrder(prop));
             return orders;
         }
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null)
+        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
         {
-            if (symbol == null) { throw new APIException("symbol cannot be null"); } // Seriously, they want you to loop through over 7500 symbol pairs to find your trades! Geez...
+            if (marketSymbol == null) { throw new APIException("market symbol cannot be null"); } // Seriously, they want you to loop through over 7500 symbol pairs to find your trades! Geez...
 
             List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "ActiveOrders");
-            payload.Add("pair", symbol);
+            payload.Add("pair", marketSymbol);
             JToken token = await MakeJsonRequestAsync<JToken>("/", PrivateURL, payload, "POST");
             if (token != null) foreach (JProperty prop in token) orders.Add(ParseOrder(prop));
             foreach (JProperty prop in token) orders.Add(ParseOrder(prop));
@@ -254,7 +254,7 @@ namespace ExchangeSharp
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "Trade");
-            payload.Add("pair", order.Symbol);
+            payload.Add("pair", order.MarketSymbol);
             payload.Add("type", order.IsBuy ? "buy" : "sell");
             payload.Add("rate", order.Price);
             payload.Add("amount", order.Amount);
@@ -277,7 +277,7 @@ namespace ExchangeSharp
             return result;
         }
 
-        protected override async Task OnCancelOrderAsync(string orderId, string symbol = null)
+        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
         {
             var payload = await GetNoncePayloadAsync();
             payload.Add("method", "CancelOrder");
@@ -334,8 +334,8 @@ namespace ExchangeSharp
         private ExchangeTicker ParseTicker(JProperty prop)
         {
             // "ltc_btc":{ "high":105.41,"low":104.67,"avg":105.04,"vol":43398.22251455,"vol_cur":4546.26962359,"last":105.11,"buy":104.2,"sell":105.11,"updated":1418654531 }
-            string symbol = prop.Name.ToUpperInvariant();
-            return this.ParseTicker(prop.First, symbol, "sell", "buy", "last", "vol", "vol_cur", "updated", TimestampType.UnixSeconds);
+            string marketSymbol = prop.Name.ToUpperInvariant();
+            return this.ParseTicker(prop.First, marketSymbol, "sell", "buy", "last", "vol", "vol_cur", "updated", TimestampType.UnixSeconds);
         }
 
         private ExchangeTrade ParseTrade(JToken prop)
@@ -351,7 +351,7 @@ namespace ExchangeSharp
             ExchangeOrderResult result = new ExchangeOrderResult()
             {
                 OrderId = prop.Name,
-                Symbol = prop["pair"].ToStringInvariant(),
+                MarketSymbol = prop["pair"].ToStringInvariant(),
                 Amount = prop["start_amount"].ConvertInvariant<decimal>(),
                 AmountFilled = prop["amount"].ConvertInvariant<decimal>(),
                 Price = prop["rate"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
@@ -26,8 +26,8 @@ namespace ExchangeSharp
 
         public ExchangeZBcomAPI()
         {
-            SymbolSeparator = "_";
-            SymbolIsUppercase = false;
+            MarketSymbolSeparator = "_";
+            MarketSymbolIsUppercase = false;
         }
 
         private string NormalizeSymbolWebsocket(string symbol)
@@ -39,10 +39,10 @@ namespace ExchangeSharp
 
         #region publicAPI
 
-        private async Task<Tuple<JToken, string>> MakeRequestZBcomAsync(string symbol, string subUrl, string baseUrl = null)
+        private async Task<Tuple<JToken, string>> MakeRequestZBcomAsync(string marketSymbol, string subUrl, string baseUrl = null)
         {
-            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", symbol ?? string.Empty), baseUrl);
-            return new Tuple<JToken, string>(obj, symbol);
+            JToken obj = await MakeJsonRequestAsync<JToken>(subUrl.Replace("$SYMBOL$", marketSymbol ?? string.Empty), baseUrl);
+            return new Tuple<JToken, string>(obj, marketSymbol);
         }
 
         private ExchangeTicker ParseTicker(string symbol, JToken data)
@@ -57,7 +57,7 @@ namespace ExchangeSharp
             return this.ParseTicker(data.First, symbol, "sell", "buy", "last", "vol");
         }
 
-        protected override async Task<IEnumerable<string>> OnGetSymbolsAsync()
+        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
         {
             var data = await MakeRequestZBcomAsync(string.Empty, "/markets");
             List<string> symbols = new List<string>();
@@ -68,9 +68,9 @@ namespace ExchangeSharp
             return symbols;
         }
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string symbol)
+        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
         {
-            var data = await MakeRequestZBcomAsync(symbol, "/ticker?market=$SYMBOL$");
+            var data = await MakeRequestZBcomAsync(marketSymbol, "/ticker?market=$SYMBOL$");
             return ParseTicker(data.Item2, data.Item1);
         }
 
@@ -80,18 +80,18 @@ namespace ExchangeSharp
 
             var data = await MakeRequestZBcomAsync(null, "/allTicker", BaseUrl);
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            var symbols = (await GetSymbolsAsync()).ToArray();
-            string symbol;
+            var symbols = (await GetMarketSymbolsAsync()).ToArray();
+            string marketSymbol;
             foreach (JToken token in data.Item1)
             {
                 //for some reason when returning tickers, the api doesn't include the symbol separator like it does everywhere else so we need to convert it to the correct format
-                symbol = symbols.First(s => s.Replace(SymbolSeparator, string.Empty).Equals(token.Path));
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTickerV2(symbol, token)));
+                marketSymbol = symbols.First(s => s.Replace(MarketSymbolSeparator, string.Empty).Equals(token.Path));
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ParseTickerV2(marketSymbol, token)));
             }
             return tickers;
         }
 
-        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        protected override IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             return ConnectWebSocket(string.Empty, (_socket, msg) =>
             {
@@ -100,21 +100,21 @@ namespace ExchangeSharp
                 {
                     var channel = token["channel"].ToStringInvariant();
                     var sArray = channel.Split('_');
-                    string symbol = sArray[0];
+                    string marketSymbol = sArray[0];
                     var data = token["data"];
                     var trades = ParseTradesWebsocket(data);
                     foreach (var trade in trades)
                     {
-                        callback(new KeyValuePair<string, ExchangeTrade>(symbol, trade));
+                        callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
                     }
                 }
                 return Task.CompletedTask;
 
             }, async (_socket) =>
             {
-                foreach (var symbol in symbols)
+                foreach (var marketSymbol in marketSymbols)
                 {
-                    string normalizedSymbol = NormalizeSymbolWebsocket(symbol);
+                    string normalizedSymbol = NormalizeSymbolWebsocket(marketSymbol);
                     await _socket.SendMessageAsync(new { @event = "addChannel", channel = normalizedSymbol + "_trades" });
                 }
             });

--- a/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
+++ b/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
@@ -79,10 +80,12 @@ namespace ExchangeSharp
 
             var data = await MakeRequestZBcomAsync(null, "/allTicker", BaseUrl);
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+            var symbols = (await GetSymbolsAsync()).ToArray();
             string symbol;
             foreach (JToken token in data.Item1)
             {
-                symbol = token.Path;
+                //for some reason when returning tickers, the api doesn't include the symbol separator like it does everywhere else so we need to convert it to the correct format
+                symbol = symbols.First(s => s.Replace(SymbolSeparator, string.Empty).Equals(token.Path));
                 tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ParseTickerV2(symbol, token)));
             }
             return tickers;

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -86,7 +86,7 @@ namespace ExchangeSharp
         protected virtual Task<ExchangeTicker> OnGetTickerAsync(string symbol) => throw new NotImplementedException();
         protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100) => throw new NotImplementedException();
         protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null) => throw new NotImplementedException();
-        protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false) => throw new NotImplementedException();
+        protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false) => throw new NotImplementedException();
         protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency) => throw new NotImplementedException();
         protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAsync() => throw new NotImplementedException();
@@ -614,20 +614,19 @@ namespace ExchangeSharp
         /// <summary>
         /// Gets the address to deposit to and applicable details.
         /// </summary>
-        /// <param name="symbol">Symbol to get address for.</param>
+        /// <param name="currency">Currency to get address for.</param>
         /// <param name="forceRegenerate">Regenerate the address</param>
         /// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
-        public virtual async Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+        public virtual async Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false)
         {
-            symbol = NormalizeSymbol(symbol);
             if (forceRegenerate)
             {
                 // force regenetate, do not cache
-                return await OnGetDepositAddressAsync(symbol, forceRegenerate);
+                return await OnGetDepositAddressAsync(currency, forceRegenerate);
             }
             else
             {
-                return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositAddressAsync(symbol, forceRegenerate), nameof(GetDepositAddressAsync), nameof(symbol), symbol);
+                return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositAddressAsync(currency, forceRegenerate), nameof(GetDepositAddressAsync), nameof(currency), currency);
             }
         }
 

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -87,7 +87,7 @@ namespace ExchangeSharp
         protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100) => throw new NotImplementedException();
         protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null) => throw new NotImplementedException();
         protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string symbol) => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency) => throw new NotImplementedException();
         protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAsync() => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetFeesAsync() => throw new NotImplementedException();
@@ -635,10 +635,9 @@ namespace ExchangeSharp
         /// Gets the deposit history for a symbol
         /// </summary>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public virtual async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol)
+        public virtual async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositHistoryAsync(symbol), nameof(GetDepositHistoryAsync), nameof(symbol), symbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositHistoryAsync(currency), nameof(GetDepositHistoryAsync), nameof(currency), currency);
         }
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -27,7 +27,7 @@ namespace ExchangeSharp
         /// <summary>
         /// Separator for global symbols
         /// </summary>
-        public const char GlobalSymbolSeparator = '-';
+        public const char GlobalMarketSymbolSeparator = '-';
 
         /// <summary>
         /// Whether to use the default method cache policy, default is true.
@@ -47,11 +47,11 @@ namespace ExchangeSharp
         protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            var symbols = await GetSymbolsAsync();
-            foreach (string symbol in symbols)
+            var marketSymbols = await GetMarketSymbolsAsync();
+            foreach (string marketSymbol in marketSymbols)
             {
-                var ticker = await GetTickerAsync(symbol);
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(symbol, ticker));
+                var ticker = await GetTickerAsync(marketSymbol);
+                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ticker));
             }
             return tickers;
         }
@@ -59,53 +59,53 @@ namespace ExchangeSharp
         protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(int maxCount = 100)
         {
             List<KeyValuePair<string, ExchangeOrderBook>> books = new List<KeyValuePair<string, ExchangeOrderBook>>();
-            var symbols = await GetSymbolsAsync();
-            foreach (string symbol in symbols)
+            var marketSymbols = await GetMarketSymbolsAsync();
+            foreach (string marketSymbol in marketSymbols)
             {
-                var book = await GetOrderBookAsync(symbol);
-                books.Add(new KeyValuePair<string, ExchangeOrderBook>(symbol, book));
+                var book = await GetOrderBookAsync(marketSymbol);
+                books.Add(new KeyValuePair<string, ExchangeOrderBook>(marketSymbol, book));
             }
             return books;
         }
 
-        protected virtual async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string symbol)
+        protected virtual async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol)
         {
-            symbol = NormalizeSymbol(symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
             await GetHistoricalTradesAsync((e) =>
             {
                 trades.AddRange(e);
                 return true;
-            }, symbol);
+            }, marketSymbol);
             return trades;
         }
 
         protected virtual Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync() => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<string>> OnGetSymbolsAsync() => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeMarket>> OnGetSymbolsMetadataAsync() => throw new NotImplementedException();
-        protected virtual Task<ExchangeTicker> OnGetTickerAsync(string symbol) => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string symbol, int maxCount = 100) => throw new NotImplementedException();
-        protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null) => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<string>> OnGetMarketSymbolsAsync() => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync() => throw new NotImplementedException();
+        protected virtual Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol) => throw new NotImplementedException();
+        protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100) => throw new NotImplementedException();
+        protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null) => throw new NotImplementedException();
         protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false) => throw new NotImplementedException();
         protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAsync() => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetFeesAsync() => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync() => throw new NotImplementedException();
         protected virtual Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order) => throw new NotImplementedException();
         protected virtual Task<ExchangeOrderResult[]> OnPlaceOrdersAsync(params ExchangeOrderRequest[] order) => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string symbol = null) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string symbol = null) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null) => throw new NotImplementedException();
-        protected virtual Task OnCancelOrderAsync(string orderId, string symbol = null) => throw new NotImplementedException();
+        protected virtual Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null) => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null) => throw new NotImplementedException();
+        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null) => throw new NotImplementedException();
+        protected virtual Task OnCancelOrderAsync(string orderId, string marketSymbol = null) => throw new NotImplementedException();
         protected virtual Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest) => throw new NotImplementedException();
         protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances) => throw new NotImplementedException();
-        protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string symbol) => throw new NotImplementedException();
-        protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string symbol) => throw new NotImplementedException();
+        protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string marketSymbol) => throw new NotImplementedException();
+        protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string marketSymbol) => throw new NotImplementedException();
 
         protected virtual IWebSocket OnGetTickersWebSocket(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers) => throw new NotImplementedException();
-        protected virtual IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols) => throw new NotImplementedException();
-        protected virtual IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols) => throw new NotImplementedException();
+        protected virtual IWebSocket OnGetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols) => throw new NotImplementedException();
+        protected virtual IWebSocket OnGetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols) => throw new NotImplementedException();
         protected virtual IWebSocket OnGetOrderDetailsWebSocket(Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
         protected virtual IWebSocket OnGetCompletedOrderDetailsWebSocket(Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
 
@@ -116,24 +116,24 @@ namespace ExchangeSharp
         /// <summary>
         /// Clamp price using market info. If necessary, a network request will be made to retrieve symbol metadata.
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <param name="outputPrice">Price</param>
         /// <returns>Clamped price</returns>
-        protected async Task<decimal> ClampOrderPrice(string symbol, decimal outputPrice)
+        protected async Task<decimal> ClampOrderPrice(string marketSymbol, decimal outputPrice)
         {
-            ExchangeMarket market = await GetExchangeMarketFromCacheAsync(symbol);
+            ExchangeMarket market = await GetExchangeMarketFromCacheAsync(marketSymbol);
             return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice, market.MaxPrice, market.PriceStepSize, outputPrice);
         }
 
         /// <summary>
         /// Clamp quantiy using market info. If necessary, a network request will be made to retrieve symbol metadata.
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <param name="outputQuantity">Quantity</param>
         /// <returns>Clamped quantity</returns>
-        protected async Task<decimal> ClampOrderQuantity(string symbol, decimal outputQuantity)
+        protected async Task<decimal> ClampOrderQuantity(string marketSymbol, decimal outputQuantity)
         {
-            ExchangeMarket market = await GetExchangeMarketFromCacheAsync(symbol);
+            ExchangeMarket market = await GetExchangeMarketFromCacheAsync(marketSymbol);
             return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, outputQuantity);
         }
 
@@ -144,21 +144,21 @@ namespace ExchangeSharp
         /// second (i.e. ETH). Example BTC-ETH, read as x BTC is worth y ETH.
         /// BTC is always first, then ETH, etc. Fiat pair is always first in global symbol too.
         /// </summary>
-        /// <param name="symbol">Exchange symbol</param>
+        /// <param name="marketSymbol">Exchange market symbol</param>
         /// <param name="separator">Separator</param>
         /// <returns>Global symbol</returns>
-        protected string ExchangeSymbolToGlobalSymbolWithSeparator(string symbol, char separator = GlobalSymbolSeparator)
+        protected string ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(string marketSymbol, char separator = GlobalMarketSymbolSeparator)
         {
-            if (string.IsNullOrEmpty(symbol))
+            if (string.IsNullOrEmpty(marketSymbol))
             {
                 throw new ArgumentException("Symbol must be non null and non empty");
             }
-            string[] pieces = symbol.Split(separator);
-            if (SymbolIsReversed)
+            string[] pieces = marketSymbol.Split(separator);
+            if (MarketSymbolIsReversed)
             {
-                return ExchangeCurrencyToGlobalCurrency(pieces[0]).ToUpperInvariant() + GlobalSymbolSeparator + ExchangeCurrencyToGlobalCurrency(pieces[1]).ToUpperInvariant();
+                return ExchangeCurrencyToGlobalCurrency(pieces[0]).ToUpperInvariant() + GlobalMarketSymbolSeparator + ExchangeCurrencyToGlobalCurrency(pieces[1]).ToUpperInvariant();
             }
-            return ExchangeCurrencyToGlobalCurrency(pieces[1]).ToUpperInvariant() + GlobalSymbolSeparator + ExchangeCurrencyToGlobalCurrency(pieces[0]).ToUpperInvariant();
+            return ExchangeCurrencyToGlobalCurrency(pieces[1]).ToUpperInvariant() + GlobalMarketSymbolSeparator + ExchangeCurrencyToGlobalCurrency(pieces[0]).ToUpperInvariant();
         }
 
         /// <summary>
@@ -197,8 +197,8 @@ namespace ExchangeSharp
             if (UseDefaultMethodCachePolicy)
             {
                 MethodCachePolicy.Add(nameof(GetCurrenciesAsync), TimeSpan.FromHours(1.0));
-                MethodCachePolicy.Add(nameof(GetSymbolsAsync), TimeSpan.FromHours(1.0));
-                MethodCachePolicy.Add(nameof(GetSymbolsMetadataAsync), TimeSpan.FromHours(1.0));
+                MethodCachePolicy.Add(nameof(GetMarketSymbolsAsync), TimeSpan.FromHours(1.0));
+                MethodCachePolicy.Add(nameof(GetMarketSymbolsMetadataAsync), TimeSpan.FromHours(1.0));
                 MethodCachePolicy.Add(nameof(GetTickerAsync), TimeSpan.FromSeconds(10.0));
                 MethodCachePolicy.Add(nameof(GetTickersAsync), TimeSpan.FromSeconds(10.0));
                 MethodCachePolicy.Add(nameof(GetOrderBookAsync), TimeSpan.FromSeconds(10.0));
@@ -337,28 +337,28 @@ namespace ExchangeSharp
             {
                 currency = currency.Replace(kv.Value, kv.Key);
             }
-            return (SymbolIsUppercase ? currency.ToUpperInvariant() : currency.ToLowerInvariant());
+            return (MarketSymbolIsUppercase ? currency.ToUpperInvariant() : currency.ToLowerInvariant());
         }
 
         /// <summary>
         /// Normalize an exchange specific symbol. The symbol should already be in the correct order,
         /// this method just deals with casing and putting in the right separator.
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <returns>Normalized symbol</returns>
-        public virtual string NormalizeSymbol(string symbol)
+        public virtual string NormalizeMarketSymbol(string marketSymbol)
         {
-            symbol = (symbol ?? string.Empty).Trim();
-            symbol = symbol.Replace("-", SymbolSeparator)
-                .Replace("/", SymbolSeparator)
-                .Replace("_", SymbolSeparator)
-                .Replace(" ", SymbolSeparator)
-                .Replace(":", SymbolSeparator);
-            if (SymbolIsUppercase)
+            marketSymbol = (marketSymbol ?? string.Empty).Trim();
+            marketSymbol = marketSymbol.Replace("-", MarketSymbolSeparator)
+                .Replace("/", MarketSymbolSeparator)
+                .Replace("_", MarketSymbolSeparator)
+                .Replace(" ", MarketSymbolSeparator)
+                .Replace(":", MarketSymbolSeparator);
+            if (MarketSymbolIsUppercase)
             {
-                return symbol.ToUpperInvariant();
+                return marketSymbol.ToUpperInvariant();
             }
-            return symbol.ToLowerInvariant();
+            return marketSymbol.ToLowerInvariant();
         }
 
         /// <summary>
@@ -368,28 +368,28 @@ namespace ExchangeSharp
         /// second (i.e. ETH). Example BTC-ETH, read as x BTC is worth y ETH.
         /// BTC is always first, then ETH, etc. Fiat pair is always first in global symbol too.
         /// </summary>
-        /// <param name="symbol">Exchange symbol</param>
+        /// <param name="marketSymbol">Exchange symbol</param>
         /// <returns>Global symbol</returns>
-        public virtual string ExchangeSymbolToGlobalSymbol(string symbol)
+        public virtual string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol)
         {
-            if (string.IsNullOrWhiteSpace(SymbolSeparator))
+            if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
             {
-                if (symbol.Length != 6)
+                if (marketSymbol.Length != 6)
                 {
-                    throw new InvalidOperationException(Name + " symbol must be 6 chars: '" + symbol + "' is not. Override this method to handle symbols that are not 6 chars in length.");
+                    throw new InvalidOperationException(Name + " market symbol must be 6 chars: '" + marketSymbol + "' is not. Override this method to handle symbols that are not 6 chars in length.");
                 }
-                return ExchangeSymbolToGlobalSymbolWithSeparator(symbol.Substring(0, symbol.Length - 3) + GlobalSymbolSeparator + (symbol.Substring(symbol.Length - 3, 3)), GlobalSymbolSeparator);
+                return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(marketSymbol.Substring(0, marketSymbol.Length - 3) + GlobalMarketSymbolSeparator + (marketSymbol.Substring(marketSymbol.Length - 3, 3)), GlobalMarketSymbolSeparator);
             }
-            return ExchangeSymbolToGlobalSymbolWithSeparator(symbol, SymbolSeparator[0]);
+            return ExchangeMarketSymbolToGlobalMarketSymbolWithSeparator(marketSymbol, MarketSymbolSeparator[0]);
         }
 
-        public virtual string CurrenciesToExchangeSymbol(string baseCurrency, string quoteCurrency)
+        public virtual string CurrenciesToExchangeMarketSymbol(string baseCurrency, string quoteCurrency)
         {
-            var symbol = SymbolIsReversed 
-                       ? $"{quoteCurrency}{SymbolSeparator}{baseCurrency}" 
-                       : $"{baseCurrency}{SymbolSeparator}{quoteCurrency}";
+            var symbol = MarketSymbolIsReversed 
+                       ? $"{quoteCurrency}{MarketSymbolSeparator}{baseCurrency}" 
+                       : $"{baseCurrency}{MarketSymbolSeparator}{quoteCurrency}";
 
-            return SymbolIsUppercase
+            return MarketSymbolIsUppercase
                        ? symbol.ToUpperInvariant()
                        : symbol;
         }
@@ -397,26 +397,26 @@ namespace ExchangeSharp
         /// <summary>
         /// NOTE: This method can potentially make a call to GetSymbolsMetadataAsync 
         /// </summary>
-        /// <param name="symbol"></param>
+        /// <param name="marketSymbol"></param>
         /// <returns></returns>
-        public virtual (string BaseCurrency, string QuoteCurrency) ExchangeSymbolToCurrencies(string symbol)
+        public virtual (string BaseCurrency, string QuoteCurrency) ExchangeMarketSymbolToCurrencies(string marketSymbol)
         {
             string baseCurrency, quoteCurrency;
-            if (string.IsNullOrWhiteSpace(SymbolSeparator))
+            if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
             {
-                if (symbol.Length != 6)
+                if (marketSymbol.Length != 6)
                 {
-                    var errorMessage = Name + " symbol must be 6 chars: '" + symbol + "' is not. Override this method to handle symbols that are not 6 chars in length.";
+                    var errorMessage = Name + " symbol must be 6 chars: '" + marketSymbol + "' is not. Override this method to handle symbols that are not 6 chars in length.";
                     try
                     {
                         //let's try looking this up by the metadata..
-                        var symbols = GetSymbolsMetadataAsync().Sync().ToArray();//.ToDictionary(market => market.MarketName, market => market);
-                        var symbolMetadata = symbols.First(
-                                market => market.MarketName.Equals(symbol, StringComparison.InvariantCultureIgnoreCase) || CurrenciesToExchangeSymbol(market.BaseCurrency, market.QuoteCurrency)
-                                   .Equals(symbol, StringComparison.InvariantCultureIgnoreCase)
+                        var symbols = GetMarketSymbolsMetadataAsync().Sync().ToArray();//.ToDictionary(market => market.MarketName, market => market);
+                        var marketSymbolMetadata = symbols.First(
+                                market => market.MarketSymbol.Equals(marketSymbol, StringComparison.InvariantCultureIgnoreCase) || CurrenciesToExchangeMarketSymbol(market.BaseCurrency, market.QuoteCurrency)
+                                   .Equals(marketSymbol, StringComparison.InvariantCultureIgnoreCase)
                             );
 
-                        return (symbolMetadata.BaseCurrency, symbolMetadata.QuoteCurrency);
+                        return (marketSymbolMetadata.BaseCurrency, marketSymbolMetadata.QuoteCurrency);
                     }
                     catch (Exception e)
                     {
@@ -425,24 +425,24 @@ namespace ExchangeSharp
                     throw new InvalidOperationException(errorMessage);
                 }
 
-                if (SymbolIsReversed)
+                if (MarketSymbolIsReversed)
                 {
-                    quoteCurrency = symbol.Substring(0, symbol.Length - 3);
-                    baseCurrency = symbol.Substring(symbol.Length - 3, 3);
+                    quoteCurrency = marketSymbol.Substring(0, marketSymbol.Length - 3);
+                    baseCurrency = marketSymbol.Substring(marketSymbol.Length - 3, 3);
                 }
                 else
                 {
-                    baseCurrency = symbol.Substring(0, symbol.Length - 3);
-                    quoteCurrency = symbol.Substring(symbol.Length - 3, 3);
+                    baseCurrency = marketSymbol.Substring(0, marketSymbol.Length - 3);
+                    quoteCurrency = marketSymbol.Substring(marketSymbol.Length - 3, 3);
                 }
             }
             else
             {
-                var pieces = symbol.Split(SymbolSeparator[0]);
+                var pieces = marketSymbol.Split(MarketSymbolSeparator[0]);
                 if (pieces.Length != 2)
-                    throw new InvalidOperationException($"Splitting {Name} symbol '{symbol}' with symbol separator '{SymbolSeparator}' must result in exactly 2 pieces.");
-                quoteCurrency = SymbolIsReversed ? pieces[0] : pieces[1];
-                baseCurrency = SymbolIsReversed ? pieces[1] : pieces[0];
+                    throw new InvalidOperationException($"Splitting {Name} symbol '{marketSymbol}' with symbol separator '{MarketSymbolSeparator}' must result in exactly 2 pieces.");
+                quoteCurrency = MarketSymbolIsReversed ? pieces[0] : pieces[1];
+                baseCurrency = MarketSymbolIsReversed ? pieces[1] : pieces[0];
             }
 
             return (baseCurrency, quoteCurrency);
@@ -451,24 +451,24 @@ namespace ExchangeSharp
         /// <summary>
         /// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
         /// </summary>
-        /// <param name="symbol">Global symbol</param>
-        /// <returns>Exchange symbol</returns>
-        public virtual string GlobalSymbolToExchangeSymbol(string symbol)
+        /// <param name="marketSymbol">Global market symbol</param>
+        /// <returns>Exchange market symbol</returns>
+        public virtual string GlobalMarketSymbolToExchangeMarketSymbol(string marketSymbol)
         {
-            if (string.IsNullOrWhiteSpace(symbol))
+            if (string.IsNullOrWhiteSpace(marketSymbol))
             {
-                throw new ArgumentException("Symbol must be non null and non empty");
+                throw new ArgumentException("Market symbol must be non null and non empty");
             }
-            int pos = symbol.IndexOf(GlobalSymbolSeparator);
-            if (SymbolIsReversed)
+            int pos = marketSymbol.IndexOf(GlobalMarketSymbolSeparator);
+            if (MarketSymbolIsReversed)
             {
-                symbol = GlobalCurrencyToExchangeCurrency(symbol.Substring(0, pos)) + SymbolSeparator + GlobalCurrencyToExchangeCurrency(symbol.Substring(pos + 1));
+                marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1));
             }
             else
             {
-                symbol = GlobalCurrencyToExchangeCurrency(symbol.Substring(pos + 1)) + SymbolSeparator + GlobalCurrencyToExchangeCurrency(symbol.Substring(0, pos));
+                marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos));
             }
-            return (SymbolIsUppercase ? symbol.ToUpperInvariant() : symbol.ToLowerInvariant());
+            return (MarketSymbolIsUppercase ? marketSymbol.ToUpperInvariant() : marketSymbol.ToLowerInvariant());
         }
 
         /// <summary>
@@ -495,27 +495,27 @@ namespace ExchangeSharp
         /// Get exchange symbols
         /// </summary>
         /// <returns>Array of symbols</returns>
-        public virtual async Task<IEnumerable<string>> GetSymbolsAsync()
+        public virtual async Task<IEnumerable<string>> GetMarketSymbolsAsync()
         {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetSymbolsAsync()).ToArray(), nameof(GetSymbolsAsync));
+            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetMarketSymbolsAsync()).ToArray(), nameof(GetMarketSymbolsAsync));
         }
 
         /// <summary>
         /// Get exchange symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
         /// <returns>Collection of ExchangeMarkets</returns>
-        public virtual async Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync()
+        public virtual async Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync()
         {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetSymbolsMetadataAsync()).ToArray(), nameof(GetSymbolsMetadataAsync));
+            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetMarketSymbolsMetadataAsync()).ToArray(), nameof(GetMarketSymbolsMetadataAsync));
         }
 
         /// <summary>
         /// Gets the exchange market from this exchange's SymbolsMetadata cache. This will make a network request if needed to retrieve fresh markets from the exchange using GetSymbolsMetadataAsync().
         /// Please note that sending a symbol that is not found over and over will result in many network requests. Only send symbols that you are confident exist on the exchange.
         /// </summary>
-        /// <param name="symbol">The symbol. Ex. ADA/BTC. This is assumed to be normalized and already correct for the exchange.</param>
+        /// <param name="marketSymbol">The market symbol. Ex. ADA/BTC. This is assumed to be normalized and already correct for the exchange.</param>
         /// <returns>The ExchangeMarket or null if it doesn't exist in the cache or there was an error</returns>
-        public virtual async Task<ExchangeMarket> GetExchangeMarketFromCacheAsync(string symbol)
+        public virtual async Task<ExchangeMarket> GetExchangeMarketFromCacheAsync(string marketSymbol)
         {
             try
             {
@@ -523,17 +523,17 @@ namespace ExchangeSharp
 
                 // not sure if this is needed, but adding it just in case
                 await new SynchronizationContextRemover();
-                ExchangeMarket[] markets = (await GetSymbolsMetadataAsync()).ToArray();
-                ExchangeMarket market = markets.FirstOrDefault(m => m.MarketName == symbol);
+                ExchangeMarket[] markets = (await GetMarketSymbolsMetadataAsync()).ToArray();
+                ExchangeMarket market = markets.FirstOrDefault(m => m.MarketSymbol == marketSymbol);
                 if (market == null)
                 {
                     // try again with a fresh request, every symbol *should* be in the response from PopulateExchangeMarketsAsync
-                    Cache.Remove(nameof(GetSymbolsMetadataAsync));
+                    Cache.Remove(nameof(GetMarketSymbolsMetadataAsync));
 
-                    markets = (await GetSymbolsMetadataAsync()).ToArray();
+                    markets = (await GetMarketSymbolsMetadataAsync()).ToArray();
 
                     // try and find the market again, this time if not found we give up and just return null
-                    market = markets.FirstOrDefault(m => m.MarketName == symbol);
+                    market = markets.FirstOrDefault(m => m.MarketSymbol == marketSymbol);
                 }
                 return market;
             }
@@ -547,12 +547,12 @@ namespace ExchangeSharp
         /// <summary>
         /// Get exchange ticker
         /// </summary>
-        /// <param name="symbol">Symbol to get ticker for</param>
+        /// <param name="marketSymbol">Symbol to get ticker for</param>
         /// <returns>Ticker</returns>
-        public virtual async Task<ExchangeTicker> GetTickerAsync(string symbol)
+        public virtual async Task<ExchangeTicker> GetTickerAsync(string marketSymbol)
         {
-            NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetTickerAsync(symbol), nameof(GetTickerAsync), nameof(symbol), symbol);
+            NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetTickerAsync(marketSymbol), nameof(GetTickerAsync), nameof(marketSymbol), marketSymbol);
         }
 
         /// <summary>
@@ -567,13 +567,13 @@ namespace ExchangeSharp
         /// <summary>
         /// Get exchange order book
         /// </summary>
-        /// <param name="symbol">Symbol to get order book for</param>
+        /// <param name="marketSymbol">Symbol to get order book for</param>
         /// <param name="maxCount">Max count, not all exchanges will honor this parameter</param>
         /// <returns>Exchange order book or null if failure</returns>
-        public virtual async Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100)
+        public virtual async Task<ExchangeOrderBook> GetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderBookAsync(symbol, maxCount), nameof(GetOrderBookAsync), nameof(symbol), symbol, nameof(maxCount), maxCount);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderBookAsync(marketSymbol, maxCount), nameof(GetOrderBookAsync), nameof(marketSymbol), marketSymbol, nameof(maxCount), maxCount);
         }
 
         /// <summary>
@@ -590,25 +590,25 @@ namespace ExchangeSharp
         /// Get historical trades for the exchange. TODO: Change to async enumerator when available.
         /// </summary>
         /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
-        /// <param name="symbol">Symbol to get historical data for</param>
+        /// <param name="marketSymbol">Symbol to get historical data for</param>
         /// <param name="startDate">Optional UTC start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
         /// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        public virtual async Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null)
+        public virtual async Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             // *NOTE*: Do not wrap in CacheMethodCall, uses a callback with custom queries, not easy to cache
             await new SynchronizationContextRemover();
-            await OnGetHistoricalTradesAsync(callback, NormalizeSymbol(symbol), startDate, endDate);
+            await OnGetHistoricalTradesAsync(callback, NormalizeMarketSymbol(marketSymbol), startDate, endDate);
         }
 
         /// <summary>
         /// Get recent trades on the exchange - the default implementation simply calls GetHistoricalTrades with a null sinceDateTime.
         /// </summary>
-        /// <param name="symbol">Symbol to get recent trades for</param>
+        /// <param name="marketSymbol">Symbol to get recent trades for</param>
         /// <returns>An enumerator that loops through all recent trades</returns>
-        public virtual async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol)
+        public virtual async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetRecentTradesAsync(symbol), nameof(GetRecentTradesAsync), nameof(symbol), symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetRecentTradesAsync(marketSymbol), nameof(GetRecentTradesAsync), nameof(marketSymbol), marketSymbol);
         }
 
         /// <summary>
@@ -642,17 +642,17 @@ namespace ExchangeSharp
         /// <summary>
         /// Get candles (open, high, low, close)
         /// </summary>
-        /// <param name="symbol">Symbol to get candles for</param>
+        /// <param name="marketSymbol">Symbol to get candles for</param>
         /// <param name="periodSeconds">Period in seconds to get candles for. Use 60 for minute, 3600 for hour, 3600*24 for day, 3600*24*30 for month.</param>
         /// <param name="startDate">Optional start date to get candles for</param>
         /// <param name="endDate">Optional end date to get candles for</param>
         /// <param name="limit">Max results, can be used instead of startDate and endDate if desired</param>
         /// <returns>Candles</returns>
-        public virtual async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+        public virtual async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetCandlesAsync(symbol, periodSeconds, startDate, endDate, limit), nameof(GetCandlesAsync),
-                nameof(symbol), symbol, nameof(periodSeconds), periodSeconds, nameof(startDate), startDate, nameof(endDate), endDate, nameof(limit), limit);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetCandlesAsync(marketSymbol, periodSeconds, startDate, endDate, limit), nameof(GetCandlesAsync),
+                nameof(marketSymbol), marketSymbol, nameof(periodSeconds), periodSeconds, nameof(startDate), startDate, nameof(endDate), endDate, nameof(limit), limit);
         }
 
         /// <summary>
@@ -691,7 +691,7 @@ namespace ExchangeSharp
         {
             // *NOTE* do not wrap in CacheMethodCall
             await new SynchronizationContextRemover();
-            order.Symbol = NormalizeSymbol(order.Symbol);
+            order.MarketSymbol = NormalizeMarketSymbol(order.MarketSymbol);
             return await OnPlaceOrderAsync(order);
         }
 
@@ -706,7 +706,7 @@ namespace ExchangeSharp
             await new SynchronizationContextRemover();
             foreach (ExchangeOrderRequest request in orders)
             {
-                request.Symbol = NormalizeSymbol(request.Symbol);
+                request.MarketSymbol = NormalizeMarketSymbol(request.MarketSymbol);
             }
             return await OnPlaceOrdersAsync(orders);
         }
@@ -715,48 +715,48 @@ namespace ExchangeSharp
         /// Get order details
         /// </summary>
         /// <param name="orderId">Order id to get details for</param>
-        /// <param name="symbol">Symbol of order (most exchanges do not require this)</param>
+        /// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
         /// <returns>Order details</returns>
-        public virtual async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string symbol = null)
+        public virtual async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string marketSymbol = null)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderDetailsAsync(orderId, symbol), nameof(GetOrderDetailsAsync), nameof(orderId), orderId, nameof(symbol), symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderDetailsAsync(orderId, marketSymbol), nameof(GetOrderDetailsAsync), nameof(orderId), orderId, nameof(marketSymbol), marketSymbol);
         }
 
         /// <summary>
         /// Get the details of all open orders
         /// </summary>
-        /// <param name="symbol">Symbol to get open orders for or null for all</param>
+        /// <param name="marketSymbol">Symbol to get open orders for or null for all</param>
         /// <returns>All open order details</returns>
-        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null)
+        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string marketSymbol = null)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenOrderDetailsAsync(symbol), nameof(GetOpenOrderDetailsAsync), nameof(symbol), symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenOrderDetailsAsync(marketSymbol), nameof(GetOpenOrderDetailsAsync), nameof(marketSymbol), marketSymbol);
         }
 
         /// <summary>
         /// Get the details of all completed orders
         /// </summary>
-        /// <param name="symbol">Symbol to get completed orders for or null for all</param>
+        /// <param name="marketSymbol">Symbol to get completed orders for or null for all</param>
         /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
         /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null)
+        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetCompletedOrderDetailsAsync(symbol, afterDate)).ToArray(), nameof(GetCompletedOrderDetailsAsync),
-                nameof(symbol), symbol, nameof(afterDate), afterDate);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetCompletedOrderDetailsAsync(marketSymbol, afterDate)).ToArray(), nameof(GetCompletedOrderDetailsAsync),
+                nameof(marketSymbol), marketSymbol, nameof(afterDate), afterDate);
         }
 
         /// <summary>
         /// Cancel an order, an exception is thrown if error
         /// </summary>
         /// <param name="orderId">Order id of the order to cancel</param>
-        /// <param name="symbol">Symbol of order (most exchanges do not require this)</param>
-        public virtual async Task CancelOrderAsync(string orderId, string symbol = null)
+        /// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
+        public virtual async Task CancelOrderAsync(string orderId, string marketSymbol = null)
         {
             // *NOTE* do not wrap in CacheMethodCall
             await new SynchronizationContextRemover();
-            await OnCancelOrderAsync(orderId, NormalizeSymbol(symbol));
+            await OnCancelOrderAsync(orderId, NormalizeMarketSymbol(marketSymbol));
         }
 
         /// <summary>
@@ -767,7 +767,7 @@ namespace ExchangeSharp
         {
             // *NOTE* do not wrap in CacheMethodCall
             await new SynchronizationContextRemover();
-            withdrawalRequest.Currency = NormalizeSymbol(withdrawalRequest.Currency);
+            withdrawalRequest.Currency = NormalizeMarketSymbol(withdrawalRequest.Currency);
             return await OnWithdrawAsync(withdrawalRequest);
         }
 
@@ -785,24 +785,24 @@ namespace ExchangeSharp
         /// <summary>
         /// Get open margin position
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <returns>Open margin position result</returns>
-        public virtual async Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string symbol)
+        public virtual async Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol)
         {
-            symbol = NormalizeSymbol(symbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenPositionAsync(symbol), nameof(GetOpenPositionAsync), nameof(symbol), symbol);
+            marketSymbol = NormalizeMarketSymbol(marketSymbol);
+            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenPositionAsync(marketSymbol), nameof(GetOpenPositionAsync), nameof(marketSymbol), marketSymbol);
         }
 
         /// <summary>
         /// Close a margin position
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <returns>Close margin position result</returns>
-        public virtual async Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string symbol)
+        public virtual async Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol)
         {
             // *NOTE* do not wrap in CacheMethodCall
             await new SynchronizationContextRemover();
-            return await OnCloseMarginPositionAsync(NormalizeSymbol(symbol));
+            return await OnCloseMarginPositionAsync(NormalizeMarketSymbol(marketSymbol));
         }
 
         #endregion REST API
@@ -824,12 +824,12 @@ namespace ExchangeSharp
         /// Get information about trades via web socket
         /// </summary>
         /// <param name="callback">Callback (symbol and trade)</param>
-        /// <param name="symbols">Symbols</param>
+        /// <param name="marketSymbols">Market Symbols</param>
         /// <returns>Web socket, call Dispose to close</returns>
-        public virtual IWebSocket GetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols)
+        public virtual IWebSocket GetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols)
         {
             callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetTradesWebSocket(callback, symbols);
+            return OnGetTradesWebSocket(callback, marketSymbols);
         }
 
         /// <summary>
@@ -837,12 +837,12 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="callback">Callback of symbol, order book</param>
         /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
-        /// <param name="symbol">Ticker symbols or null/empty for all of them (if supported)</param>
+        /// <param name="marketSymbols">Market symbols or null/empty for all of them (if supported)</param>
         /// <returns>Web socket, call Dispose to close</returns>
-        public virtual IWebSocket GetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols)
+        public virtual IWebSocket GetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetOrderBookWebSocket(callback, maxCount, symbols);
+            return OnGetOrderBookWebSocket(callback, maxCount, marketSymbols);
         }
 
         /// <summary>

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIDefinitions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIDefinitions.cs
@@ -81,17 +81,17 @@ namespace ExchangeSharp
         /// <summary>
         /// Separator for exchange symbol. If not a hyphen, set in constructor.
         /// </summary>
-        public string SymbolSeparator { get; protected set; } = "-";
+        public string MarketSymbolSeparator { get; protected set; } = "-";
 
         /// <summary>
         /// Whether the symbol is reversed. Most exchanges do ETH-BTC, if your exchange does BTC-ETH, set to true in constructor.
         /// </summary>
-        public bool SymbolIsReversed { get; protected set; }
+        public bool MarketSymbolIsReversed { get; protected set; }
 
         /// <summary>
         /// Whether the symbol is uppercase. Most exchanges are true, but if your exchange is lowercase, set to false in constructor.
         /// </summary>
-        public bool SymbolIsUppercase { get; protected set; } = true;
+        public bool MarketSymbolIsUppercase { get; protected set; } = true;
 
         /// <summary>
         /// The type of web socket order book supported

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -554,12 +554,12 @@ namespace ExchangeSharp
         /// <param name="closeKey">Close key</param>
         /// <param name="timestampKey">Timestamp key</param>
         /// <param name="timestampType">Timestamp type</param>
-        /// <param name="baseVolumeKey">Base volume key</param>
-        /// <param name="convertVolumeKey">Convert volume key</param>
+        /// <param name="baseVolumeKey">Base currency volume key</param>
+        /// <param name="quoteVolumeKey">Quote currency volume key</param>
         /// <param name="weightedAverageKey">Weighted average key</param>
         /// <returns>MarketCandle</returns>
         internal static MarketCandle ParseCandle(this INamed named, JToken token, string symbol, int periodSeconds, object openKey, object highKey, object lowKey,
-            object closeKey, object timestampKey, TimestampType timestampType, object baseVolumeKey, object convertVolumeKey = null, object weightedAverageKey = null)
+            object closeKey, object timestampKey, TimestampType timestampType, object baseVolumeKey, object quoteVolumeKey = null, object weightedAverageKey = null)
         {
             MarketCandle candle = new MarketCandle
             {
@@ -573,9 +573,9 @@ namespace ExchangeSharp
                 Timestamp = CryptoUtility.ParseTimestamp(token[timestampKey], timestampType)
             };
 
-            token.ParseVolumes(baseVolumeKey, convertVolumeKey, candle.ClosePrice, out decimal baseVolume, out decimal convertVolume);
-            candle.BaseVolume = (double)baseVolume;
-            candle.ConvertedVolume = (double)convertVolume;
+            token.ParseVolumes(baseVolumeKey, quoteVolumeKey, candle.ClosePrice, out decimal baseVolume, out decimal convertVolume);
+            candle.BaseCurrencyVolume = (double)baseVolume;
+            candle.QuoteCurrencyVolume = (double)convertVolume;
             if (weightedAverageKey != null)
             {
                 candle.WeightedAverage = token[weightedAverageKey].ConvertInvariant<decimal>();

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -81,7 +81,7 @@ namespace ExchangeSharp
                 // ideally all exchanges would send the full order book on first message, followed by delta order books
                 // but this is not the case
 
-                bool foundFullBook = fullBooks.TryGetValue(newOrderBook.Symbol, out ExchangeOrderBook fullOrderBook);
+                bool foundFullBook = fullBooks.TryGetValue(newOrderBook.MarketSymbol, out ExchangeOrderBook fullOrderBook);
                 switch (api.WebSocketOrderBookType)
                 {
                     case WebSocketOrderBookType.DeltasOnly:
@@ -95,10 +95,10 @@ namespace ExchangeSharp
                         // attempt to find the right queue to put the partial order book in to be processed later
                         lock (partialOrderBookQueues)
                         {
-                            if (!partialOrderBookQueues.TryGetValue(newOrderBook.Symbol, out partialOrderBookQueue))
+                            if (!partialOrderBookQueues.TryGetValue(newOrderBook.MarketSymbol, out partialOrderBookQueue))
                             {
                                 // no queue found, make a new one
-                                partialOrderBookQueues[newOrderBook.Symbol] = partialOrderBookQueue = new Queue<ExchangeOrderBook>();
+                                partialOrderBookQueues[newOrderBook.MarketSymbol] = partialOrderBookQueue = new Queue<ExchangeOrderBook>();
                                 requestFullOrderBook = !foundFullBook;
                             }
 
@@ -109,9 +109,9 @@ namespace ExchangeSharp
                         // request the entire order book if we need it
                         if (requestFullOrderBook)
                         {
-                            fullOrderBook = await api.GetOrderBookAsync(newOrderBook.Symbol, maxCount);
-                            fullOrderBook.Symbol = newOrderBook.Symbol;
-                            fullBooks[newOrderBook.Symbol] = fullOrderBook;
+                            fullOrderBook = await api.GetOrderBookAsync(newOrderBook.MarketSymbol, maxCount);
+                            fullOrderBook.MarketSymbol = newOrderBook.MarketSymbol;
+                            fullBooks[newOrderBook.MarketSymbol] = fullOrderBook;
                         }
                         else if (!foundFullBook)
                         {
@@ -125,7 +125,7 @@ namespace ExchangeSharp
                         // lock dictionary of queues for lookup only
                         lock (partialOrderBookQueues)
                         {
-                            partialOrderBookQueues.TryGetValue(newOrderBook.Symbol, out partialOrderBookQueue);
+                            partialOrderBookQueues.TryGetValue(newOrderBook.MarketSymbol, out partialOrderBookQueue);
                         }
 
                         if (partialOrderBookQueue != null)
@@ -147,7 +147,7 @@ namespace ExchangeSharp
                         // Subsequent updates will be deltas, at least some exchanges have their heads on straight
                         if (!foundFullBook)
                         {
-                            fullBooks[newOrderBook.Symbol] = fullOrderBook = newOrderBook;
+                            fullBooks[newOrderBook.MarketSymbol] = fullOrderBook = newOrderBook;
                         }
                         else
                         {
@@ -158,7 +158,7 @@ namespace ExchangeSharp
                     case WebSocketOrderBookType.FullBookAlways:
                     {
                         // Websocket always returns full order book, WTF...?
-                        fullBooks[newOrderBook.Symbol] = fullOrderBook = newOrderBook;
+                        fullBooks[newOrderBook.MarketSymbol] = fullOrderBook = newOrderBook;
                     } break;
                 }
 
@@ -269,7 +269,7 @@ namespace ExchangeSharp
                 OrderType = OrderType.Limit,
                 Price = CryptoUtility.RoundAmount((isBuy ? highPrice : lowPrice) * priceThreshold),
                 ShouldRoundAmount = true,
-                Symbol = symbol
+                MarketSymbol = symbol
             };
             ExchangeOrderResult result = await api.PlaceOrderAsync(request);
 
@@ -387,7 +387,7 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="api">ExchangeAPI</param>
         /// <param name="token">Token</param>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <param name="askKey">Ask key</param>
         /// <param name="bidKey">Bid key</param>
         /// <param name="lastKey">Last key</param>
@@ -399,7 +399,7 @@ namespace ExchangeSharp
         /// <param name="quoteCurrencyKey">Quote currency key</param>
         /// <param name="idKey">Id key</param>
         /// <returns>ExchangeTicker</returns>
-        internal static ExchangeTicker ParseTicker(this ExchangeAPI api, JToken token, string symbol,
+        internal static ExchangeTicker ParseTicker(this ExchangeAPI api, JToken token, string marketSymbol,
             object askKey, object bidKey, object lastKey, object baseVolumeKey,
             object quoteVolumeKey = null, object timestampKey = null, TimestampType timestampType = TimestampType.None,
             object baseCurrencyKey = null, object quoteCurrencyKey = null, object idKey = null)
@@ -424,13 +424,13 @@ namespace ExchangeSharp
                 baseCurrency = token[baseCurrencyKey].ToStringInvariant();
                 quoteCurrency = token[quoteCurrencyKey].ToStringInvariant();
             }
-            else if (string.IsNullOrWhiteSpace(symbol))
+            else if (string.IsNullOrWhiteSpace(marketSymbol))
             {
-                throw new ArgumentNullException(nameof(symbol));
+                throw new ArgumentNullException(nameof(marketSymbol));
             }
             else
             {
-                (baseCurrency, quoteCurrency) = api.ExchangeSymbolToCurrencies(symbol);
+                (baseCurrency, quoteCurrency) = api.ExchangeMarketSymbolToCurrencies(marketSymbol);
             }
 
             // create the ticker and return it
@@ -446,7 +446,7 @@ namespace ExchangeSharp
             }
             ExchangeTicker ticker = new ExchangeTicker
             {
-                Symbol = symbol,
+                MarketSymbol = marketSymbol,
                 Ask = askValue.ConvertInvariant<decimal>(),
                 Bid = bidValue.ConvertInvariant<decimal>(),
                 Id = (idKey == null ? null : token[idKey].ToStringInvariant()),
@@ -546,7 +546,7 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="named">Named item</param>
         /// <param name="token">JToken</param>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <param name="periodSeconds">Period seconds</param>
         /// <param name="openKey">Open key</param>
         /// <param name="highKey">High key</param>
@@ -558,7 +558,7 @@ namespace ExchangeSharp
         /// <param name="quoteVolumeKey">Quote currency volume key</param>
         /// <param name="weightedAverageKey">Weighted average key</param>
         /// <returns>MarketCandle</returns>
-        internal static MarketCandle ParseCandle(this INamed named, JToken token, string symbol, int periodSeconds, object openKey, object highKey, object lowKey,
+        internal static MarketCandle ParseCandle(this INamed named, JToken token, string marketSymbol, int periodSeconds, object openKey, object highKey, object lowKey,
             object closeKey, object timestampKey, TimestampType timestampType, object baseVolumeKey, object quoteVolumeKey = null, object weightedAverageKey = null)
         {
             MarketCandle candle = new MarketCandle
@@ -567,7 +567,7 @@ namespace ExchangeSharp
                 ExchangeName = named.Name,
                 HighPrice = token[highKey].ConvertInvariant<decimal>(),
                 LowPrice = token[lowKey].ConvertInvariant<decimal>(),
-                Name = symbol,
+                Name = marketSymbol,
                 OpenPrice = token[openKey].ConvertInvariant<decimal>(),
                 PeriodSeconds = periodSeconds,
                 Timestamp = CryptoUtility.ParseTimestamp(token[timestampKey], timestampType)

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeHistoricalTradeHelper.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeHistoricalTradeHelper.cs
@@ -26,10 +26,10 @@ namespace ExchangeSharp
             private ExchangeAPI api;
 
             public Func<IEnumerable<ExchangeTrade>, bool> Callback { get; set; }
-            public string Symbol { get; set; }
+            public string MarketSymbol { get; set; }
             public DateTime? StartDate { get; set; }
             public DateTime? EndDate { get; set; }
-            public string Url { get; set; } // url with format [symbol], {0} = start timestamp, {1} = end timestamp
+            public string Url { get; set; } // url with format [marketSymbol], {0} = start timestamp, {1} = end timestamp
             public int DelayMilliseconds { get; set; } = 1000;
             public TimeSpan BlockTime { get; set; } = TimeSpan.FromHours(1.0); // how much time to move for each block of data, default 1 hour
             public bool MillisecondGranularity { get; set; } = true;
@@ -62,9 +62,9 @@ namespace ExchangeSharp
                     throw new ArgumentException("Missing required parameter", nameof(Url));
                 }
 
-                Symbol = api.NormalizeSymbol(Symbol);
+                MarketSymbol = api.NormalizeMarketSymbol(MarketSymbol);
                 string url;
-                Url = Url.Replace("[symbol]", Symbol);
+                Url = Url.Replace("[marketSymbol]", MarketSymbol);
                 List<ExchangeTrade> trades = new List<ExchangeTrade>();
                 ExchangeTrade trade;
                 EndDate = (EndDate ?? CryptoUtility.UtcNow);

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeLogger.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeLogger.cs
@@ -58,15 +58,15 @@ namespace ExchangeSharp
         /// Constructor
         /// </summary>
         /// <param name="api">API</param>
-        /// <param name="symbol">The symbol to log, i.e. btcusd</param>
+        /// <param name="marketSymbol">The symbol to log, i.e. btcusd</param>
         /// <param name="intervalSeconds">Interval in seconds between updates</param>
         /// <param name="path">The path to write the log files to</param>
         /// <param name="compress">Whether to compress the log files using gzip compression</param>
-        public ExchangeLogger(IExchangeAPI api, string symbol, float intervalSeconds, string path, bool compress = false)
+        public ExchangeLogger(IExchangeAPI api, string marketSymbol, float intervalSeconds, string path, bool compress = false)
         {
             string compressExtension = (compress ? ".gz" : string.Empty);
             API = api;
-            Symbol = symbol;
+            MarketSymbol = marketSymbol;
             Interval = TimeSpan.FromSeconds(intervalSeconds);
             sysTimeWriter = CreateLogWriter(Path.Combine(path, api.Name + "_time.bin" + compressExtension), compress);
             tickerWriter = CreateLogWriter(Path.Combine(path, api.Name + "_ticker.bin" + compressExtension), compress);
@@ -84,7 +84,7 @@ namespace ExchangeSharp
 
             try
             {
-                if (Symbol == "*")
+                if (MarketSymbol == "*")
                 {
                     // get all symbols
                     Tickers = API.GetTickersAsync().Sync().ToArray();
@@ -98,9 +98,9 @@ namespace ExchangeSharp
                 else
                 {
                     // make API calls first, if they fail we will try again later
-                    Tickers = new KeyValuePair<string, ExchangeTicker>[1] { new KeyValuePair<string, ExchangeTicker>(Symbol, API.GetTickerAsync(Symbol).Sync()) };
-                    OrderBook = API.GetOrderBookAsync(Symbol).Sync();
-                    Trades = API.GetRecentTradesAsync(Symbol).Sync().OrderBy(t => t.Timestamp).ToArray();
+                    Tickers = new KeyValuePair<string, ExchangeTicker>[1] { new KeyValuePair<string, ExchangeTicker>(MarketSymbol, API.GetTickerAsync(MarketSymbol).Sync()) };
+                    OrderBook = API.GetOrderBookAsync(MarketSymbol).Sync();
+                    Trades = API.GetRecentTradesAsync(MarketSymbol).Sync().OrderBy(t => t.Timestamp).ToArray();
 
                     // all API calls succeeded, we can write to files
 
@@ -303,7 +303,7 @@ namespace ExchangeSharp
         /// <summary>
         /// The symbol being logged
         /// </summary>
-        public string Symbol { get; private set; }
+        public string MarketSymbol { get; private set; }
 
         /// <summary>
         /// The interval in between log calls

--- a/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -27,9 +27,9 @@ namespace ExchangeSharp
         /// <summary>
         /// Normalize a symbol for use on this exchange
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <returns>Normalized symbol</returns>
-        string NormalizeSymbol(string symbol);
+        string NormalizeMarketSymbol(string marketSymbol);
 
         /// <summary>
         /// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
@@ -37,16 +37,16 @@ namespace ExchangeSharp
         /// Global symbols list the base currency first (i.e. BTC) and conversion currency
         /// second (i.e. USD). Example BTC-USD, read as x BTC is worth y USD.
         /// </summary>
-        /// <param name="symbol">Exchange symbol</param>
+        /// <param name="marketSymbol">Exchange symbol</param>
         /// <returns>Global symbol</returns>
-        string ExchangeSymbolToGlobalSymbol(string symbol);
+        string ExchangeMarketSymbolToGlobalMarketSymbol(string marketSymbol);
 
         /// <summary>
         /// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
         /// </summary>
-        /// <param name="symbol">Global symbol</param>
+        /// <param name="marketSymbol">Global symbol</param>
         /// <returns>Exchange symbol</returns>
-        string GlobalSymbolToExchangeSymbol(string symbol);
+        string GlobalMarketSymbolToExchangeMarketSymbol(string marketSymbol);
 
         /// <summary>
         /// Convert seconds to a period string, or throw exception if seconds invalid. Example: 60 seconds becomes 1m.
@@ -81,23 +81,23 @@ namespace ExchangeSharp
         Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency);
 
         /// <summary>
-        /// Get symbols for the exchange
+        /// Get symbols for the exchange markets
         /// </summary>
         /// <returns>Symbols</returns>
-        Task<IEnumerable<string>> GetSymbolsAsync();
+        Task<IEnumerable<string>> GetMarketSymbolsAsync();
 
         /// <summary>
-        /// Get exchange symbols including available metadata such as min trade size and whether the market is active
+        /// Get exchange market symbols including available metadata such as min trade size and whether the market is active
         /// </summary>
         /// <returns>Collection of ExchangeMarkets</returns>
-        Task<IEnumerable<ExchangeMarket>> GetSymbolsMetadataAsync();
+        Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync();
 
         /// <summary>
         /// Get latest ticker
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <returns>Latest ticker</returns>
-        Task<ExchangeTicker> GetTickerAsync(string symbol);
+        Task<ExchangeTicker> GetTickerAsync(string marketSymbol);
 
         /// <summary>
         /// Get all tickers, not all exchanges support this
@@ -109,28 +109,28 @@ namespace ExchangeSharp
         /// Get historical trades for the exchange
         /// </summary>
         /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
-        /// <param name="symbol">Symbol to get historical data for</param>
+        /// <param name="marketSymbol">Symbol to get historical data for</param>
         /// <param name="startDate">Optional start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
         /// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string symbol, DateTime? startDate = null, DateTime? endDate = null);
+        Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null);
 
         /// <summary>
         /// Get the latest trades
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <returns>Trades</returns>
-        Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string symbol);
+        Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol);
 
         /// <summary>
         /// Get candles (open, high, low, close)
         /// </summary>
-        /// <param name="symbol">Symbol to get candles for</param>
+        /// <param name="marketSymbol">Market symbol to get candles for</param>
         /// <param name="periodSeconds">Period in seconds to get candles for. Use 60 for minute, 3600 for hour, 3600*24 for day, 3600*24*30 for month.</param>
         /// <param name="startDate">Optional start date to get candles for</param>
         /// <param name="endDate">Optional end date to get candles for</param>
         /// <param name="limit">Max results, can be used instead of startDate and endDate if desired</param>
         /// <returns>Candles</returns>
-        Task<IEnumerable<MarketCandle>> GetCandlesAsync(string symbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null);
+        Task<IEnumerable<MarketCandle>> GetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null);
 
         /// <summary>
         /// Get total amounts, symbol / amount dictionary
@@ -162,30 +162,31 @@ namespace ExchangeSharp
         /// Get details of an order
         /// </summary>
         /// <param name="orderId">order id</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <returns>Order details</returns>
-        Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string symbol = null);
+        Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string marketSymbol = null);
 
         /// <summary>
         /// Get the details of all open orders
         /// </summary>
-        /// <param name="symbol">Symbol to get open orders for or null for all</param>
+        /// <param name="marketSymbol">Market symbol to get open orders for or null for all</param>
         /// <returns>All open order details for the specified symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string symbol = null);
+        Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string marketSymbol = null);
 
         /// <summary>
         /// Get the details of all completed orders
         /// </summary>
-        /// <param name="symbol">Symbol to get completed orders for or null for all</param>
+        /// <param name="marketSymbol">Market symbol to get completed orders for or null for all</param>
         /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
         /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string symbol = null, DateTime? afterDate = null);
+        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null);
 
         /// <summary>
         /// Cancel an order, an exception is thrown if failure
         /// </summary>
         /// <param name="orderId">Order id of the order to cancel</param>
-        /// <param name="symbol">Order symbol of the order to cancel (not required for most exchanges)</param>
-        Task CancelOrderAsync(string orderId, string symbol = null);
+        /// <param name="marketSymbol">Market symbol of the order to cancel (not required for most exchanges)</param>
+        Task CancelOrderAsync(string orderId, string marketSymbol = null);
 
         /// <summary>
         /// Get margin amounts available to trade, symbol / amount dictionary
@@ -197,16 +198,16 @@ namespace ExchangeSharp
         /// <summary>
         /// Get open margin position
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <returns>Open margin position result</returns>
-        Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string symbol);
+        Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol);
 
         /// <summary>
         /// Close a margin position
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Market Symbol</param>
         /// <returns>Close margin position result</returns>
-        Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string symbol);
+        Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol);
          
         /// <summary>
         /// Get fees
@@ -229,9 +230,9 @@ namespace ExchangeSharp
         /// Get information about trades via web socket
         /// </summary>
         /// <param name="callback">Callback (symbol and trade)</param>
-        /// <param name="symbols">Symbols</param>
+        /// <param name="marketSymbols">Market symbols</param>
         /// <returns>Web socket, call Dispose to close</returns>
-        IWebSocket GetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] symbols);
+        IWebSocket GetTradesWebSocket(Action<KeyValuePair<string, ExchangeTrade>> callback, params string[] marketSymbols);
 
         /// <summary>
         /// Get the details of all changed orders via web socket

--- a/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -74,11 +74,11 @@ namespace ExchangeSharp
         Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false);
 
         /// <summary>
-        /// Gets the deposit history for a symbol
+        /// Gets the deposit history for a currency
         /// </summary>
-        /// <param name="symbol">The symbol to check. May be null.</param>
+        /// <param name="currency">The currency to check. May be null.</param>
         /// <returns>Collection of ExchangeCoinTransfers</returns>
-        Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string symbol);
+        Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency);
 
         /// <summary>
         /// Get symbols for the exchange

--- a/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -68,10 +68,10 @@ namespace ExchangeSharp
         /// <summary>
         /// Gets the address to deposit to and applicable details.
         /// </summary>
-        /// <param name="symbol">Symbol to get address for.</param>
+        /// <param name="currency">Currency to get address for.</param>
         /// <param name="forceRegenerate">True to regenerate the address</param>
         /// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
-        Task<ExchangeDepositDetails> GetDepositAddressAsync(string symbol, bool forceRegenerate = false);
+        Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false);
 
         /// <summary>
         /// Gets the deposit history for a currency

--- a/ExchangeSharp/API/Exchanges/_Base/Interfaces/IOrderBookProvider.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/Interfaces/IOrderBookProvider.cs
@@ -25,10 +25,10 @@ namespace ExchangeSharp
         /// <summary>
         /// Get pending orders. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
         /// </summary>
-        /// <param name="symbol">Symbol</param>
+        /// <param name="marketSymbol">Symbol</param>
         /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
         /// <returns>Orders</returns>
-        Task<ExchangeOrderBook> GetOrderBookAsync(string symbol, int maxCount = 100);
+        Task<ExchangeOrderBook> GetOrderBookAsync(string marketSymbol, int maxCount = 100);
 
         /// <summary>
         /// Get exchange order book for all symbols. Not all exchanges support this. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
@@ -42,9 +42,9 @@ namespace ExchangeSharp
         /// </summary>
         /// <param name="callback">Callback with the full ExchangeOrderBook</param>
         /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
-        /// <param name="symbol">Order book symbols or null/empty for all of them (if supported)</param>
+        /// <param name="marketSymbols">Market symbols or null/empty for all of them (if supported)</param>
         /// <returns>Web socket, call Dispose to close</returns>
-        IWebSocket GetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] symbols);
+        IWebSocket GetOrderBookWebSocket(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols);
 
         /// <summary>
         /// What type of web socket order book is provided

--- a/ExchangeSharp/API/Services/CryptowatchAPI.cs
+++ b/ExchangeSharp/API/Services/CryptowatchAPI.cs
@@ -102,12 +102,12 @@ namespace ExchangeSharp
             return summaries;
         }
 
-        public async Task<ExchangeOrderBook> GetOrderBookAsync(string exchange, string symbol, int maxCount = 100)
+        public async Task<ExchangeOrderBook> GetOrderBookAsync(string exchange, string marketSymbol, int maxCount = 100)
         {
             await new SynchronizationContextRemover();
 
             ExchangeOrderBook book = new ExchangeOrderBook();
-            JToken result = await MakeJsonRequestAsync<JToken>("/markets/" + exchange.ToLowerInvariant() + "/" + symbol + "/orderbook");
+            JToken result = await MakeJsonRequestAsync<JToken>("/markets/" + exchange.ToLowerInvariant() + "/" + marketSymbol + "/orderbook");
             int count = 0;
             foreach (JArray array in result["asks"])
             {

--- a/ExchangeSharp/Model/ExchangeCloseMarginPositionResult.cs
+++ b/ExchangeSharp/Model/ExchangeCloseMarginPositionResult.cs
@@ -21,7 +21,7 @@ namespace ExchangeSharp
         public bool Success { get; set; }
         public string Message { get; set; }
         public bool IsBuy { get; set; }
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
         public string FeesCurrency { get; set; }
         public decimal AmountFilled { get; set; }
         public decimal AveragePrice { get; set; }

--- a/ExchangeSharp/Model/ExchangeDepositDetails.cs
+++ b/ExchangeSharp/Model/ExchangeDepositDetails.cs
@@ -15,8 +15,8 @@ namespace ExchangeSharp
     /// <summary>Class to encapsulate details required to make a deposit.</summary>
     public sealed class ExchangeDepositDetails
     {
-        /// <summary>The symbol of the currency. Ex. ETH</summary>
-        public string Symbol;
+        /// <summary>The name of the currency. Ex. ETH</summary>
+        public string Currency;
 
         /// <summary>The address to deposit to</summary>
         public string Address;
@@ -29,7 +29,7 @@ namespace ExchangeSharp
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         public override string ToString()
         {
-            return $"{Symbol}: Address: {Address} AddressTag: {AddressTag}";
+            return $"{Currency}: Address: {Address} AddressTag: {AddressTag}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeInfo.cs
+++ b/ExchangeSharp/Model/ExchangeInfo.cs
@@ -27,12 +27,12 @@ namespace ExchangeSharp
         /// Constructor
         /// </summary>
         /// <param name="api">Exchange API</param>
-        /// <param name="symbol">The symbol to trade by default, can be null</param>
-        public ExchangeInfo(IExchangeAPI api, string symbol = null)
+        /// <param name="marketSymbol">The market symbol to trade by default, can be null</param>
+        public ExchangeInfo(IExchangeAPI api, string marketSymbol = null)
         {
             API = api;
-            Symbols = api.GetSymbolsAsync().Sync().ToArray();
-            TradeInfo = new ExchangeTradeInfo(this, symbol);
+            MarketSymbols = api.GetMarketSymbolsAsync().Sync().ToArray();
+            TradeInfo = new ExchangeTradeInfo(this, marketSymbol);
         }
 
         /// <summary>
@@ -54,9 +54,9 @@ namespace ExchangeSharp
         public int Id { get; set; }
 
         /// <summary>
-        /// Symbols of the exchange
+        /// Market symbols of the exchange
         /// </summary>
-        public IReadOnlyCollection<string> Symbols { get; private set; }
+        public IReadOnlyCollection<string> MarketSymbols { get; private set; }
 
         /// <summary>
         /// Latest trade info for the exchange

--- a/ExchangeSharp/Model/ExchangeMarginPositionResult.cs
+++ b/ExchangeSharp/Model/ExchangeMarginPositionResult.cs
@@ -18,9 +18,9 @@ namespace ExchangeSharp
     public class ExchangeMarginPositionResult
     {
         /// <summary>
-        /// Symbol
+        /// Market Symbol
         /// </summary>
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
 
         /// <summary>
         /// Amount

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -18,8 +18,8 @@ namespace ExchangeSharp
         /// <summary>Id of the market (specific to the exchange), null if none</summary>
         public string MarketId { get; set; }
 
-        /// <summary>Gets or sets the name of the market.</summary>
-        public string MarketName { get; set; }
+        /// <summary>Gets or sets the symbol representing the market's currency pair.</summary>
+        public string MarketSymbol { get; set; }
 
         /// <summary>A value indicating whether the market is active.</summary>
         public bool IsActive { get; set; }
@@ -69,7 +69,7 @@ namespace ExchangeSharp
 
         public override string ToString()
         {
-            return $"{MarketName}, {BaseCurrency}-{QuoteCurrency}";
+            return $"{MarketSymbol}, {BaseCurrency}-{QuoteCurrency}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/ExchangeSharp/Model/ExchangeMarket.cs
@@ -24,18 +24,28 @@ namespace ExchangeSharp
         /// <summary>A value indicating whether the market is active.</summary>
         public bool IsActive { get; set; }
 
-        /// <summary>In a pair like ZRX/BTC, BTC is the base currency.</summary>
+        /// <summary>In a pair like ZRX/BTC, BTC is the quote currency.</summary>
+        public string QuoteCurrency { get; set; }
+
+        /// <summary>In a pair like ZRX/BTC, ZRX is the base currency.</summary>
         public string BaseCurrency { get; set; }
 
-        /// <summary>In a pair like ZRX/BTC, ZRX is the market currency.</summary>
-        public string MarketCurrency { get; set; }
-
-        /// <summary>The minimum size of the trade in the unit of "MarketCurrency". For example, in
+        /// <summary>The minimum size of the trade in the unit of "BaseCurrency". For example, in
         /// DOGE/BTC the MinTradeSize is currently 423.72881356 DOGE</summary>
         public decimal MinTradeSize { get; set; }
 
-        /// <summary>The maximum size of the trade in the unit of "MarketCurrency".</summary>
+        /// <summary>The maximum size of the trade in the unit of "BaseCurrency".</summary>
         public decimal MaxTradeSize { get; set; } = decimal.MaxValue;
+
+        /// <summary>The minimum size of the trade in the unit of "QuoteCurrency". To determine an order's
+        /// trade size in terms of the Quote Currency, you need to calculate: price * quantity
+        /// NOTE: Not all exchanges provide this information</summary>
+        public decimal? MinTradeSizeInQuoteCurrency { get; set; }
+
+        /// <summary>The maximum size of the trade in the unit of "QuoteCurrency". To determine an order's
+        /// trade size in terms of the Quote Currency, you need to calculate: price * quantity
+        /// NOTE: Not all exchanges provide this information</summary>
+        public decimal? MaxTradeSizeInQuoteCurrency { get; set; }
 
         /// <summary>The minimum price of the pair.</summary>
         public decimal MinPrice { get; set; }
@@ -52,9 +62,14 @@ namespace ExchangeSharp
         /// if unknown or not applicable.</summary>
         public decimal? QuantityStepSize { get; set; }
 
+        /// <summary>
+        /// Margin trading enabled for this market
+        /// </summary>
+        public bool MarginEnabled { get; set; }
+
         public override string ToString()
         {
-            return $"{MarketName}, {MarketCurrency}-{BaseCurrency}";
+            return $"{MarketName}, {BaseCurrency}-{QuoteCurrency}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeOrderBook.cs
+++ b/ExchangeSharp/Model/ExchangeOrderBook.cs
@@ -74,10 +74,10 @@ namespace ExchangeSharp
         public long SequenceId { get; set; }
 
         /// <summary>
-        /// The symbol.
+        /// The market symbol.
         /// This property is not serialized using the ToBinary and FromBinary methods.
         /// </summary>
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
 
         /// <summary>The last updated UTC</summary>
         public DateTime LastUpdatedUtc { get; set; } = DateTime.MinValue;

--- a/ExchangeSharp/Model/ExchangeOrderRequest.cs
+++ b/ExchangeSharp/Model/ExchangeOrderRequest.cs
@@ -22,9 +22,9 @@ namespace ExchangeSharp
     public class ExchangeOrderRequest
     {
         /// <summary>
-        /// Symbol or pair for the order, i.e. btcusd
+        /// Market symbol or pair for the order, i.e. btcusd
         /// </summary>
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
 
         /// <summary>
         /// Amount to buy or sell

--- a/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -47,8 +47,8 @@ namespace ExchangeSharp
         /// <summary>Fill datetime in UTC</summary>
         public DateTime FillDate { get; set; }
     
-        /// <summary>Symbol. E.g. ADA/ETH</summary>
-        public string Symbol { get; set; }
+        /// <summary>Market Symbol. E.g. ADA/ETH</summary>
+        public string MarketSymbol { get; set; }
 
         /// <summary>Whether the order is a buy or sell</summary>
         public bool IsBuy { get; set; }
@@ -65,9 +65,9 @@ namespace ExchangeSharp
         /// <param name="other">Order to append</param>
         public void AppendOrderWithOrder(ExchangeOrderResult other)
         {
-            if ((OrderId != null) && (Symbol != null) && ((OrderId != other.OrderId) || (IsBuy != other.IsBuy) || (Symbol != other.Symbol)))
+            if ((OrderId != null) && (MarketSymbol != null) && ((OrderId != other.OrderId) || (IsBuy != other.IsBuy) || (MarketSymbol != other.MarketSymbol)))
             {
-                throw new InvalidOperationException("Appending orders requires order id, symbol and is buy to match");
+                throw new InvalidOperationException("Appending orders requires order id, market symbol and is buy to match");
             }
 
             decimal tradeSum = Amount + other.Amount;
@@ -79,7 +79,7 @@ namespace ExchangeSharp
             AveragePrice = (AveragePrice * (baseAmount / tradeSum)) + (other.AveragePrice * (other.Amount / tradeSum));
             OrderId = other.OrderId;
             OrderDate = OrderDate == default ? other.OrderDate : OrderDate;
-            Symbol = other.Symbol;
+            MarketSymbol = other.MarketSymbol;
             IsBuy = other.IsBuy;
         }
 
@@ -87,7 +87,7 @@ namespace ExchangeSharp
         /// <returns>A string that represents this instance.</returns>
         public override string ToString()
         {
-            return $"[{OrderDate}], {(IsBuy ? "Buy" : "Sell")} {AmountFilled} of {Amount} {Symbol} {Result} at {AveragePrice}, fees paid {Fees} {FeesCurrency}";
+            return $"[{OrderDate}], {(IsBuy ? "Buy" : "Sell")} {AmountFilled} of {Amount} {MarketSymbol} {Result} at {AveragePrice}, fees paid {Fees} {FeesCurrency}";
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeTicker.cs
+++ b/ExchangeSharp/Model/ExchangeTicker.cs
@@ -34,7 +34,7 @@ namespace ExchangeSharp
         /// <summary>
         /// The currency pair symbol that this ticker is in reference to
         /// </summary>
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
 
         /// <summary>
         /// The bid is the price to sell at

--- a/ExchangeSharp/Model/ExchangeTicker.cs
+++ b/ExchangeSharp/Model/ExchangeTicker.cs
@@ -32,6 +32,11 @@ namespace ExchangeSharp
         public string Id { get; set; }
 
         /// <summary>
+        /// The currency pair symbol that this ticker is in reference to
+        /// </summary>
+        public string Symbol { get; set; }
+
+        /// <summary>
         /// The bid is the price to sell at
         /// </summary>
         public decimal Bid { get; set; }
@@ -97,28 +102,28 @@ namespace ExchangeSharp
         public DateTime Timestamp { get; set; }
 
         /// <summary>
-        /// Price symbol - will equal quantity symbol if exchange doesn't break it out by price unit and quantity unit
-        /// In BTC-USD, this would be BTC
-        /// </summary>
-        public string BaseSymbol { get; set; }
-
-        /// <summary>
-        /// Price amount - will equal QuantityAmount if exchange doesn't break it out by price unit and quantity unit
-        /// In BTC-USD, this would be BTC volume
-        /// </summary>
-        public decimal BaseVolume { get; set; }
-
-        /// <summary>
-        /// Quantity symbol (converted into this unit)
+        /// Quote / Price currency - will equal base currency if exchange doesn't break it out by price unit and quantity unit
         /// In BTC-USD, this would be USD
         /// </summary>
-        public string ConvertedSymbol { get; set; }
+        public string QuoteCurrency { get; set; }
 
         /// <summary>
-        /// Quantity amount (this many units total)
-        /// In BTC-USD this would be USD volume
+        /// Amount in units of the QuoteCurrency - will equal BaseCurrencyVolume if exchange doesn't break it out by price unit and quantity unit
+        /// In BTC-USD, this would be USD volume
         /// </summary>
-        public decimal ConvertedVolume { get; set; }
+        public decimal QuoteCurrencyVolume { get; set; }
+
+        /// <summary>
+        /// Base currency
+        /// In BTC-USD, this would be BTC
+        /// </summary>
+        public string BaseCurrency { get; set; }
+
+        /// <summary>
+        /// Base currency amount (this many units total)
+        /// In BTC-USD this would be BTC volume
+        /// </summary>
+        public decimal BaseCurrencyVolume { get; set; }
 
         /// <summary>
         /// Write to a binary writer
@@ -127,10 +132,10 @@ namespace ExchangeSharp
         public void ToBinary(BinaryWriter writer)
         {
             writer.Write(Timestamp.ToUniversalTime().Ticks);
-            writer.Write(BaseSymbol);
-            writer.Write((double)BaseVolume);
-            writer.Write(ConvertedSymbol);
-            writer.Write((double)ConvertedVolume);
+            writer.Write(QuoteCurrency);
+            writer.Write((double)QuoteCurrencyVolume);
+            writer.Write(BaseCurrency);
+            writer.Write((double)BaseCurrencyVolume);
         }
 
         /// <summary>
@@ -140,10 +145,10 @@ namespace ExchangeSharp
         public void FromBinary(BinaryReader reader)
         {
             Timestamp = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
-            BaseSymbol = reader.ReadString();
-            BaseVolume = (decimal)reader.ReadDouble();
-            ConvertedSymbol = reader.ReadString();
-            ConvertedVolume = (decimal)reader.ReadDouble();
+            QuoteCurrency = reader.ReadString();
+            QuoteCurrencyVolume = (decimal)reader.ReadDouble();
+            BaseCurrency = reader.ReadString();
+            BaseCurrencyVolume = (decimal)reader.ReadDouble();
         }
     }
 }

--- a/ExchangeSharp/Model/ExchangeTradeInfo.cs
+++ b/ExchangeSharp/Model/ExchangeTradeInfo.cs
@@ -27,11 +27,11 @@ namespace ExchangeSharp
         /// Constructor
         /// </summary>
         /// <param name="info">Exchange info</param>
-        /// <param name="symbol">The symbol to trade</param>
-        public ExchangeTradeInfo(ExchangeInfo info, string symbol)
+        /// <param name="marketSymbol">The symbol to trade</param>
+        public ExchangeTradeInfo(ExchangeInfo info, string marketSymbol)
         {
             ExchangeInfo = info;
-            Symbol = symbol;
+            MarketSymbol = marketSymbol;
         }
 
         /// <summary>
@@ -39,8 +39,8 @@ namespace ExchangeSharp
         /// </summary>
         public void Update()
         {
-            Ticker = ExchangeInfo.API.GetTickerAsync(Symbol).Sync();
-            RecentTrades = ExchangeInfo.API.GetRecentTradesAsync(Symbol).Sync().ToArray();
+            Ticker = ExchangeInfo.API.GetTickerAsync(MarketSymbol).Sync();
+            RecentTrades = ExchangeInfo.API.GetRecentTradesAsync(MarketSymbol).Sync().ToArray();
             if (RecentTrades.Length == 0)
             {
                 Trade = new Trade();
@@ -49,7 +49,7 @@ namespace ExchangeSharp
             {
                 Trade = new Trade { Amount = (float)RecentTrades[RecentTrades.Length - 1].Amount, Price = (float)RecentTrades[RecentTrades.Length - 1].Price, Ticks = (long)CryptoUtility.UnixTimestampFromDateTimeMilliseconds(RecentTrades[RecentTrades.Length - 1].Timestamp) };
             }
-            Orders = ExchangeInfo.API.GetOrderBookAsync(Symbol).Sync();
+            Orders = ExchangeInfo.API.GetOrderBookAsync(MarketSymbol).Sync();
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace ExchangeSharp
         public Trade Trade { get; set; }
 
         /// <summary>
-        /// The current symbol being traded
+        /// The current market symbol being traded
         /// </summary>
-        public string Symbol { get; set; }
+        public string MarketSymbol { get; set; }
     }
 }

--- a/ExchangeSharp/Model/ExchangeTransaction.cs
+++ b/ExchangeSharp/Model/ExchangeTransaction.cs
@@ -44,13 +44,13 @@ namespace ExchangeSharp
         /// <summary>The fee on the transaction</summary>
         public decimal TxFee { get; set; }
 
-        /// <summary>The currency symbol (ex. BTC)</summary>
-        public string Symbol { get; set; }
+        /// <summary>The currency name (ex. BTC)</summary>
+        public string Currency { get; set; }
 
         public override string ToString()
         {
             return
-                $"{Amount} {Symbol} (fee: {TxFee}) sent to Address: {Address ?? "null"} with AddressTag: {AddressTag ?? "null"} BlockchainTxId: {BlockchainTxId ?? "null"} sent at {Timestamp} UTC. Status: {Status}. Exchange paymentId: {PaymentId ?? "null"}. Notes: {Notes ?? "null"}";
+                $"{Amount} {Currency} (fee: {TxFee}) sent to Address: {Address ?? "null"} with AddressTag: {AddressTag ?? "null"} BlockchainTxId: {BlockchainTxId ?? "null"} sent at {Timestamp} UTC. Status: {Status}. Exchange paymentId: {PaymentId ?? "null"}. Notes: {Notes ?? "null"}";
         }
     }
 }

--- a/ExchangeSharp/Model/MarketCandle.cs
+++ b/ExchangeSharp/Model/MarketCandle.cs
@@ -66,12 +66,12 @@ namespace ExchangeSharp
         /// <summary>
         /// Base currency volume (i.e. in BTC-USD, this would be BTC volume)
         /// </summary>
-        public double BaseVolume { get; set; }
+        public double BaseCurrencyVolume { get; set; }
 
         /// <summary>
-        /// Conversion currency volume (i.e. in BTC-USD, this would be USD volume)
+        /// Quote currency volume (i.e. in BTC-USD, this would be USD volume)
         /// </summary>
-        public double ConvertedVolume { get; set; }
+        public double QuoteCurrencyVolume { get; set; }
 
         /// <summary>
         /// The weighted average price if provided
@@ -84,7 +84,7 @@ namespace ExchangeSharp
         /// <returns>String</returns>
         public override string ToString()
         {
-            return string.Format("{0}/{1}: {2}, {3}, {4}, {5}, {6}, {7}, {8}", Timestamp, PeriodSeconds, OpenPrice, HighPrice, LowPrice, ClosePrice, BaseVolume, ConvertedVolume, WeightedAverage);
+            return string.Format("{0}/{1}: {2}, {3}, {4}, {5}, {6}, {7}, {8}", Timestamp, PeriodSeconds, OpenPrice, HighPrice, LowPrice, ClosePrice, BaseCurrencyVolume, QuoteCurrencyVolume, WeightedAverage);
         }
     }
 }

--- a/ExchangeSharp/Traders/Trader.cs
+++ b/ExchangeSharp/Traders/Trader.cs
@@ -82,7 +82,7 @@ namespace ExchangeSharp
             if (ProductionMode)
             {
                 var dict = TradeInfo.ExchangeInfo.API.GetAmountsAvailableToTradeAsync().Sync();
-                string[] tradeSymbols = TradeInfo.Symbol.Split('_');
+                string[] tradeSymbols = TradeInfo.MarketSymbol.Split('_');
                 dict.TryGetValue(tradeSymbols[1], out decimal itemCount);
                 dict.TryGetValue(tradeSymbols[0], out decimal cashFlow);
                 ItemCount = itemCount;
@@ -165,7 +165,7 @@ namespace ExchangeSharp
                         IsBuy = true,
                         Price = actualBuyPrice,
                         ShouldRoundAmount = false,
-                        Symbol = TradeInfo.Symbol
+                        MarketSymbol = TradeInfo.MarketSymbol
                     }).Sync();
                 }
                 else
@@ -199,7 +199,7 @@ namespace ExchangeSharp
                         IsBuy = false,
                         Price = actualSellPrice,
                         ShouldRoundAmount = false,
-                        Symbol = TradeInfo.Symbol
+                        MarketSymbol = TradeInfo.MarketSymbol
                     }).Sync();
                 }
                 else

--- a/ExchangeSharp/Traders/TraderExchangeExport.cs
+++ b/ExchangeSharp/Traders/TraderExchangeExport.cs
@@ -25,13 +25,13 @@ namespace ExchangeSharp
         /// Export exchange data to csv and then to optimized bin files
         /// </summary>
         /// <param name="api">Exchange api, null to just convert existing csv files</param>
-        /// <param name="symbol">Symbol to export</param>
+        /// <param name="marketSymbol">Market symbol to export</param>
         /// <param name="basePath">Base path to export to, should not contain symbol, symbol will be appended</param>
         /// <param name="sinceDateTime">Start date to begin export at</param>
         /// <param name="callback">Callback if api is not null to notify of progress</param>
-        public static void ExportExchangeTrades(IExchangeAPI api, string symbol, string basePath, DateTime sinceDateTime, Action<long> callback = null)
+        public static void ExportExchangeTrades(IExchangeAPI api, string marketSymbol, string basePath, DateTime sinceDateTime, Action<long> callback = null)
         {
-            basePath = Path.Combine(basePath, symbol);
+            basePath = Path.Combine(basePath, marketSymbol);
             Directory.CreateDirectory(basePath);
             sinceDateTime = sinceDateTime.ToUniversalTime();
             if (api != null)
@@ -62,7 +62,7 @@ namespace ExchangeSharp
                     }
                     return true;
                 }
-                api.GetHistoricalTradesAsync(innerCallback, symbol, sinceDateTime).Sync();
+                api.GetHistoricalTradesAsync(innerCallback, marketSymbol, sinceDateTime).Sync();
                 writer.Close();
                 callback?.Invoke(count);
             }

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -206,6 +206,7 @@ namespace ExchangeSharp
                 {
                     // fallback to float conversion, i.e. 1E-1 for a decimal conversion will fail
                     string stringValue = (jValue == null ? obj.ToStringInvariant() : jValue.Value.ToStringInvariant());
+                    if (string.IsNullOrWhiteSpace(stringValue)) return defaultValue;
                     decimal decimalValue = decimal.Parse(stringValue, System.Globalization.NumberStyles.Float);
                     return (T)Convert.ChangeType(decimalValue, typeof(T), CultureInfo.InvariantCulture);
                 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
@@ -276,5 +276,35 @@ namespace ExchangeSharpConsole
                 }
             }
         }
+
+        public static void RunGetCandles(Dictionary<string, string> dict)
+        {
+            RequireArgs(dict, "exchangeName", "symbol");
+            using (var api = ExchangeAPI.GetExchangeAPI(dict["exchangeName"]))
+            {
+                if (api == null)
+                {
+                    throw new ArgumentException("Cannot find exchange with name {0}", dict["exchangeName"]);
+                }
+
+                try
+                {
+                    var symbol = dict["symbol"];
+                    var candles = api.GetCandlesAsync(symbol, 1800, DateTime.UtcNow.AddDays(-12), DateTime.UtcNow).Sync();                   
+                    
+                    foreach (var candle in candles)
+                    {
+                        Console.WriteLine(candle);
+                    }
+
+                    Console.WriteLine("Press any key to quit.");
+                    Console.ReadKey();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+            }
+        }
     }
 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
@@ -118,11 +118,11 @@ namespace ExchangeSharpConsole
 
         private static void RunWebSocketTickers(Dictionary<string, string> dict)
         {
-            string[] symbols = GetSymbols(dict, false);
+            string[] symbols = GetMarketSymbols(dict, false);
             RunWebSocket(dict, (api) =>
                                {
                                    if(symbols != null)
-                                    symbols = ValidateSymbols(api, symbols);
+                                    symbols = ValidateMarketSymbols(api, symbols);
                                    return api.GetTickersWebSocket(
                                            freshTickers =>
                                            {

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
@@ -176,5 +176,34 @@ namespace ExchangeSharpConsole
                 throw new ArgumentException("Invalid mode: " + dict["mode"]);
             }
         }
+
+        public static void RunGetSymbolsMetadata(Dictionary<string, string> dict)
+        {
+            RequireArgs(dict, "exchangeName");
+            using (var api = ExchangeAPI.GetExchangeAPI(dict["exchangeName"]))
+            {
+                if (api == null)
+                {
+                    throw new ArgumentException("Cannot find exchange with name {0}", dict["exchangeName"]);
+                }
+
+                try
+                {
+                    var symbols = api.GetSymbolsMetadataAsync().Sync();
+
+                    foreach (var symbol in symbols)
+                    {
+                        Console.WriteLine(symbol);
+                    }
+
+                    Console.WriteLine("Press any key to quit.");
+                    Console.ReadKey();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+            }
+        }
     }
 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
@@ -234,5 +234,47 @@ namespace ExchangeSharpConsole
                 }
             }
         }
+
+        public static void RunGetTickers(Dictionary<string, string> dict)
+        {
+            RequireArgs(dict, "exchangeName");
+            using (var api = ExchangeAPI.GetExchangeAPI(dict["exchangeName"]))
+            {
+                if (api == null)
+                {
+                    throw new ArgumentException("Cannot find exchange with name {0}", dict["exchangeName"]);
+                }
+
+                try
+                {
+                    IEnumerable<KeyValuePair<string, ExchangeTicker>> tickers;
+                    if (dict.ContainsKey("symbol"))
+                    {
+                        var symbol = dict["symbol"];
+                        var ticker = api.GetTickerAsync(symbol).Sync();
+                        tickers = new List<KeyValuePair<string, ExchangeTicker>>()
+                                  {
+                                      new KeyValuePair<string, ExchangeTicker>(symbol, ticker)
+                                  };
+                    }
+                    else
+                    {
+                        tickers = api.GetTickersAsync().Sync();
+                    }
+                    
+                    foreach (var ticker in tickers)
+                    {
+                        Console.WriteLine(ticker);
+                    }
+
+                    Console.WriteLine("Press any key to quit.");
+                    Console.ReadKey();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+            }
+        }
     }
 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Example.cs
@@ -205,5 +205,34 @@ namespace ExchangeSharpConsole
                 }
             }
         }
+
+        public static void RunGetSymbols(Dictionary<string, string> dict)
+        {
+            RequireArgs(dict, "exchangeName");
+            using (var api = ExchangeAPI.GetExchangeAPI(dict["exchangeName"]))
+            {
+                if (api == null)
+                {
+                    throw new ArgumentException("Cannot find exchange with name {0}", dict["exchangeName"]);
+                }
+
+                try
+                {
+                    var symbols = api.GetSymbolsAsync().Sync();
+
+                    foreach (var symbol in symbols)
+                    {
+                        Console.WriteLine(symbol);
+                    }
+
+                    Console.WriteLine("Press any key to quit.");
+                    Console.ReadKey();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+            }
+        }
     }
 }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
@@ -157,8 +157,8 @@ namespace ExchangeSharpConsole
                             var candles = api.GetCandlesAsync(symbol, 86400, CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(7.0)), null).Sync().ToArray();
                             Assert(candles.Length != 0 && candles[0].ClosePrice > 0m && candles[0].HighPrice > 0m && candles[0].LowPrice > 0m && candles[0].OpenPrice > 0m &&
                                 candles[0].HighPrice >= candles[0].LowPrice && candles[0].HighPrice >= candles[0].ClosePrice && candles[0].HighPrice >= candles[0].OpenPrice &&
-                                !string.IsNullOrWhiteSpace(candles[0].Name) && candles[0].ExchangeName == api.Name && candles[0].PeriodSeconds == 86400 && candles[0].BaseVolume > 0.0 &&
-                                candles[0].ConvertedVolume > 0.0 && candles[0].WeightedAverage >= 0m);
+                                !string.IsNullOrWhiteSpace(candles[0].Name) && candles[0].ExchangeName == api.Name && candles[0].PeriodSeconds == 86400 && candles[0].BaseCurrencyVolume > 0.0 &&
+                                candles[0].QuoteCurrencyVolume > 0.0 && candles[0].WeightedAverage >= 0m);
 
                             Console.WriteLine($"OK ({candles.Length})");
                         }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
@@ -87,14 +87,14 @@ namespace ExchangeSharpConsole
                 // test all public API for each exchange
                 try
                 {
-                    string symbol = api.NormalizeSymbol(GetSymbol(api));
+                    string marketSymbol = api.NormalizeMarketSymbol(GetSymbol(api));
 
                     if (functionRegex == null || Regex.IsMatch("symbol", functionRegex, RegexOptions.IgnoreCase))
                     {
                         Console.Write("Test {0} GetSymbolsAsync... ", api.Name);
-                        IReadOnlyCollection<string> symbols = api.GetSymbolsAsync().Sync().ToArray();
-                        Assert(symbols != null && symbols.Count != 0 && symbols.Contains(symbol, StringComparer.OrdinalIgnoreCase));
-                        Console.WriteLine($"OK (default: {symbol}; {symbols.Count} symbols)");
+                        IReadOnlyCollection<string> symbols = api.GetMarketSymbolsAsync().Sync().ToArray();
+                        Assert(symbols != null && symbols.Count != 0 && symbols.Contains(marketSymbol, StringComparer.OrdinalIgnoreCase));
+                        Console.WriteLine($"OK (default: {marketSymbol}; {symbols.Count} symbols)");
                     }
 
                     if (functionRegex == null || Regex.IsMatch("orderbook", functionRegex, RegexOptions.IgnoreCase))
@@ -102,7 +102,7 @@ namespace ExchangeSharpConsole
                         try
                         {
                             Console.Write("Test {0} GetOrderBookAsync... ", api.Name);
-                            var book = api.GetOrderBookAsync(symbol).Sync();
+                            var book = api.GetOrderBookAsync(marketSymbol).Sync();
                             Assert(book.Asks.Count != 0 && book.Bids.Count != 0 && book.Asks.First().Value.Amount > 0m &&
                                 book.Asks.First().Value.Price > 0m && book.Bids.First().Value.Amount > 0m && book.Bids.First().Value.Price > 0m);
                             Console.WriteLine($"OK ({book.Asks.Count} asks, {book.Bids.Count} bids)");
@@ -118,7 +118,7 @@ namespace ExchangeSharpConsole
                         try
                         {
                             Console.Write("Test {0} GetTickerAsync... ", api.Name);
-                            var ticker = api.GetTickerAsync(symbol).Sync();
+                            var ticker = api.GetTickerAsync(marketSymbol).Sync();
                             Assert(ticker != null && ticker.Ask > 0m && ticker.Bid > 0m && ticker.Last > 0m &&
                                 ticker.Volume != null && ticker.Volume.QuoteCurrencyVolume > 0m && ticker.Volume.BaseCurrencyVolume > 0m);
                             Console.WriteLine($"OK (ask: {ticker.Ask}, bid: {ticker.Bid}, last: {ticker.Last})");
@@ -134,12 +134,12 @@ namespace ExchangeSharpConsole
                         try
                         {
                             Console.Write("Test {0} GetHistoricalTradesAsync... ", api.Name);
-                            api.GetHistoricalTradesAsync(histTradeCallback, symbol).Sync();
+                            api.GetHistoricalTradesAsync(histTradeCallback, marketSymbol).Sync();
                             Assert(trades.Length != 0 && trades[0].Price > 0m && trades[0].Amount > 0m);
                             Console.WriteLine($"OK ({trades.Length})");
 
                             Console.Write("Test {0} GetRecentTradesAsync... ", api.Name);
-                            trades = api.GetRecentTradesAsync(symbol).Sync().ToArray();
+                            trades = api.GetRecentTradesAsync(marketSymbol).Sync().ToArray();
                             Assert(trades.Length != 0 && trades[0].Price > 0m && trades[0].Amount > 0m);
                             Console.WriteLine($"OK ({trades.Length} trades)");
                         }
@@ -154,7 +154,7 @@ namespace ExchangeSharpConsole
                         try
                         {
                             Console.Write("Test {0} GetCandlesAsync... ", api.Name);
-                            var candles = api.GetCandlesAsync(symbol, 86400, CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(7.0)), null).Sync().ToArray();
+                            var candles = api.GetCandlesAsync(marketSymbol, 86400, CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(7.0)), null).Sync().ToArray();
                             Assert(candles.Length != 0 && candles[0].ClosePrice > 0m && candles[0].HighPrice > 0m && candles[0].LowPrice > 0m && candles[0].OpenPrice > 0m &&
                                 candles[0].HighPrice >= candles[0].LowPrice && candles[0].HighPrice >= candles[0].ClosePrice && candles[0].HighPrice >= candles[0].OpenPrice &&
                                 !string.IsNullOrWhiteSpace(candles[0].Name) && candles[0].ExchangeName == api.Name && candles[0].PeriodSeconds == 86400 && candles[0].BaseCurrencyVolume > 0.0 &&

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_ExchangeTests.cs
@@ -120,7 +120,7 @@ namespace ExchangeSharpConsole
                             Console.Write("Test {0} GetTickerAsync... ", api.Name);
                             var ticker = api.GetTickerAsync(symbol).Sync();
                             Assert(ticker != null && ticker.Ask > 0m && ticker.Bid > 0m && ticker.Last > 0m &&
-                                ticker.Volume != null && ticker.Volume.BaseVolume > 0m && ticker.Volume.ConvertedVolume > 0m);
+                                ticker.Volume != null && ticker.Volume.QuoteCurrencyVolume > 0m && ticker.Volume.BaseCurrencyVolume > 0m);
                             Console.WriteLine($"OK (ask: {ticker.Ask}, bid: {ticker.Bid}, last: {ticker.Last})");
                         }
                         catch

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Export.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Export.cs
@@ -20,11 +20,11 @@ namespace ExchangeSharpConsole
     {
         public static void RunGetHistoricalTrades(Dictionary<string, string> dict)
         {
-            RequireArgs(dict, "exchangeName", "symbol");
+            RequireArgs(dict, "exchangeName", "marketSymbol");
 
             string exchangeName = dict["exchangeName"];
             IExchangeAPI api = ExchangeAPI.GetExchangeAPI(exchangeName);
-            string symbol = dict["symbol"];
+            string marketSymbol = dict["marketSymbol"];
             Console.WriteLine("Showing historical trades for exchange {0}...", exchangeName);
             DateTime? startDate = null;
             DateTime? endDate = null;
@@ -43,7 +43,7 @@ namespace ExchangeSharpConsole
                     Console.WriteLine("Trade at timestamp {0}: {1}/{2}/{3}", trade.Timestamp.ToLocalTime(), trade.Id, trade.Price, trade.Amount);
                 }
                 return true;
-            }, symbol, startDate, endDate).Sync();
+            }, marketSymbol, startDate, endDate).Sync();
         }
 
         public static void RunExportData(Dictionary<string, string> dict)

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Orders.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Orders.cs
@@ -18,14 +18,7 @@ namespace ExchangeSharpConsole
             IExchangeAPI api = ExchangeAPI.GetExchangeAPI(exchangeName);
             string symbol = dict["symbol"];
 
-            Console.Write("Enter Public Api Key: ");
-            var publicApiKey = GetSecureInput();
-            api.PublicApiKey = publicApiKey;
-            Console.WriteLine();
-            Console.Write("Enter Private Api Key: ");
-            var privateApiKey = GetSecureInput();
-            api.PrivateApiKey = privateApiKey;
-            Console.WriteLine();
+            Authenticate(api);
 
             DateTime? startDate = null;
             if (dict.ContainsKey("startDate"))
@@ -41,6 +34,45 @@ namespace ExchangeSharpConsole
 
             Console.Write("Press enter to exit..");
             Console.ReadLine();
+        }
+
+        public static void RunGetOrderDetails(Dictionary<string, string> dict)
+        {
+            RequireArgs(dict, "exchangeName", "orderId");
+
+            string exchangeName = dict["exchangeName"];
+            IExchangeAPI api = ExchangeAPI.GetExchangeAPI(exchangeName);
+            string orderId = dict["orderId"];
+
+            Authenticate(api);
+
+            string symbol = null;
+            if (dict.ContainsKey("symbol"))
+            {
+                symbol = dict["symbol"];
+            }
+
+            var orderDetails = api.GetOrderDetailsAsync(orderId, symbol).Sync();
+            Console.WriteLine(orderDetails);
+
+            Console.Write("Press enter to exit..");
+            Console.ReadLine();
+        }
+
+        private static void Authenticate(IExchangeAPI api)
+        {
+            Console.Write("Enter Public Api Key: ");
+            var publicApiKey = GetSecureInput();
+            api.PublicApiKey = publicApiKey;
+            Console.WriteLine();
+            Console.Write("Enter Private Api Key: ");
+            var privateApiKey = GetSecureInput();
+            api.PrivateApiKey = privateApiKey;
+            Console.WriteLine();
+            Console.Write("Enter Passphrase: ");
+            var passphrase = GetSecureInput();
+            api.Passphrase = passphrase;
+            Console.WriteLine();
         }
 
         private static SecureString GetSecureInput()

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Orders.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Orders.cs
@@ -12,11 +12,11 @@ namespace ExchangeSharpConsole
     {
         public static void RunGetOrderHistory(Dictionary<string, string> dict)
         {
-            RequireArgs(dict, "exchangeName", "symbol");
+            RequireArgs(dict, "exchangeName", "marketSymbol");
 
             string exchangeName = dict["exchangeName"];
             IExchangeAPI api = ExchangeAPI.GetExchangeAPI(exchangeName);
-            string symbol = dict["symbol"];
+            string marketSymbol = dict["marketSymbol"];
 
             Authenticate(api);
 
@@ -26,7 +26,7 @@ namespace ExchangeSharpConsole
                 startDate = DateTime.Parse(dict["startDate"]).ToUniversalTime();
             }
 
-            var completedOrders = api.GetCompletedOrderDetailsAsync(symbol, startDate).Sync();
+            var completedOrders = api.GetCompletedOrderDetailsAsync(marketSymbol, startDate).Sync();
             foreach (var completedOrder in completedOrders)
             {
                 Console.WriteLine(completedOrder);
@@ -46,13 +46,13 @@ namespace ExchangeSharpConsole
 
             Authenticate(api);
 
-            string symbol = null;
-            if (dict.ContainsKey("symbol"))
+            string marketSymbol = null;
+            if (dict.ContainsKey("marketSymbol"))
             {
-                symbol = dict["symbol"];
+                marketSymbol = dict["marketSymbol"];
             }
 
-            var orderDetails = api.GetOrderDetailsAsync(orderId, symbol).Sync();
+            var orderDetails = api.GetOrderDetailsAsync(orderId, marketSymbol).Sync();
             Console.WriteLine(orderDetails);
 
             Console.Write("Press enter to exit..");

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Stats.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Stats.cs
@@ -60,10 +60,10 @@ namespace ExchangeSharpConsole
                 decimal bidPriceSum4 = orders4.Bids.Values.Sum(o => o.Price);
 
                 Console.Clear();
-                Console.WriteLine("GDAX: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker.Last, ticker.Volume.BaseVolume, askAmountSum, askPriceSum, bidAmountSum, bidPriceSum);
-                Console.WriteLine("GEMI: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker2.Last, ticker2.Volume.BaseVolume, askAmountSum2, askPriceSum2, bidAmountSum2, bidPriceSum2);
-                Console.WriteLine("KRAK: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker3.Last, ticker3.Volume.BaseVolume, askAmountSum3, askPriceSum3, bidAmountSum3, bidPriceSum3);
-                Console.WriteLine("BITF: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker4.Last, ticker4.Volume.BaseVolume, askAmountSum4, askPriceSum4, bidAmountSum4, bidPriceSum4);
+                Console.WriteLine("GDAX: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker.Last, ticker.Volume.QuoteCurrencyVolume, askAmountSum, askPriceSum, bidAmountSum, bidPriceSum);
+                Console.WriteLine("GEMI: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker2.Last, ticker2.Volume.QuoteCurrencyVolume, askAmountSum2, askPriceSum2, bidAmountSum2, bidPriceSum2);
+                Console.WriteLine("KRAK: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker3.Last, ticker3.Volume.QuoteCurrencyVolume, askAmountSum3, askPriceSum3, bidAmountSum3, bidPriceSum3);
+                Console.WriteLine("BITF: {0:0.00}, {1:0.00}, {2:0.00}, {3:0.00}, {4:0.00}, {5:0.00}", ticker4.Last, ticker4.Volume.QuoteCurrencyVolume, askAmountSum4, askPriceSum4, bidAmountSum4, bidPriceSum4);
                 Thread.Sleep(5000);
             }
         }

--- a/ExchangeSharpConsole/Console/ExchangeSharpConsole_Stats.cs
+++ b/ExchangeSharpConsole/Console/ExchangeSharpConsole_Stats.cs
@@ -22,8 +22,8 @@ namespace ExchangeSharpConsole
     {
         public static void RunShowExchangeStats(Dictionary<string, string> dict)
         {
-            string symbol = "BTC-USD";
-            string symbol2 = "XXBTZUSD";
+            string marketSymbol = "BTC-USD";
+            string marketSymbol2 = "XXBTZUSD";
             IExchangeAPI apiCoinbase = new ExchangeCoinbaseAPI();
             IExchangeAPI apiGemini = new ExchangeGeminiAPI();
             IExchangeAPI apiKraken = new ExchangeKrakenAPI();
@@ -31,29 +31,29 @@ namespace ExchangeSharpConsole
 
             while (true)
             {
-                ExchangeTicker ticker = apiCoinbase.GetTickerAsync(symbol).Sync();
-                ExchangeOrderBook orders = apiCoinbase.GetOrderBookAsync(symbol).Sync();
+                ExchangeTicker ticker = apiCoinbase.GetTickerAsync(marketSymbol).Sync();
+                ExchangeOrderBook orders = apiCoinbase.GetOrderBookAsync(marketSymbol).Sync();
                 decimal askAmountSum = orders.Asks.Values.Sum(o => o.Amount);
                 decimal askPriceSum = orders.Asks.Values.Sum(o => o.Price);
                 decimal bidAmountSum = orders.Bids.Values.Sum(o => o.Amount);
                 decimal bidPriceSum = orders.Bids.Values.Sum(o => o.Price);
 
-                ExchangeTicker ticker2 = apiGemini.GetTickerAsync(symbol).Sync();
-                ExchangeOrderBook orders2 = apiGemini.GetOrderBookAsync(symbol).Sync();
+                ExchangeTicker ticker2 = apiGemini.GetTickerAsync(marketSymbol).Sync();
+                ExchangeOrderBook orders2 = apiGemini.GetOrderBookAsync(marketSymbol).Sync();
                 decimal askAmountSum2 = orders2.Asks.Values.Sum(o => o.Amount);
                 decimal askPriceSum2 = orders2.Asks.Values.Sum(o => o.Price);
                 decimal bidAmountSum2 = orders2.Bids.Values.Sum(o => o.Amount);
                 decimal bidPriceSum2 = orders2.Bids.Values.Sum(o => o.Price);
 
-                ExchangeTicker ticker3 = apiKraken.GetTickerAsync(symbol2).Sync();
-                ExchangeOrderBook orders3 = apiKraken.GetOrderBookAsync(symbol2).Sync();
+                ExchangeTicker ticker3 = apiKraken.GetTickerAsync(marketSymbol2).Sync();
+                ExchangeOrderBook orders3 = apiKraken.GetOrderBookAsync(marketSymbol2).Sync();
                 decimal askAmountSum3 = orders3.Asks.Values.Sum(o => o.Amount);
                 decimal askPriceSum3 = orders3.Asks.Values.Sum(o => o.Price);
                 decimal bidAmountSum3 = orders3.Bids.Values.Sum(o => o.Amount);
                 decimal bidPriceSum3 = orders3.Bids.Values.Sum(o => o.Price);
 
-                ExchangeTicker ticker4 = apiBitfinex.GetTickerAsync(symbol).Sync();
-                ExchangeOrderBook orders4 = apiBitfinex.GetOrderBookAsync(symbol).Sync();
+                ExchangeTicker ticker4 = apiBitfinex.GetTickerAsync(marketSymbol).Sync();
+                ExchangeOrderBook orders4 = apiBitfinex.GetOrderBookAsync(marketSymbol).Sync();
                 decimal askAmountSum4 = orders4.Asks.Values.Sum(o => o.Amount);
                 decimal askPriceSum4 = orders4.Asks.Values.Sum(o => o.Price);
                 decimal bidAmountSum4 = orders4.Bids.Values.Sum(o => o.Amount);

--- a/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
+++ b/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
@@ -128,6 +128,10 @@ namespace ExchangeSharpConsole
                 {
                     RunGetOrderHistory(argsDictionary);
                 }
+                else if (argsDictionary.ContainsKey("symbols-metadata"))
+                {
+                    RunGetSymbolsMetadata(argsDictionary);
+                }
                 else
                 {
                     Logger.Error("Unrecognized command line arguments.");

--- a/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
+++ b/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
@@ -138,7 +138,7 @@ namespace ExchangeSharpConsole
                 }
                 else if (argsDictionary.ContainsKey("symbols"))
                 {
-                    RunGetSymbols(argsDictionary);
+                    RunGetMarketSymbols(argsDictionary);
                 }
                 else if (argsDictionary.ContainsKey("tickers"))
                 {

--- a/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
+++ b/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
@@ -128,9 +128,17 @@ namespace ExchangeSharpConsole
                 {
                     RunGetOrderHistory(argsDictionary);
                 }
+                else if (argsDictionary.ContainsKey("getOrderDetails"))
+                {
+                    RunGetOrderDetails(argsDictionary);
+                }
                 else if (argsDictionary.ContainsKey("symbols-metadata"))
                 {
                     RunGetSymbolsMetadata(argsDictionary);
+                }
+                else if (argsDictionary.ContainsKey("symbols"))
+                {
+                    RunGetSymbols(argsDictionary);
                 }
                 else
                 {
@@ -147,6 +155,8 @@ namespace ExchangeSharpConsole
             finally
             {
                 Logger.Info("ExchangeSharp console finished.");
+                Logger.Info("Press any key to exit");
+                Console.ReadKey(true);
             }
         }
     }

--- a/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
+++ b/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
@@ -144,6 +144,10 @@ namespace ExchangeSharpConsole
                 {
                     RunGetTickers(argsDictionary);
                 }
+                else if (argsDictionary.ContainsKey("candles"))
+                {
+                    RunGetCandles(argsDictionary);
+                }
                 else
                 {
                     Logger.Error("Unrecognized command line arguments.");

--- a/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
+++ b/ExchangeSharpConsole/ExchangeSharpConsole_Main.cs
@@ -140,6 +140,10 @@ namespace ExchangeSharpConsole
                 {
                     RunGetSymbols(argsDictionary);
                 }
+                else if (argsDictionary.ContainsKey("tickers"))
+                {
+                    RunGetTickers(argsDictionary);
+                }
                 else
                 {
                     Logger.Error("Unrecognized command line arguments.");
@@ -155,8 +159,6 @@ namespace ExchangeSharpConsole
             finally
             {
                 Logger.Info("ExchangeSharp console finished.");
-                Logger.Info("Press any key to exit");
-                Console.ReadKey(true);
             }
         }
     }

--- a/ExchangeSharpTests/ExchangeBinanceAPITests.cs
+++ b/ExchangeSharpTests/ExchangeBinanceAPITests.cs
@@ -129,7 +129,7 @@ namespace ExchangeSharpTests
         {
             diff.EventType.Should().Be("depthUpdate");
             diff.EventTime.Should().Be(123456789);
-            diff.Symbol.Should().Be("BNBBTC");
+            diff.MarketSymbol.Should().Be("BNBBTC");
             diff.FirstUpdate.Should().Be(157);
             diff.FinalUpdate.Should().Be(160);
             diff.Bids[0][0].Should().Be("0.0024");

--- a/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -112,7 +112,7 @@ namespace ExchangeSharpTests
             order.OrderId.Should().BeNullOrEmpty();
             order.AveragePrice.Should().Be(0.0001716132563851949140701411m);
             order.Price.Should().Be(order.AveragePrice);
-            order.Symbol.Should().Be("BTC_VIA");
+            order.MarketSymbol.Should().Be("BTC_VIA");
         }
 
         [TestMethod]
@@ -128,7 +128,7 @@ namespace ExchangeSharpTests
             order.IsBuy.Should().BeTrue();
             order.Fees.Should().Be(28.64470495m);
             order.FeesCurrency.Should().Be("XEM");
-            order.Symbol.Should().Be("BTC_XEM");
+            order.MarketSymbol.Should().Be("BTC_XEM");
             order.Price.Should().Be(0.00005128m);
             order.AveragePrice.Should().Be(0.00005128m);
         }
@@ -241,7 +241,7 @@ namespace ExchangeSharpTests
             order.IsBuy.Should().BeTrue();
             order.Fees.Should().Be(28.64470495m);
             order.FeesCurrency.Should().Be("XEM");
-            order.Symbol.Should().Be("BTC_XEM");
+            order.MarketSymbol.Should().Be("BTC_XEM");
             order.Price.Should().Be(0.00005128m);
             order.AveragePrice.Should().Be(0.00005128m);
             order.Result.Should().Be(ExchangeAPIOrderResult.Filled);
@@ -293,7 +293,7 @@ namespace ExchangeSharpTests
             // {"BTC_MAID": [ { "globalTradeID": 29251512, "tradeID": "1385888", "date": "2016-05-03 01:29:55", "rate": "0.00014243", "amount": "353.74692925", "total": "0.05038417", "fee": "0.00200000", "orderNumber": "12603322113", "type": "buy", "category": "settlement" }, { "globalTradeID": 29251511, "tradeID": "1385887", "date": "2016-05-03 01:29:55", "rate": "0.00014111", "amount": "311.24262497", "total": "0.04391944", "fee": "0.00200000", "orderNumber": "12603319116", "type": "sell", "category": "marginTrade" }
             var polo = CreatePoloniexAPI(GetCompletedOrderDetails_AllSymbolsOrders);
             ExchangeOrderResult order = polo.GetCompletedOrderDetailsAsync().Sync().First();
-            order.Symbol.Should().Be("BTC_MAID");
+            order.MarketSymbol.Should().Be("BTC_MAID");
             order.OrderId.Should().Be("12603322113");
             order.OrderDate.Should().Be(new DateTime(2016, 5, 3, 1, 29, 55));
             order.AveragePrice.Should().Be(0.00014243m);

--- a/ExchangeSharpTests/ExchangeTests.cs
+++ b/ExchangeSharpTests/ExchangeTests.cs
@@ -37,7 +37,7 @@ namespace ExchangeSharpTests
             Dictionary<string, string[]> allSymbols = new Dictionary<string, string[]>();
             foreach (IExchangeAPI api in ExchangeAPI.GetExchangeAPIs())
             {
-                allSymbols[api.Name] = api.GetSymbolsAsync().Sync().ToArray();
+                allSymbols[api.Name] = api.GetMarketSymbolsAsync().Sync().ToArray();
             }
             return JsonConvert.SerializeObject(allSymbols);
         }
@@ -45,8 +45,8 @@ namespace ExchangeSharpTests
         [TestMethod]
         public void GlobalSymbolTest()
         {
-            string globalSymbol = "BTC-ETH";
-            string globalSymbolAlt = "KRW-BTC"; // WTF Bitthumb...
+            string globalMarketSymbol = "BTC-ETH";
+            string globalMarketSymbolAlt = "KRW-BTC"; // WTF Bitthumb...
             Dictionary<string, string[]> allSymbols = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(Resources.AllSymbolsJson);
 
             // sanity test that all exchanges return the same global symbol when converted back and forth
@@ -55,11 +55,11 @@ namespace ExchangeSharpTests
                 try
                 {
                     bool isBithumb = (api.Name == ExchangeName.Bithumb);
-                    string exchangeSymbol = api.GlobalSymbolToExchangeSymbol(isBithumb ? globalSymbolAlt : globalSymbol);
-                    string globalSymbol2 = api.ExchangeSymbolToGlobalSymbol(exchangeSymbol);
-                    if ((!isBithumb && globalSymbol2.EndsWith("-BTC")) ||
-                        globalSymbol2.EndsWith("-USD") ||
-                        globalSymbol2.EndsWith("-USDT"))
+                    string exchangeMarketSymbol = api.GlobalMarketSymbolToExchangeMarketSymbol(isBithumb ? globalMarketSymbolAlt : globalMarketSymbol);
+                    string globalMarketSymbol2 = api.ExchangeMarketSymbolToGlobalMarketSymbol(exchangeMarketSymbol);
+                    if ((!isBithumb && globalMarketSymbol2.EndsWith("-BTC")) ||
+                        globalMarketSymbol2.EndsWith("-USD") ||
+                        globalMarketSymbol2.EndsWith("-USDT"))
                     {
                         Assert.Fail($"Exchange {api.Name} has wrong SymbolIsReversed parameter");
                     }
@@ -71,13 +71,13 @@ namespace ExchangeSharpTests
                                 "then apply this new string to Resources.AllSymbolsJson");
                         }
                         string[] symbols = allSymbols[api.Name];
-                        Assert.IsTrue(symbols.Contains(exchangeSymbol), "Symbols does not contain exchange symbol");
+                        Assert.IsTrue(symbols.Contains(exchangeMarketSymbol), "Symbols does not contain exchange symbol");
                     }
                     catch
                     {
                         Assert.Fail("Error getting symbols");
                     }
-                    Assert.IsTrue(globalSymbol == globalSymbol2 || globalSymbolAlt == globalSymbol2);
+                    Assert.IsTrue(globalMarketSymbol == globalMarketSymbol2 || globalMarketSymbolAlt == globalMarketSymbol2);
                 }
                 catch (NotImplementedException)
                 {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ExchangeSharp is a C# console app and framework for trading and communicating wi
 ### Features
 - Many exchanges supported with public, private and web socket API
 - Easy to use and well documented code and API
-- Optional global symbol normalization, since each exchange has their own way of doing symbols
+- Optional global market symbol normalization, since each exchange has their own way of doing market symbols
 - Runs anywhere .NET core will run (Windows 8.1 or newer, MAC, Linux, iOS, Android, Unity 2018+, etc.)
 
 ### Exchanges
@@ -41,7 +41,7 @@ The following cryptocurrency services are supported:
 - Cryptowatch (partial)
 
 ### Notes
-ExchangeSharp uses 'symbol' to refer to markets, or pairs of currencies.
+ExchangeSharp uses 'marketSymbol' to refer to markets, or pairs of currencies.
 
 Please send pull requests if you have made a change that you feel is worthwhile, want a bug fixed or want a new feature. You can also donate to get new features.
 
@@ -82,7 +82,7 @@ ExchangeOrderResult result = api.PlaceOrderAsync(new ExchangeOrderRequest
     Amount = 0.01m,
     IsBuy = true,
     Price = ticker.Ask,
-    Symbol = "XXBTZUSD"
+    MarketSymbol = "XXBTZUSD"
 }).Sync();
 
 // Kraken is a bit funny in that they don't return the order details in the initial request, so you have to follow up with an order details request


### PR DESCRIPTION
This is a pretty large refactor attempting to bring some more consistent naming to several of the model class properties.  More specifically, every time a symbol is referred to in code it should be in reference to a currency pair, consisting of the following elements (order matters):  a base currency, an optional separator, and a quote currency.  For example, consider the symbol "BTC-USD"..  If BTC-USD==20,000.00; then 1 BTC is exchanged for 20000 USD. See issue #267 for more info.