### PR TITLE
Fix parsing of marketSymbol and Id in Kucoin trade stream.

### DIFF
--- a/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
@@ -448,9 +448,10 @@ namespace ExchangeSharp
 						if (token["type"].ToStringInvariant() == "message")
 						{
 							var dataToken = token["data"];
-							var marketSymbol = token["topic"].ToStringInvariant().Split('_')[0]; // /trade/CHSB-BTC_HISTORY
+							var marketSymbol = token["topic"].ToStringInvariant().Split('/','_')[2]; // /trade/CHSB-BTC_HISTORY
 							var trade = dataToken.ParseTrade(amountKey: "count", priceKey: "price", typeKey: "direction",
-								timestampKey: "time", TimestampType.UnixMilliseconds, idKey: "oid");
+								timestampKey: "time", TimestampType.UnixMilliseconds); // idKey: "oid");
+							// one day, if ExchangeTrade.Id is converted to string, then the above can be uncommented  
 							callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
 						}
 						return Task.CompletedTask;


### PR DESCRIPTION
In Kucoin, the trade Id and order Id are long hexadecimals, such as 5bda8e5c9dda157958b7b4cc. Thus, since ExchangeTrade.Id is a long, the Id cannot be parsed correctly. If one day ExchangeTrade.Id is converted to string instead, then the line can be uncommented and the oid can be parsed. 