### PR TITLE
Fix bad argument when creating KeyValuePair objects inside OnGetTickersWebSocket

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -250,7 +250,7 @@ namespace ExchangeSharp
                 foreach (JToken childToken in token["data"])
                 {
                     ticker = ParseTickerWebSocket(childToken);
-                    tickerList.Add(new KeyValuePair<string, ExchangeTicker>(ticker.Volume.QuoteCurrency, ticker));
+                    tickerList.Add(new KeyValuePair<string, ExchangeTicker>(ticker.MarketSymbol, ticker));
                 }
                 if (tickerList.Count != 0)
                 {


### PR DESCRIPTION
Somehow I missed this when I did the naming refactor 