### PR TITLE
Binance: fix WS depth response int overflow bug

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/Models/MarketDepthDiffUpdate.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/Models/MarketDepthDiffUpdate.cs
@@ -28,10 +28,10 @@ namespace ExchangeSharp.BinanceGroup
         public string MarketSymbol { get; set; }
 
         [JsonProperty("U")]
-        public int FirstUpdate { get; set; }
+        public long FirstUpdate { get; set; }
 
         [JsonProperty("u")]
-        public int FinalUpdate { get; set; }
+        public long FinalUpdate { get; set; }
 
         [JsonProperty("b")]
         public List<List<object>> Bids { get; set; }


### PR DESCRIPTION
Library couldn't parse the Json response for the symbol BTCUSDT because of overflow error 
In the MarketDepthDiffUpdate model: int generated overflow error for some symbols, changed to long