### PR TITLE
Convert TradeID in trade stream to string from long

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -391,12 +391,13 @@ namespace ExchangeSharp
                 foreach (var token in obj)
                 {
                     var trade = token.ParseTrade("q", "p", "m", "T", TimestampType.UnixMilliseconds, "a", "false");
-                    if (trade.Id < fromId) continue;
-                    if (trade.Id > endId) continue;
-                    if (!processedIds.Add(trade.Id)) continue;
+					long tradeId = (long)trade.Id.ConvertInvariant<ulong>();
+					if (tradeId < fromId) continue;
+                    if (tradeId > endId) continue;
+                    if (!processedIds.Add(tradeId)) continue;
 
                     trades.Add(trade);
-                    fromId = trade.Id;
+                    fromId = tradeId;
                 }
 
                 fromId++;

--- a/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -328,7 +328,7 @@ namespace ExchangeSharp
             decimal amount = token[2].ConvertInvariant<decimal>();
             return new ExchangeTrade
             {
-                Id = token[0].ConvertInvariant<int>(),
+                Id = token[0].ToStringInvariant(),
                 Timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(token[1].ConvertInvariant<long>()),
                 Amount = Math.Abs(amount),
                 IsBuy = amount > 0,
@@ -380,7 +380,7 @@ namespace ExchangeSharp
                 }
                 foreach (decimal[] tradeChunkPiece in tradeChunk)
                 {
-                    trades.Add(new ExchangeTrade { Amount = Math.Abs(tradeChunkPiece[2]), IsBuy = tradeChunkPiece[2] > 0m, Price = tradeChunkPiece[3], Timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds((double)tradeChunkPiece[1]), Id = (long)tradeChunkPiece[0] });
+                    trades.Add(new ExchangeTrade { Amount = Math.Abs(tradeChunkPiece[2]), IsBuy = tradeChunkPiece[2] > 0m, Price = tradeChunkPiece[3], Timestamp = CryptoUtility.UnixTimeStampToDateTimeMilliseconds((double)tradeChunkPiece[1]), Id = tradeChunkPiece[0].ToStringInvariant() });
                 }
                 trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));
                 if (!callback(trades))

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -323,8 +323,8 @@ namespace ExchangeSharp
                         Amount = trade["V"].ConvertInvariant<decimal>(),
                         Price = trade["C"].ConvertInvariant<decimal>(),
                         Timestamp = trade["T"].ToDateTimeInvariant(),
-                        Id = -1,
-                        IsBuy = true
+                        Id = trade["T"].ToStringInvariant(),
+						IsBuy = true
                     });
                 }
                 trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));

--- a/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
+++ b/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI_WebSocket.cs
@@ -239,7 +239,7 @@ namespace ExchangeSharp
 						// Bittrex doesn't currently send out FillId on socket.bittrex.com, only beta.bittrex.com, but this will be ready when they start
 						// https://github.com/Bittrex/beta/issues/2, https://github.com/Bittrex/bittrex.github.io/issues/3
 						// You can always change the URL on the top of the file to beta.bittrex.com to start getting FillIds now
-						Id = fill.FillId,
+						Id = fill.FillId.ToStringInvariant(),
 						IsBuy = fill.OrderSide == OrderSide.Buy,
 						Price = fill.Rate,
 						Timestamp = fill.Timestamp

--- a/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -439,7 +439,7 @@ namespace ExchangeSharp
 
         private ExchangeTrade ParseTradeWebSocket(JToken token)
         {
-            return token.ParseTrade("last_size", "price", "side", "time", TimestampType.Iso8601, "sequence");
+            return token.ParseTrade("last_size", "price", "side", "time", TimestampType.Iso8601, "trade_id");
         }
 
         protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)

--- a/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Cryptopia/ExchangeCryptopiaAPI.cs
@@ -433,7 +433,7 @@ namespace ExchangeSharp
         private ExchangeTrade ParseTrade(JToken token)
         {
             // [{ "TradePairId":100,"Label":"LTC/BTC","Type":"Sell","Price":0.00006000, "Amount":499.99640000,"Total":0.02999978,"Timestamp": 1418297368}, ...]
-            return token.ParseTrade("Amount", "Price", "Type", "Timestamp", TimestampType.UnixSeconds);
+            return token.ParseTrade("Amount", "Price", "Type", "Timestamp", TimestampType.UnixSeconds, null);
         }
 
         #endregion Private Functions

--- a/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
@@ -122,7 +122,7 @@ namespace ExchangeSharp
                 Callback = callback,
                 DirectionIsBackwards = false,
                 EndDate = endDate,
