### PR TITLE
Kraken - confirm trading agreement for German residents

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -719,6 +719,7 @@ namespace ExchangeSharp
                 { "type", (order.IsBuy ? "buy" : "sell") },
                 { "ordertype", order.OrderType.ToString().ToLowerInvariant() },
                 { "volume", order.RoundAmount().ToStringInvariant() },
+                { "trading_agreement", "agree" },
                 { "nonce", nonce }
             };
             if (order.OrderType != OrderType.Market)


### PR DESCRIPTION
Hi, Kraken [requires people from Germany to accept on a trading agreement](https://support.kraken.com/hc/en-us/articles/360036157952):

> If your Kraken account is verified with a German address, you will need to accept a trading agreement (shown below) in order to place market and margin orders.

> If you trade via API, the trading agreement needs to be included in every relevant API call you make.

[Details](https://support.kraken.com/hc/en-us/articles/360000920026-Trading-agreement-required-error):

> The trading agreement error can easily be resolved by including an additional parameter named trading_agreement with a value of agree when calling the AddOrder endpoint.

This seems to be the only trading agreement that Kraken requires from anyone.

This pull request (sending the header with every request) is the easiest way but still a kind of sledgehammer. It would allow [BTCPay Server](https://btcpayserver.org/) and [btcTransmuter](https://github.com/btcpayserver/btcTransmuter) users from Germany to sell coins automatically when an order arrives.

I do not have the possibility to test this pull request.