### PR TITLE
Eliminate SSL3

### DIFF
--- a/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/ExchangeSharp/API/Common/BaseAPI.cs
@@ -264,11 +264,11 @@ namespace ExchangeSharp
 
 #if HAS_WINDOWS_FORMS // NET47
 
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault | SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
 #else
 
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
 #endif
 


### PR DESCRIPTION
- SSL3 is now deprecated
	- https://medium.com/@kyle.gagnet/your-net-code-could-stop-working-in-june-afb35fbf29ca
	- https://tools.ietf.org/html/rfc7568
	- https://docs.microsoft.com/en-us/security-updates/securityadvisories/2015/3009008
- plus, it was giving me the exception `System.NotSupportedException: 'The requested security protocol is not supported.'`