### PR TITLE
BL3P: Get full order book

### DIFF
--- a/ExchangeSharp/API/Exchanges/BL3P/Models/BL3POrderBook.cs
+++ b/ExchangeSharp/API/Exchanges/BL3P/Models/BL3POrderBook.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 namespace ExchangeSharp.BL3P
 {
 	// ReSharper disable once InconsistentNaming
-	internal class BL3POrderBook
+	internal class BL3POrderBook : BL3PResponsePayload
 	{
 		[JsonProperty("marketplace")]
 		public string MarketSymbol { get; set; }

--- a/ExchangeSharp/API/Exchanges/BL3P/Models/BL3PReponseFullOrderBook.cs
+++ b/ExchangeSharp/API/Exchanges/BL3P/Models/BL3PReponseFullOrderBook.cs
@@ -1,0 +1,11 @@
+using ExchangeSharp.API.Exchanges.BL3P.Converters;
+using Newtonsoft.Json;
+
+namespace ExchangeSharp.API.Exchanges.BL3P.Models
+{
+	internal class BL3PReponseFullOrderBook : BL3PResponse<BL3POrderBook>
+	{
+		[JsonConverter(typeof(BL3PResponseConverter<BL3POrderBook>))]
+		protected override BL3PResponsePayload Data { get; set; }
+	}
+}

--- a/ExchangeSharp/API/Exchanges/BL3P/Models/BL3PReponseFullOrderBook.cs
+++ b/ExchangeSharp/API/Exchanges/BL3P/Models/BL3PReponseFullOrderBook.cs
@@ -1,7 +1,6 @@
-using ExchangeSharp.API.Exchanges.BL3P.Converters;
 using Newtonsoft.Json;
 
-namespace ExchangeSharp.API.Exchanges.BL3P.Models
+namespace ExchangeSharp.BL3P
 {
 	internal class BL3PReponseFullOrderBook : BL3PResponse<BL3POrderBook>
 	{

--- a/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -74,7 +74,7 @@ namespace ExchangeSharp
 			        orderBook.MarketSymbol ??= ms;
 			        return orderBook;
 		        })
-	        ).ConfigureAwait(false);
+	        );
 	        return orderBooks.ToDictionary(k => k.MarketSymbol, v => v);
         }
 

--- a/ExchangeSharp/ExchangeSharp.csproj.DotSettings
+++ b/ExchangeSharp/ExchangeSharp.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeEditing/Localization/Localizable/@EntryValue">No</s:String>
+</wpf:ResourceDictionary>

--- a/ExchangeSharpConsole/Constants.cs
+++ b/ExchangeSharpConsole/Constants.cs
@@ -1,0 +1,7 @@
+namespace ExchangeSharpConsole
+{
+	public static class Constants
+	{
+		public const string DefaultKeyPath = "keys.bin";
+	}
+}

--- a/ExchangeSharpConsole/Options/BaseOption.cs
+++ b/ExchangeSharpConsole/Options/BaseOption.cs
@@ -214,5 +214,27 @@ namespace ExchangeSharpConsole.Options
 				);
 			}
 		}
+
+		protected void PrintOrderBook(ExchangeOrderBook orderBook)
+		{
+			Console.WriteLine($"{"BID",-22} | {"ASK",22}");
+
+			Console.WriteLine("---");
+
+			var length = orderBook.Asks.Count;
+
+			if (orderBook.Bids.Count > length)
+			{
+				length = orderBook.Bids.Count;
+			}
+
+			for (var i = 0; i < length; i++)
+			{
+				var (_, ask) = orderBook.Asks.ElementAtOrDefault(i);
+				var (_, bid) = orderBook.Bids.ElementAtOrDefault(i);
+				Console.WriteLine($"{bid.Price,10} ({bid.Amount,9:N2}) | " +
+				                  $"{ask.Price,10} ({ask.Amount,9:N})");
+			}
+		}
 	}
 }

