### PR TITLE
Changes Coinbase Trade stream to 'matches' from 'ticker'

### DIFF
--- a/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/ExchangeBinanceAPI.cs
@@ -294,7 +294,7 @@ namespace ExchangeSharp
 
                 // buy=0 -> m = true (The buyer is maker, while the seller is taker).
                 // buy=1 -> m = false(The seller is maker, while the buyer is taker).
-                await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, token.ParseTrade("q", "p", "m", "E", TimestampType.UnixMilliseconds, "a", "false")));
+                await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, token.ParseTradeBinance("q", "p", "m", "E", TimestampType.UnixMilliseconds, "a", "false")));
             });
         }
 

--- a/ExchangeSharp/API/Exchanges/Binance/Models/BinanceAggregateTrade.cs
+++ b/ExchangeSharp/API/Exchanges/Binance/Models/BinanceAggregateTrade.cs
@@ -1,0 +1,30 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp.Binance
+{
+	public class BinanceAggregateTrade : ExchangeTrade
+	{
+		public long FirstTradeId { get; set; }
+		public long LastTradeId { get; set; }
+		public override string ToString()
+		{
+			return string.Format("{0},{1},{2}", base.ToString(), FirstTradeId, LastTradeId);
+		}
+	}
+}

--- a/ExchangeSharp/API/Exchanges/Coinbase/Models/CoinbaseTrade.cs
+++ b/ExchangeSharp/API/Exchanges/Coinbase/Models/CoinbaseTrade.cs
@@ -1,0 +1,30 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp.Coinbase
+{
+	public class CoinbaseTrade : ExchangeTrade
+	{
+		public Guid MakerOrderId { get; set; }
+		public Guid TakerOrderId { get; set; }
+		public override string ToString()
+		{
+			return string.Format("{0},{1},{2}", base.ToString(), MakerOrderId, TakerOrderId);
+		}
+	}
+}

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -14,7 +14,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+using ExchangeSharp.Binance;
+using ExchangeSharp.Coinbase;
 using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp

--- a/ExchangeSharp/Model/ExchangeTrade.cs
+++ b/ExchangeSharp/Model/ExchangeTrade.cs
@@ -22,7 +22,7 @@ namespace ExchangeSharp
     /// <summary>
     /// Details of an exchangetrade
     /// </summary>
-    public sealed class ExchangeTrade
+    public class ExchangeTrade
     {
         /// <summary>
         /// Timestamp
@@ -117,4 +117,24 @@ namespace ExchangeSharp
         /// </summary>
         IsLastFromSnapshot = 4
     }
+
+	public class CoinbaseTrade : ExchangeTrade
+	{
+		public Guid MakerOrderId { get; set; }
+		public Guid TakerOrderId { get; set; }
+		public override string ToString()
+		{
+			return string.Format("{0},{1},{2}", base.ToString(), MakerOrderId, TakerOrderId);
+		}
+	}
+
+	public class BinanceAggregateTrade : ExchangeTrade
+	{
+		public long FirstTradeId { get; set; }
+		public long LastTradeId { get; set; }
+		public override string ToString()
+		{
+			return string.Format("{0},{1},{2}", base.ToString(), FirstTradeId, LastTradeId);
+		}
+	}
 }

--- a/ExchangeSharp/Model/ExchangeTrade.cs
+++ b/ExchangeSharp/Model/ExchangeTrade.cs
@@ -117,24 +117,4 @@ namespace ExchangeSharp
         /// </summary>
         IsLastFromSnapshot = 4
     }
-
-	public class CoinbaseTrade : ExchangeTrade
-	{
-		public Guid MakerOrderId { get; set; }
-		public Guid TakerOrderId { get; set; }
-		public override string ToString()
-		{
-			return string.Format("{0},{1},{2}", base.ToString(), MakerOrderId, TakerOrderId);
-		}
-	}
-
-	public class BinanceAggregateTrade : ExchangeTrade
-	{
-		public long FirstTradeId { get; set; }
-		public long LastTradeId { get; set; }
-		public override string ToString()
-		{
-			return string.Format("{0},{1},{2}", base.ToString(), FirstTradeId, LastTradeId);
-		}
-	}
 }


### PR DESCRIPTION
- doing so provides additional information such as MakerOrderId and TakerOrderId
- created new subclasses of ExchangeTrade to provide this info
- does the same for BinanceAggregateTrade as well
- does all of this in a backwards compatible way (does not break existing code)
- now logs Trade steam errors in Coinbase