-                ParseFunction = (JToken token) => token.ParseTrade("amount", "price", "type", "timestampms", TimestampType.UnixMilliseconds),
+                ParseFunction = (JToken token) => token.ParseTrade("amount", "price", "type", "timestampms", TimestampType.UnixMilliseconds, idKey: "tid"),
                 StartDate = startDate,
                 MarketSymbol = marketSymbol,
                 TimestampFunction = (DateTime dt) => ((long)CryptoUtility.UnixTimestampFromDateTimeMilliseconds(dt)).ToStringInvariant(),

--- a/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -178,7 +178,6 @@ namespace ExchangeSharp
         protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null)
         {
             List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            long? lastTradeID = null;
             // TODO: Can't get Hitbtc to return other than the last 50 trades even though their API says it should (by orderid or timestamp). When passing either of these parms, it still returns the last 50
             // So until there is an update, that's what we'll go with
             JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol);
@@ -187,7 +186,6 @@ namespace ExchangeSharp
                 foreach (JToken token in obj)
                 {
                     ExchangeTrade trade = ParseExchangeTrade(token);
-                    lastTradeID = trade.Id;
                     if (startDate == null || trade.Timestamp >= startDate)
                     {
                         trades.Add(trade);

--- a/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -270,7 +270,6 @@ namespace ExchangeSharp
                 var trades = ParseTradesWebSocket(data);
                 foreach (var trade in trades)
                 {
-                    trade.Id = id;
                     callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
                 }
             }, async (_socket) =>

--- a/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kucoin/ExchangeKucoinAPI.cs
@@ -199,8 +199,9 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/orders?status=active&symbol=" + marketSymbol);
             foreach (JToken trade in token)
             {
-                trades.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.UnixMilliseconds));
-            }
+                trades.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.UnixMilliseconds, idKey: "tradeId"));
+
+			}
             return trades;
         }
 
@@ -210,7 +211,7 @@ namespace ExchangeSharp
             JToken token = await MakeJsonRequestAsync<JToken>("/market/histories?symbol=" + marketSymbol + (startDate == null ? string.Empty : "&since=" + startDate.Value.UnixTimestampFromDateTimeMilliseconds()));
             foreach (JObject trade in token)
             {
-                trades.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.UnixMilliseconds));
+                trades.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.UnixMilliseconds, idKey: "tradeId"));
             }
             var rc = callback?.Invoke(trades);
         }
@@ -477,8 +478,7 @@ namespace ExchangeSharp
                             var dataToken = token["data"];
 							var marketSymbol = token["data"]["symbol"].ToStringInvariant();
                             var trade = dataToken.ParseTrade(amountKey: "size", priceKey: "price", typeKey: "side",
-                                timestampKey: "time", TimestampType.UnixNanoseconds); // idKey: "tradeId");
-																					   // one day, if ExchangeTrade.Id is converted to string, then the above can be uncommented
+                                timestampKey: "time", TimestampType.UnixNanoseconds, idKey: "tradeId");
 							callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
                         }
 						else if (token["type"].ToStringInvariant() == "error")

