### PR TITLE
Fix BitMEX orderbook websocket request string

### DIFF
--- a/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -352,7 +352,7 @@ namespace ExchangeSharp
                 {
                     marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
                 }
-                await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "\"orderBookL2:" + this.NormalizeMarketSymbol(s) + "\"").ToArray() });
+                await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "orderBookL2:" + this.NormalizeMarketSymbol(s)).ToArray() });
             });
         }
 


### PR DESCRIPTION
Fix BitMEX orderbook websocket request string by removing redundant **\\"** in the arguments.

Fixes #337.