### PR TITLE
dont add price when orderType is Market

### DIFF
--- a/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -556,7 +556,10 @@ namespace ExchangeSharp
             payload["ordType"] = order.OrderType.ToStringInvariant();
             payload["side"] = order.IsBuy ? "Buy" : "Sell";
             payload["orderQty"] = order.Amount;
+            
+            if(order.OrderType!=OrderType.Market)
             payload["price"] = order.Price;
+            
             if (order.ExtraParameters.TryGetValue("execInst", out var execInst))
             {
                 payload["execInst"] = execInst;


### PR DESCRIPTION
Hi,

An api call with order type Market and price Bitmex response has error as  invalid price. After this update works again.