### PR TITLE
Fix OnGetAmountsAvailableToTradeAsync for Livecoin

### DIFF
--- a/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -206,7 +206,7 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/payment/balances", null, await GetNoncePayloadAsync());
             foreach (JToken child in token)
             {
-                if (child["type"].ToStringInvariant() == "trade")
+                if (child["type"].ToStringInvariant() == "available")
                 {
                     decimal amount = child["value"].ConvertInvariant<decimal>();
                     if (amount > 0m) amounts.Add(child["currency"].ToStringInvariant(), amount);


### PR DESCRIPTION
Fixed from **trade** to **available**.
Official documentation states that:
- trade: in open orders
- available: for trading
Source: [https://www.livecoin.net/api/userdata#paymentbalances](https://www.livecoin.net/api/userdata#paymentbalances)

First of (I hope) many contributions!.