### PR TITLE
remove nuget creation from ExchangeSharp.Forms

### DIFF
--- a/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
+++ b/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
@@ -5,26 +5,8 @@
         <DefineConstants>HAS_WINDOWS_FORMS</DefineConstants>
         <NeutralLanguage>en</NeutralLanguage>
         <LangVersion>8</LangVersion>
-        <!-- Version -->
         <AssemblyVersion>0.6.4</AssemblyVersion>
         <FileVersion>0.6.4</FileVersion>
-        <PackageVersion>0.6.4</PackageVersion>
-        <!-- Nuget Package -->
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Copyright>Copyright 2017, Digital Ruby, LLC - www.digitalruby.com</Copyright>
-        <PackageId>DigitalRuby.ExchangeSharp.Forms</PackageId>
-        <Title>ExchangeSharp - C# API for cryptocurrency exchanges</Title>
-        <Authors>jjxtra</Authors>
-        <Description>ExchangeSharp is a C# API for working with various cryptocurrency exchanges. Web sockets are also supported for some exchanges.</Description>
-        <Summary>Supported exchanges: Abucoins, Binance, Bitfinex, Bithumb, Bitmex, Bitstamp, Bittrex, BL3P, Bleutrade, Coinbase, Cryptopia, Gemini, Hitbtc, Huobi, Kraken, Kucoin, Livecoin, Okex, Poloniex, TuxExchange, Yobit, ZBcom. Pull request welcome.</Summary>
-        <PackageIcon>icon.png</PackageIcon>
-        <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-        <PackageProjectUrl>https://github.com/jjxtra/ExchangeSharp</PackageProjectUrl>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>https://github.com/jjxtra/ExchangeSharp/releases</PackageReleaseNotes>
-        <PackageTags>C# crypto cryptocurrency trade trader exchange sharp socket web socket websocket signalr secure API Binance BitMEX Bitfinex Bithumb Bitstamp Bittrex BL3P Bleutrade Cryptopia Coinbase(GDAX) Digifinex Gemini Gitbtc Huobi Kraken Kucoin Livecoin NDAX OKCoin OKEx Poloniex TuxExchange Yobit ZBcom</PackageTags>
-        <RepositoryUrl>https://github.com/jjxtra/ExchangeSharp</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
+++ b/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>exchange-sharp</AssemblyName>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
+    <LangVersion>8</LangVersion>
     <AssemblyVersion>0.6.4</AssemblyVersion>
     <FileVersion>0.6.4</FileVersion>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- ExchangeSharp.Forms is just a sample project
- we only publish a nuget from the main ExchangeSharp project