### PR TITLE
Skip writing of empty content-body for GET requests

### DIFF
--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -660,7 +660,7 @@ namespace ExchangeSharp
             {
                 request.AddHeader("content-length", "0");
             }
-            else if (!string.IsNullOrEmpty(form) && request.Method != "GET")
+            else if (!string.IsNullOrEmpty(form))
             {
                 byte[] bytes = form.ToBytesUTF8();
                 request.AddHeader("content-length", bytes.Length.ToStringInvariant());

--- a/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/ExchangeSharp/Utility/CryptoUtility.cs
@@ -660,7 +660,7 @@ namespace ExchangeSharp
             {
                 request.AddHeader("content-length", "0");
             }
-            else
+            else if (!string.IsNullOrEmpty(form) && request.Method != "GET")
             {
                 byte[] bytes = form.ToBytesUTF8();
                 request.AddHeader("content-length", bytes.Length.ToStringInvariant());


### PR DESCRIPTION
Skip writing of empty content-body for GET requests. This fixes the error in BitMEX GET requests - "Cannot send a content-body with this verb-type".

Fixes issue #335.