### PR TITLE
Refined Bittrex API RateLimit

### DIFF
--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -33,6 +33,9 @@ namespace ExchangeSharp
 
         public ExchangeBittrexAPI()
         {
+            // https://bittrex.github.io/api/v1-1#call-limits (Same counts for the V3 API)
+            RateLimit = new RateGate(60, TimeSpan.FromSeconds(60));
+
             TwoFieldDepositCoinTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "BITSHAREX",


### PR DESCRIPTION
Bittrex does not have a configured RateLimit, which uses the base 5calls/15seconds.

We can see from their documentation that the accepted rate limit is 60 calls / 60 seconds