### PR TITLE
#578 Set Bittrex MarketSymbolIsReversed to false

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -68,7 +68,7 @@ namespace ExchangeSharp
                 "WAVES_ASSET",
             };
 
-            MarketSymbolIsReversed = true;
+            MarketSymbolIsReversed = false;
             WebSocketOrderBookType = WebSocketOrderBookType.DeltasOnly;
         }
 


### PR DESCRIPTION
This is in regards to my issue #578 . Bittrex is using the Global Format already (BASE-QUOTE). See https://global.bittrex.com/Market/Index?MarketName=BTC-ETH 
