### PR TITLE
Added InvariantCulture for use in enviroments with other cultures

### DIFF
--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -313,6 +313,7 @@ namespace ExchangeSharp
             int maxCount = 100
         )
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
             var book = new ExchangeOrderBook { SequenceId = token[sequence].ConvertInvariant<long>() };
             foreach (JArray array in token[asks])
             {


### PR DESCRIPTION
Problem: when requesting the order book on Livecoin and the exchange returns for example: asks = {["7800.07", "0.00172",155975495],["7.93E+3","0.00018984","155975362"]} 
If using a culture different than "us", the conversion of "7.93E+3" throws an error as it is not recognized (it only recognizes "7,93E+3").
Setting CultureInfo.InvariantCulture forces to use always the same culture on convertions.
