### PR TITLE
Okex - ExchangeMarket.MaxTradeSize fixed

### DIFF
--- a/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
@@ -144,8 +144,8 @@ namespace ExchangeSharp
                 var quantityStepSize = Math.Pow(10, -quotePrecision);
                 market.QuantityStepSize = quantityStepSize.ConvertInvariant<decimal>();
                 var maxSizeDigit = marketSymbolToken["maxSizeDigit"].ConvertInvariant<double>();
-                var maxTradeSize = Math.Pow(10, maxSizeDigit);
-                market.MaxTradeSize = (decimal)maxTradeSize - 1.0m;
+                var maxTradeSize = (decimal)Math.Pow(10, maxSizeDigit);
+                market.MaxTradeSize = maxTradeSize - 1.0m;
                 market.MinTradeSize = marketSymbolToken["minTradeSize"].ConvertInvariant<decimal>();
 
                 market.PriceStepSize = marketSymbolToken["quoteIncrement"].ConvertInvariant<decimal>();

--- a/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
@@ -145,7 +145,7 @@ namespace ExchangeSharp
                 market.QuantityStepSize = quantityStepSize.ConvertInvariant<decimal>();
                 var maxSizeDigit = marketSymbolToken["maxSizeDigit"].ConvertInvariant<double>();
                 var maxTradeSize = Math.Pow(10, maxSizeDigit);
-                market.MaxTradeSize = maxTradeSize.ConvertInvariant<decimal>() - 1.0m;
+                market.MaxTradeSize = (decimal)maxTradeSize - 1.0m;
                 market.MinTradeSize = marketSymbolToken["minTradeSize"].ConvertInvariant<decimal>();
 
                 market.PriceStepSize = marketSymbolToken["quoteIncrement"].ConvertInvariant<decimal>();


### PR DESCRIPTION
MaxTradeSize is not marketSymbolToken and ConvertInvariant sets maxTradeSize always 100 so it disabled