### PR TITLE
Console: updated help for export and trade-history

### DIFF
--- a/src/ExchangeSharpConsole/Options/ExportOption.cs
+++ b/src/ExchangeSharpConsole/Options/ExportOption.cs
@@ -13,7 +13,7 @@ namespace ExchangeSharpConsole.Options
 		"This can take a long time depending on your sinceDateTime parameter.\n" +
 		"Please note that not all exchanges will let you do this and may ban your IP if you try to grab to much data at once. " +
 		"I've added sensible sleep statements to limit request rates.\n" +
-		"Example: export -e gemini --since 20150101 -s btcusd -o \"./data/gemini\"")]
+		"Example: export -e gemini --since 2015-01-01 -s btcusd -p \"./data/gemini\"")]
 	public class ExportOption : BaseOption, IOptionPerExchange, IOptionPerMarketSymbol, IOptionWithIO,
 		IOptionWithStartDate
 	{
@@ -25,7 +25,7 @@ namespace ExchangeSharpConsole.Options
 				ExchangeAPI.GetExchangeAPI(ExchangeName),
 				MarketSymbol,
 				Path,
-				DateTime.Parse(SinceDateString, CultureInfo.InvariantCulture),
+				DateTime.Parse(SinceDateString, CultureInfo.InvariantCulture).ToUniversalTime(),
 				count =>
 				{
 					total = count;

--- a/src/ExchangeSharpConsole/Options/ExportOption.cs
+++ b/src/ExchangeSharpConsole/Options/ExportOption.cs
@@ -25,7 +25,7 @@ namespace ExchangeSharpConsole.Options
 				ExchangeAPI.GetExchangeAPI(ExchangeName),
 				MarketSymbol,
 				Path,
-				DateTime.Parse(SinceDateString, CultureInfo.InvariantCulture).ToUniversalTime(),
+				DateTime.Parse(SinceDateString, CultureInfo.InvariantCulture),
 				count =>
 				{
 					total = count;

--- a/src/ExchangeSharpConsole/Options/TradeHistoryOption.cs
+++ b/src/ExchangeSharpConsole/Options/TradeHistoryOption.cs
@@ -8,7 +8,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("trade-history", HelpText = "Print trade history from an Exchange to output.\n" +
-	                                  "Example: trade-history -e Binance -s btcusdt --since \"20180517\" --to \"20180518\"")]
+	                                  "Example: trade-history -e Binance -s btcusdt --since \"2018-05-17\" --to \"2018-05-18\"")]
 	public class TradeHistoryOption : BaseOption, IOptionPerExchange, IOptionPerMarketSymbol, IOptionWithStartDate,
 		IOptionWithEndDate
 	{


### PR DESCRIPTION
Changes to HelpText which currently don't work due to Datetime.Parse not recognising yyyymmdd as a format an dthe optoin for path being -p