### PR TITLE
Kraken symbol refactor

### DIFF
--- a/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -495,7 +495,7 @@ namespace ExchangeSharp
                 var quantityStepSize = Math.Pow(0.1, pair["lot_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>();
                 var market = new ExchangeMarket
                 {
-                    IsActive = !prop.Name.Contains(".d"),
+                    IsActive = true,
                     MarketSymbol = prop.Name,
                     MinTradeSize = quantityStepSize,
                     MarginEnabled = pair["leverage_buy"].Children().Any() || pair["leverage_sell"].Children().Any(),

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -429,10 +429,10 @@ namespace ExchangeSharp
         /// <param name="baseCurrency">Base currency</param>
         /// <param name="quoteCurrency">Quote currency</param>
         /// <returns>Exchange market symbol</returns>
-        public virtual string CurrenciesToExchangeMarketSymbol(string baseCurrency, string quoteCurrency)
+        public virtual Task<string> CurrenciesToExchangeMarketSymbol(string baseCurrency, string quoteCurrency)
         {
             string symbol = (MarketSymbolIsReversed ? $"{quoteCurrency}{MarketSymbolSeparator}{baseCurrency}" : $"{baseCurrency}{MarketSymbolSeparator}{quoteCurrency}");
-            return (MarketSymbolIsUppercase ? symbol.ToUpperInvariant() : symbol);
+            return Task.FromResult(MarketSymbolIsUppercase ? symbol.ToUpperInvariant() : symbol);
         }
 
         /// <summary>

--- a/ExchangeSharp/Model/ExchangeCurrency.cs
+++ b/ExchangeSharp/Model/ExchangeCurrency.cs
@@ -20,6 +20,9 @@ namespace ExchangeSharp
         /// <summary>Full name of the currency. Eg. Ethereum</summary>
         public string FullName { get; set; }
 
+        /// <summary>Alternate name, null if none</summary>
+        public string AltName { get; set; }
+
         /// <summary>The transaction fee.</summary>
         public decimal TxFee { get; set; }
 


### PR DESCRIPTION
Remove the hard-coded Kraken symbol list and create from api call instead. Drop handling of dark mode symbols, these can be passed manually by appending '.d' if needed to order calls.