### PR TITLE
Update Ticker Address - NDAX

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/NDAX/ExchangeNDAXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/NDAX/ExchangeNDAXAPI.cs
@@ -30,7 +30,7 @@ namespace ExchangeSharp
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
         {
             var result =
-                await MakeJsonRequestAsync<Dictionary<string, NDAXTicker>>("returnticker", "https://ndax.io/api", null, "GET");
+                await MakeJsonRequestAsync<Dictionary<string, NDAXTicker>>("returnticker", "https://core.ndax.io/api/returnticker", null, "GET");
             _marketSymbolToInstrumentIdMapping = result.ToDictionary(pair => pair.Key.Replace("_", ""), pair => pair.Value.Id); // remove the _
             return result.Select(pair =>
                 new KeyValuePair<string, ExchangeTicker>(pair.Key, pair.Value.ToExchangeTicker(pair.Key)));


### PR DESCRIPTION
Ticker address was a 404 error. This new address should return a valid response.

Background: I was having issues connecting to NDAX on btcpay's transmuter. I'm hoping this was because of the invalid URL so I thought I'd push this. Not sure if it will fix my issues further down the road, but needs to be fixed anyways :)
