### PR TITLE
Provide additional information buy/sell OrderId in Bitstamp

### DIFF
--- a/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -542,7 +542,7 @@ namespace ExchangeSharp
 					//	"channel": "live_trades_btcusd"
 					//}}
 					string marketSymbol = token["channel"].ToStringInvariant().Split('_')[2];
-					var trade = token["data"].ParseTrade(amountKey: "amount", priceKey: "price",
+					var trade = token["data"].ParseTradeBitstamp(amountKey: "amount", priceKey: "price",
 							typeKey: "type", timestampKey: "microtimestamp",
 							TimestampType.UnixMicroeconds, idKey: "id",
 							typeKeyIsBuyValue: "0");

--- a/ExchangeSharp/API/Exchanges/Bitstamp/Models/BitstampTrade.cs
+++ b/ExchangeSharp/API/Exchanges/Bitstamp/Models/BitstampTrade.cs
@@ -1,0 +1,30 @@
+﻿/*
+MIT LICENSE
+
+Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExchangeSharp.Bitstamp
+{
+	public class BitstampTrade : ExchangeTrade
+	{
+		public Int64 BuyOrderId { get; set; }
+		public Int64 SellOrderId { get; set; }
+		public override string ToString()
+		{
+			return string.Format("{0},{1},{2}", base.ToString(), BuyOrderId, SellOrderId);
+		}
+	}
+}

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -15,6 +15,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using ExchangeSharp.Binance;
+using ExchangeSharp.Bitstamp;
 using ExchangeSharp.Coinbase;
 using Newtonsoft.Json.Linq;
 
@@ -484,16 +485,6 @@ namespace ExchangeSharp
 
 		}
 
-		internal static ExchangeTrade ParseTradeCoinbase(this JToken token, object amountKey, object priceKey, object typeKey,
-			object timestampKey, TimestampType timestampType, object idKey, string typeKeyIsBuyValue = "buy")
-		{
-			var trade = ParseTradeComponents<CoinbaseTrade>(token, amountKey, priceKey, typeKey,
-				timestampKey, timestampType, idKey, typeKeyIsBuyValue);
-			trade.MakerOrderId = (Guid)token["maker_order_id"];
-			trade.TakerOrderId = (Guid)token["taker_order_id"];
-			return trade;
-		}
-
 		internal static ExchangeTrade ParseTradeBinance(this JToken token, object amountKey, object priceKey, object typeKey,
 			object timestampKey, TimestampType timestampType, object idKey, string typeKeyIsBuyValue = "buy")
 		{
@@ -501,6 +492,26 @@ namespace ExchangeSharp
 				timestampKey, timestampType, idKey, typeKeyIsBuyValue);
 			trade.FirstTradeId = token["f"].ConvertInvariant<long>();
 			trade.LastTradeId = token["l"].ConvertInvariant<long>();
+			return trade;
+		}
+
+		internal static ExchangeTrade ParseTradeBitstamp(this JToken token, object amountKey, object priceKey, object typeKey,
+			object timestampKey, TimestampType timestampType, object idKey, string typeKeyIsBuyValue = "buy")
+		{
+			var trade = ParseTradeComponents<BitstampTrade>(token, amountKey, priceKey, typeKey,
+				timestampKey, timestampType, idKey, typeKeyIsBuyValue);
+			trade.BuyOrderId = token["buy_order_id"].ConvertInvariant<long>();
+			trade.SellOrderId = token["sell_order_id"].ConvertInvariant<long>();
+			return trade;
+		}
+
+		internal static ExchangeTrade ParseTradeCoinbase(this JToken token, object amountKey, object priceKey, object typeKey,
+			object timestampKey, TimestampType timestampType, object idKey, string typeKeyIsBuyValue = "buy")
+		{
+			var trade = ParseTradeComponents<CoinbaseTrade>(token, amountKey, priceKey, typeKey,
+				timestampKey, timestampType, idKey, typeKeyIsBuyValue);
+			trade.MakerOrderId = (Guid)token["maker_order_id"];
+			trade.TakerOrderId = (Guid)token["taker_order_id"];
 			return trade;
 		}
 


### PR DESCRIPTION
- similar to recent work on Binance and Coinbase #408
- reordered ParseTrade() methods alphabetically