### PR TITLE
Update ExchangeBitMEXAPI.cs

### DIFF
--- a/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -369,11 +369,11 @@ namespace ExchangeSharp
             string url = $"/trade/bucketed?binSize={periodString}&partial=false&symbol={marketSymbol}&reverse=true" + marketSymbol;
             if (startDate != null)
             {
-                url += "&startTime=" + startDate.Value.ToString("yyyy-MM-dd");
+                url += "&startTime=" + startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
             }
             if (endDate != null)
             {
-                url += "&endTime=" + endDate.Value.ToString("yyyy-MM-dd");
+                url += "&endTime=" + endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
             }
             if (limit != null)
             {


### PR DESCRIPTION
support for intraday Datetime:
it wasn't possible to get a full day 1min candles list, due to max result count limit.