### PR TITLE
Kraken: speedup symbol lookup in trade stream

### DIFF
--- a/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -868,7 +868,7 @@ namespace ExchangeSharp
 				//    "name": "ticker"
 				//  }
 				//}
-				await GetExchangeMarketFromCacheAsync(marketSymbols[0]); // prime cache
+				await PopulateLookupTables(); // prime cache
 				Task<string>[] marketSymbolsArray = marketSymbols.Select(async (m) =>
                 {
                     ExchangeMarket market = await GetExchangeMarketFromCacheAsync(m);

--- a/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -859,16 +859,17 @@ namespace ExchangeSharp
 				}
 			}, connectCallback: async (_socket) =>
 			{
-                //{
-                //  "event": "subscribe",
-                //  "pair": [
-                //    "XBT/USD","XBT/EUR"
-                //  ],
-                //  "subscription": {
-                //    "name": "ticker"
-                //  }
-                //}
-                Task<string>[] marketSymbolsArray = marketSymbols.Select(async (m) =>
+				//{
+				//  "event": "subscribe",
+				//  "pair": [
+				//    "XBT/USD","XBT/EUR"
+				//  ],
+				//  "subscription": {
+				//    "name": "ticker"
+				//  }
+				//}
+				await GetExchangeMarketFromCacheAsync(marketSymbols[0]); // prime cache
+				Task<string>[] marketSymbolsArray = marketSymbols.Select(async (m) =>
                 {
                     ExchangeMarket market = await GetExchangeMarketFromCacheAsync(m);
                     if (market == null)


### PR DESCRIPTION
- Kraken uses special symbols (ADA/CAD rather than ADACAD)
- a recent bugfix fa2534ec7ec0c7b400bc5cb584e353ac62486bf9 now sets the WS name as an alternate name
- the ExchangeMarket is looked up for each symbol name to pull out the alternate name
- while it attempts to use caching, it is not actually able to use the cache, bc once it hits the [await MakeJsonRequestAsync()](https://github.com/jjxtra/ExchangeSharp/blob/7b6e897f005f81afe3eb0aac326396d5d1415db9/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs#L495), the next select statement progresses so OnGetMarketSymbolsMetadataAsync() is called for every symbol
- by priming the cache first, this allows the cache to populate first before the select statement, thus hitting OnGetMarketSymbolsMetadataAsync() once
- this is a hacky way to fix this problem, unless @jjxtra can think of a more elegant way?