### PR TITLE
#386 Fails due to common API being removed

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -359,7 +359,7 @@ namespace ExchangeSharp
             await state.ProcessHistoricalTrades();
         }
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, long startId, long? endId = null)
+        public async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, long startId, long? endId = null)
         {
             /* [ {
             "a": 26129,         // Aggregate tradeId


### PR DESCRIPTION
My earlier removal of the common API layer was pushed a little quick while attempting to get the change merge.

The build fails due to the implemented function still being marked as override, this has now been corrected (... and tested)