### PR TITLE
Consistent trade data type for Binance

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -294,7 +294,7 @@ namespace ExchangeSharp
 
                 // buy=0 -> m = true (The buyer is maker, while the seller is taker).
                 // buy=1 -> m = false(The seller is maker, while the buyer is taker).
-                callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, token.ParseTrade("q", "p", "m", "E", TimestampType.UnixMilliseconds, "t", "false")));
+                callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, token.ParseTrade("q", "p", "m", "E", TimestampType.UnixMilliseconds, "a", "false")));
                 return Task.CompletedTask;
             });
         }


### PR DESCRIPTION
Binances live data stream is currently set to use the RAW trade data while the historical data is set to use the AGGREGATED data.

This pull request brings the live data stream inline with the more useful AGGREGATED datatype.

One could argue that for regression purposes it should be other way around, which then simply means the historical data should use the RAW data as well.

Either is fine, as long as it's consistent.