### PR TITLE
fix MemoryStream disposed bug in Websockets

### DIFF
--- a/src/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/src/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -394,12 +394,12 @@ namespace ExchangeSharp
         private async Task ReadTask()
         {
             ArraySegment<byte> receiveBuffer = new ArraySegment<byte>(new byte[receiveChunkSize]);
-            MemoryStream stream = new MemoryStream();
             WebSocketReceiveResult result;
             bool wasConnected = false;
 
             while (!disposed)
             {
+				MemoryStream stream = new MemoryStream();
                 try
                 {
                     // open the socket


### PR DESCRIPTION
- when the connection breaks, the MemoryStream is disposed, so a new one needs to be created
- prev, it was only created once outside the loop
- now, it will be created with every loop