### PR TITLE
fixed WebSocket disconnected (NRE) bug

### DIFF
--- a/src/ExchangeSharp/Utility/ClientWebSocket.cs
+++ b/src/ExchangeSharp/Utility/ClientWebSocket.cs
@@ -135,7 +135,9 @@ namespace ExchangeSharp
 
             public Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
             {
-                return webSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+				if (webSocket.State == WebSocketState.Open)
+					return webSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+				else return Task.CompletedTask;
             }
         }
 


### PR DESCRIPTION
- upon connecting to a WS endpoint, sometimes the connection can be lost prior to the subscribe messages being sent
- check to make sure the WebSocket is still connected prior to sending each message