### PR TITLE
workaround SignalR HubConnection.Stop() bug

### DIFF
--- a/ExchangeSharp/Utility/SignalrManager.cs
+++ b/ExchangeSharp/Utility/SignalrManager.cs
@@ -677,8 +677,15 @@ namespace ExchangeSharp
         /// </summary>
         public void Stop()
         {
-            hubConnection.Stop(TimeSpan.FromSeconds(0.1));
-        }
+			try
+			{
+				hubConnection.Stop(TimeSpan.FromSeconds(0.1));
+			}
+			catch (NullReferenceException) 
+			{ // bug in SignalR where Stop() throws a NRE if it times out
+			  // https://github.com/SignalR/SignalR/issues/3561
+			}
+		}
 
         /// <summary>
         /// Finalizer
@@ -700,7 +707,7 @@ namespace ExchangeSharp
             disposed = true;
             try
             {
-                hubConnection.Transport.Dispose();
+                hubConnection.Transport?.Dispose();
                 hubConnection.Dispose();
             }
             catch


### PR DESCRIPTION
- bug in SignalR where Stop() throws a NRE if it times out
	- https://github.com/SignalR/SignalR/issues/3561
- also handle case where trying to dispose of a HubConnection where the Transport is null