--- a/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
+++ b/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
@@ -212,7 +212,7 @@ namespace ExchangeSharp
                 exTradeList.Add(
                     new ExchangeTrade
                     {
-                        Id = token["tid"].ConvertInvariant<long>(),
+                        Id = token["tid"].ToStringInvariant(),
                         Timestamp = timestamp,
                         Price = token["price"].ConvertInvariant<decimal>(),
                         Amount = token["amount"].ConvertInvariant<decimal>(),

--- a/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Okex/ExchangeOkexAPI.cs
@@ -580,7 +580,7 @@ namespace ExchangeSharp
 
 			return new ExchangeTrade
 			  {
-				  Id = token["trade_id"].ConvertInvariant<long>(),
+				  Id = token["trade_id"].ToStringInvariant(),
 				  Price = token["price"].ConvertInvariant<decimal>(),
 				  Amount = token["size"].ConvertInvariant<decimal>(),
 				  Timestamp = DateTime.Parse(token["timestamp"].ToStringInvariant()),

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -476,25 +476,25 @@ namespace ExchangeSharp
         /// <param name="typeKeyIsBuyValue">Type key buy value</param>
         /// <returns>Trade</returns>
         internal static ExchangeTrade ParseTrade(this JToken token, object amountKey, object priceKey, object typeKey,
-            object timestampKey, TimestampType timestampType, object idKey = null, string typeKeyIsBuyValue = "buy")
+            object timestampKey, TimestampType timestampType, object idKey, string typeKeyIsBuyValue = "buy")
         {
             ExchangeTrade trade = new ExchangeTrade
             {
                 Amount = token[amountKey].ConvertInvariant<decimal>(),
                 Price = token[priceKey].ConvertInvariant<decimal>(),
-                IsBuy = (token[typeKey].ToStringInvariant().EqualsWithOption(typeKeyIsBuyValue))
-            };
+                IsBuy = (token[typeKey].ToStringInvariant().EqualsWithOption(typeKeyIsBuyValue)),
+			};
             trade.Timestamp = (timestampKey == null ? CryptoUtility.UtcNow : CryptoUtility.ParseTimestamp(token[timestampKey], timestampType));
             if (idKey == null)
             {
-                trade.Id = trade.Timestamp.Ticks;
+                trade.Id = trade.Timestamp.Ticks.ToStringInvariant();
             }
             else
             {
                 try
                 {
-                    trade.Id = (long)token[idKey].ConvertInvariant<ulong>();
-                }
+					trade.Id = token[idKey].ToStringInvariant();
+				}
                 catch
                 {
                     // dont care

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeHistoricalTradeHelper.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeHistoricalTradeHelper.cs
@@ -71,9 +71,9 @@ namespace ExchangeSharp
                 StartDate = (StartDate ?? EndDate.Value.Subtract(BlockTime));
                 string startTimestamp;
                 string endTimestamp;
-                HashSet<long> previousTrades = new HashSet<long>();
-                HashSet<long> tempTradeIds = new HashSet<long>();
-                HashSet<long> tmpIds;
+                HashSet<string> previousTrades = new HashSet<string>();
+                HashSet<string> tempTradeIds = new HashSet<string>();
+                HashSet<string> tmpIds;
                 SetDates(out DateTime startDateMoving, out DateTime endDateMoving);
 
                 while (true)
@@ -104,7 +104,7 @@ namespace ExchangeSharp
                         {
                             trades.Add(trade);
                         }
-                        if (trade.Id != 0)
+                        if (trade.Id != null)
                         {
                             tempTradeIds.Add(trade.Id);
                         }

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeLogger.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeLogger.cs
@@ -31,8 +31,8 @@ namespace ExchangeSharp
         private BinaryWriter bookWriter;
         private BinaryWriter tradeWriter;
 
-        HashSet<long> tradeIds = new HashSet<long>();
-        HashSet<long> tradeIds2 = new HashSet<long>();
+        HashSet<string> tradeIds = new HashSet<string>();
+        HashSet<string> tradeIds2 = new HashSet<string>();
 
         private void LoggerThread()
         {
@@ -80,7 +80,7 @@ namespace ExchangeSharp
         public void Update()
         {
             ExchangeTrade[] newTrades;
-            HashSet<long> tmpTradeIds;
+            HashSet<string> tmpTradeIds;
 
             try
             {

--- a/ExchangeSharp/Model/ExchangeTrade.cs
+++ b/ExchangeSharp/Model/ExchangeTrade.cs
@@ -32,7 +32,7 @@ namespace ExchangeSharp
         /// <summary>
         /// Trade id
         /// </summary>
-        public long Id { get; set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Price
@@ -87,7 +87,7 @@ namespace ExchangeSharp
         public void FromBinary(BinaryReader reader)
         {
             Timestamp = new DateTime(reader.ReadInt64(), DateTimeKind.Utc);
-            Id = reader.ReadInt64();
+            Id = reader.ReadString();
             Price = (decimal)reader.ReadDouble();
             Amount = (decimal)reader.ReadDouble();
             IsBuy = reader.ReadBoolean();


### PR DESCRIPTION
Exchanges use a varying set of types for Trade IDs. Currently, we use a bunch of ugly hacks to convert them to long in the trade stream. In BitMex, we were attempting to parse a GUID into a long and thus throwing and then catching an exception for each trade. In Huobi, we were setting all of the trade IDs to that of the parent tick. Finally, in many other exchanges, were substituting the timestamp ticks for the trade ID as we didn’t know what else to do.

These hacks have a variety of problems. First, some of them do not uniquely identify trades, such that multiple trades can have the same ID. Also, since we are not using the original trade IDs from the exchanges, the new IDs are not able to be used to look up trades from those same exchanges.

Changing the type to string allows the end user to access the actual Trade ID. They can then parse them to long, hash them, or ignore them and use timestamp. This would be a breaking change. However, it would be a small one and allows them to make decisions about the tradeoffs themselves.