--- a/ExchangeSharpConsole/Options/Interfaces/IOptionWithKey.cs
+++ b/ExchangeSharpConsole/Options/Interfaces/IOptionWithKey.cs
@@ -4,7 +4,7 @@ namespace ExchangeSharpConsole.Options.Interfaces
 {
 	public interface IOptionWithKey
 	{
-		[Option('k', "key", Default = "keys.bin",
+		[Option('k', "key", Default = Constants.DefaultKeyPath,
 			HelpText = "Path to key file (generated with the key utility).")]
 		string KeyPath { get; set; }
 	}

--- a/ExchangeSharpConsole/Options/Interfaces/IOptionWithMaximum.cs
+++ b/ExchangeSharpConsole/Options/Interfaces/IOptionWithMaximum.cs
@@ -1,0 +1,10 @@
+using CommandLine;
+
+namespace ExchangeSharpConsole.Options.Interfaces
+{
+	public interface IOptionWithMaximum
+	{
+		[Option("max", Default = 10, HelpText = "Sets the maximum.")]
+		int Max { get; set; }
+	}
+}

--- a/ExchangeSharpConsole/Options/OrderBookOption.cs
+++ b/ExchangeSharpConsole/Options/OrderBookOption.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using ExchangeSharp;
+using ExchangeSharpConsole.Options.Interfaces;
+
+namespace ExchangeSharpConsole.Options
+{
+	[Verb("orderbook", HelpText = "Prints the order book from an exchange.")]
+	public class OrderBookOption : BaseOption,
+		IOptionPerExchange, IOptionWithMultipleMarketSymbol, IOptionWithMaximum, IOptionWithKey
+	{
+		public override async Task RunCommand()
+		{
+			using var api = GetExchangeInstance(ExchangeName);
+
+			if (!string.IsNullOrWhiteSpace(KeyPath)
+			    && !KeyPath.Equals(Constants.DefaultKeyPath, StringComparison.Ordinal))
+			{
+				api.LoadAPIKeys(KeyPath);
+			}
+
+			var marketSymbols = MarketSymbols.ToArray();
+
+			var orderBooks = await GetOrderBooks(marketSymbols, api);
+
+			foreach (var (marketSymbol, orderBook) in orderBooks)
+			{
+				Console.WriteLine($"Order Book for market: {marketSymbol} {orderBook}");
+				PrintOrderBook(orderBook);
+				Console.WriteLine();
+			}
+		}
+
+		private async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooks(
+			string[] marketSymbols,
+			IExchangeAPI api
+		)
+		{
+			IEnumerable<KeyValuePair<string, ExchangeOrderBook>> orderBooks;
+
+			if (marketSymbols.Length == 0)
+			{
+				orderBooks = await api.GetOrderBooksAsync(Max);
+			}
+			else
+			{
+				var orderBooksList = await Task.WhenAll(
+					marketSymbols.Select(async ms =>
+					{
+						var orderBook = await api.GetOrderBookAsync(ms, Max);
+
+						orderBook.MarketSymbol ??= ms;
+
+						return orderBook;
+					})
+				);
+				orderBooks = orderBooksList.ToDictionary(k => k.MarketSymbol, v => v);
+			}
+
+			return orderBooks;
+		}
+
+		public string ExchangeName { get; set; }
+
+		public IEnumerable<string> MarketSymbols { get; set; }
+
+		public int Max { get; set; }
+
+		public string KeyPath { get; set; }
+	}
+}

--- a/ExchangeSharpConsole/Program.cs
+++ b/ExchangeSharpConsole/Program.cs
@@ -24,6 +24,7 @@ namespace ExchangeSharpConsole
 			typeof(KeysOption),
 			typeof(MarketSymbolsMetadataOption),
 			typeof(MarketSymbolsOption),
+			typeof(OrderBookOption),
 			typeof(OrderDetailsOption),
 			typeof(OrderHistoryOption),
 			typeof(SellOption),


### PR DESCRIPTION
 - Improves BaseAPI method `OnGetOrderBooksAsync` to fetch all OrderBooks in parallel
- Adds a new console command `orderbook` that fetch and print a full orderbook from an exchange.