### PR TITLE
fix Base/Quote currency ordering in global symbol conversion

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT LICENSE
 
 Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
@@ -40,12 +40,14 @@ namespace ExchangeSharp
 
         public override Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
         {
-            return Task.FromResult("KRW" + GlobalMarketSymbolSeparator + marketSymbol);
+            return Task.FromResult(marketSymbol + GlobalMarketSymbolSeparator + "KRW"); //e.g. 1 btc worth 9.7m KRW
         }
 
         public override Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
         {
-            return Task.FromResult(marketSymbol.Substring(marketSymbol.IndexOf(GlobalMarketSymbolSeparator) + 1));
+	        var values = marketSymbol.Split(GlobalMarketSymbolSeparator); //for Bitthumb, e.g. "BTC-KRW", 1 btc worth about 9.7m won. Market symbol is BTC.
+
+	        return Task.FromResult(values[0]);
         }
 
         private string StatusToError(string status)

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -131,11 +131,6 @@ namespace ExchangeSharp
             {
                 quoteCurrencyNormalized = quoteCurrency;
             }
-            if (quoteCurrencyNormalized == "BTC")
-            {
-                // prefer BTC in front
-                return quoteCurrencyNormalized + GlobalMarketSymbolSeparatorString + baseCurrencyNormalized;
-            }
             return baseCurrencyNormalized + GlobalMarketSymbolSeparatorString + quoteCurrencyNormalized;
         }
 

--- a/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -25,21 +25,32 @@ namespace ExchangeSharp
         #region Utility Methods
 
         /// <summary>
-        /// Normalize a symbol for use on this exchange
+        /// Normalize a symbol for use on this exchange.
         /// </summary>
         /// <param name="marketSymbol">Symbol</param>
         /// <returns>Normalized symbol</returns>
         string NormalizeMarketSymbol(string marketSymbol);
 
-        /// <summary>
-        /// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
-        /// Global symbols are always uppercase and separate the currency pair with a hyphen (-).
-        /// Global symbols list the base currency first (i.e. BTC) and conversion currency
-        /// second (i.e. USD). Example BTC-USD, read as x BTC is worth y USD.
-        /// </summary>
-        /// <param name="marketSymbol">Exchange symbol</param>
-        /// <returns>Global symbol</returns>
-        Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol);
+		/// <summary>
+		/// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
+		/// Global symbols are always uppercase and separate the currency pair with a hyphen (-).
+		/// Global symbols list the base currency first (i.e. BTC) and quote/conversion currency
+		/// second (i.e. USD). Global symbols are of the form BASE-QUOTE. BASE-QUOTE is read as
+		/// 1 BASE is worth y QUOTE. 
+		///
+		/// Examples:
+		///		On 1/25/2020,
+		///			- BTC-USD: $8,371; 1 BTC (base) is worth $8,371 USD (quote)
+		///			- ETH-BTC: 0.01934; 1 ETH is worth 0.01934 BTC
+		///			- EUR-USD: 1.2; 1 EUR worth 1.2 USD
+		/// 
+		/// A value greater than 1 means one unit of base currency is more valuable than one unit of
+		/// quote currency.
+		/// 
+		/// </summary>
+		/// <param name="marketSymbol">Exchange symbol</param>
+		/// <returns>Global symbol</returns>
+		Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol);
 
         /// <summary>
         /// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.

--- a/tests/ExchangeSharpTests/ExchangeTests.cs
+++ b/tests/ExchangeSharpTests/ExchangeTests.cs
@@ -68,8 +68,8 @@ namespace ExchangeSharpTests
             // if tests fail, uncomment this and it will save a new test file
             // string allSymbolsJson = GetAllSymbolsJsonAsync().Sync(); System.IO.File.WriteAllText("TestData/AllSymbols.json", allSymbolsJson);
 
-            string globalMarketSymbol = "BTC-ETH";
-            string globalMarketSymbolAlt = "KRW-BTC"; // WTF Bitthumb...
+            string globalMarketSymbol = "ETH-BTC"; //1 ETH is worth 0.0192 BTC...
+            string globalMarketSymbolAlt = "BTC-KRW"; // WTF Bitthumb... //1 BTC worth 9,783,000 won
             Dictionary<string, string[]> allSymbols = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(System.IO.File.ReadAllText("TestData/AllSymbols.json"));
 
             // sanity test that all exchanges return the same global symbol when converted back and forth
@@ -88,9 +88,10 @@ namespace ExchangeSharpTests
                     bool isBithumb = (api.Name == ExchangeName.Bithumb);
                     string exchangeMarketSymbol = await api.GlobalMarketSymbolToExchangeMarketSymbolAsync(isBithumb ? globalMarketSymbolAlt : globalMarketSymbol);
                     string globalMarketSymbol2 = await api.ExchangeMarketSymbolToGlobalMarketSymbolAsync(exchangeMarketSymbol);
-                    if ((!isBithumb && globalMarketSymbol2.EndsWith("-BTC")) ||
-                        globalMarketSymbol2.EndsWith("-USD") ||
-                        globalMarketSymbol2.EndsWith("-USDT"))
+
+                    if ((!isBithumb && globalMarketSymbol2.StartsWith("BTC-")) ||
+                        globalMarketSymbol2.StartsWith("USD-") ||
+                        globalMarketSymbol2.StartsWith("USDT-"))
                     {
                         Assert.Fail($"Exchange {api.Name} has wrong SymbolIsReversed parameter");
                     }


### PR DESCRIPTION
Fixes #500 

Global symbols list the base currency first (e.g. BTC) and quote/conversion currency
second (e.g. USD). Global symbols are of the form BASE-QUOTE. BASE-QUOTE is read as
1 BASE is worth y QUOTE.

Examples:
	On 1/25/2020,
		- BTC-USD: $8,371; 1 BTC (base) is worth $8,371 USD (quote)
		- ETH-BTC: 0.01934; 1 ETH is worth 0.01934 BTC
		- EUR-USD: 1.2; 1 EUR worth 1.2 USD

Pull Request Changes:
- Fixed issue with GlobalMarketSymbolToExchangeMarketSymbolAsync returning QUOTE-BASE in base ExchangeAPI class
- Fixed tests to use standard BASE-QUOTE format
- Fixed Bitthumb and Kraken exchange APIs as a result of changes
- Added some better details/docs about currency pairs