### PR TITLE
Updated ParseOrder function to read marketSymbol from product_id

### DIFF
--- a/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -71,7 +71,7 @@ namespace ExchangeSharp
             decimal stop_price = result["stop_price"].ConvertInvariant<decimal>();
             decimal averagePrice = (amountFilled <= 0m ? 0m : executedValue / amountFilled);
             decimal fees = result["fill_fees"].ConvertInvariant<decimal>();
-            string marketSymbol = result["product_id"].ToStringInvariant();
+            string marketSymbol = result["product_id"].ToStringInvariant(result["id"].ToStringInvariant());
 
             ExchangeOrderResult order = new ExchangeOrderResult
             {

--- a/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -71,7 +71,7 @@ namespace ExchangeSharp
             decimal stop_price = result["stop_price"].ConvertInvariant<decimal>();
             decimal averagePrice = (amountFilled <= 0m ? 0m : executedValue / amountFilled);
             decimal fees = result["fill_fees"].ConvertInvariant<decimal>();
-            string marketSymbol = result["id"].ToStringInvariant(result["product_id"].ToStringInvariant());
+            string marketSymbol = result["product_id"].ToStringInvariant();
 
             ExchangeOrderResult order = new ExchangeOrderResult
             {

--- a/ExchangeSharp/ExchangeSharp.csproj
+++ b/ExchangeSharp/ExchangeSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <PackageId>DigitalRuby.ExchangeSharp</PackageId>
     <Title>ExchangeSharp - C# API for cryptocurrency exchanges</Title>
     <PackageVersion>0.5.8.0</PackageVersion>

--- a/ExchangeSharp/ExchangeSharp.csproj
+++ b/ExchangeSharp/ExchangeSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <PackageId>DigitalRuby.ExchangeSharp</PackageId>
     <Title>ExchangeSharp - C# API for cryptocurrency exchanges</Title>
     <PackageVersion>0.5.8.0</PackageVersion>


### PR DESCRIPTION
Updated ParseOrder function to read marketSymbol from product_id instead of id. Updated TargetFramework in ExchangeSharp.cspoj to move nestandard2.0 before net472 to be able to support intellisense in netcore projects also.