### PR TITLE
Convert exchange currencies format to global currencies format in the ExchangeAPI class

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -44,11 +44,6 @@ namespace ExchangeSharp
 
         static ExchangeKrakenAPI()
         {
-            ExchangeGlobalCurrencyReplacements[typeof(ExchangeKrakenAPI)] = new KeyValuePair<string, string>[]
-            {
-                new KeyValuePair<string, string>("XBT", "BTC"),
-                new KeyValuePair<string, string>("XDG", "DOGE")
-            };
         }
 
         /// <summary>
@@ -105,8 +100,15 @@ namespace ExchangeSharp
                 normalizedSymbolToExchangeSymbol = normalizedSymbolToExchangeSymbolNew;
                 exchangeCurrenciesToMarketSymbol = exchangeCurrenciesToMarketSymbolNew;
 
+                ExchangeGlobalCurrencyReplacements[typeof(ExchangeKrakenAPI)] = exchangeCurrencyToNormalizedCurrency.ToArray();                
+
                 return new CachedItem<object>(new object(), CryptoUtility.UtcNow.AddHours(4.0));
             });
+        }
+
+        public override Task InitializeAsync()
+        {
+            return PopulateLookupTables();
         }
 
         public override async Task<(string baseCurrency, string quoteCurrency)> ExchangeMarketSymbolToCurrenciesAsync(string marketSymbol)

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -404,9 +404,9 @@ namespace ExchangeSharp
         /// <returns>Global currency</returns>
         public async Task<string> ExchangeCurrencyToGlobalCurrencyAsync(string currency)
         {
-            await this.InitializeAsync(); // TODO:MT - let's come up with some Initialization mechanism. Perhaps it would be ExchangeAPI.GetExchangeAsync
+            await this.InitializeAsync();
 
-            currency = (currency ?? string.Empty);
+            currency ??= string.Empty;
 
             var dict = ExchangeGlobalCurrencyReplacements[GetType()].ToDictionary(i => i.Key, i => i.Value);
 

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -361,6 +361,16 @@ namespace ExchangeSharp
             }
         }
 
+		public static async Task<IExchangeAPI?> GetExchangeAPIAsync(string exchangeName)
+		{
+			var api = GetExchangeAPI(exchangeName);
+
+			if (api is ExchangeAPI exchangeAPI)
+				await exchangeAPI.InitializeAsync();
+
+			return api;
+		}
+
         /// <summary>
         /// Get all exchange APIs
         /// </summary>


### PR DESCRIPTION
# Problem
Some exchanges such as Kraken and Binance etc. have weird currencies namings and these weird namings are considered to be of "exchange" format and the most popular namings are considered to be of "global" format. And in the GetAmounts etc. methods the keys returned (strings) are expected to be of global format, not exchange. But the exchanges return exchange format

# Solution
I added in the ExchangeAPI class mapping from exchange to global currency format after calling OnGetCurrencies etc methods. Also, some exchanges require initialization to be done (Kraken for example) so that it can come up with mapping tables, so I decided to add InitializeAsync method 