### PR TITLE
Feature: Add support for `ws-orderbook` to Kraken and Gemini Exchanges

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -18,375 +18,387 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-
 using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    public sealed partial class ExchangeKrakenAPI : ExchangeAPI
-    {
-        public override string BaseUrl { get; set; } = "https://api.kraken.com";
+	public sealed partial class ExchangeKrakenAPI : ExchangeAPI
+	{
+		public override string BaseUrl { get; set; } = "https://api.kraken.com";
 		public override string BaseUrlWebSocket { get; set; } = "wss://ws.kraken.com";
 
 		private ExchangeKrakenAPI()
-        {
-            RequestMethod = "POST";
-            RequestContentType = "application/x-www-form-urlencoded";
-            MarketSymbolSeparator = string.Empty;
-            NonceStyle = NonceStyle.UnixMilliseconds;
-        }
+		{
+			RequestMethod = "POST";
+			RequestContentType = "application/x-www-form-urlencoded";
+			MarketSymbolSeparator = string.Empty;
+			NonceStyle = NonceStyle.UnixMilliseconds;
+		}
 
-        private IReadOnlyDictionary<string, string> exchangeCurrencyToNormalizedCurrency = new Dictionary<string, string>();
-        private IReadOnlyDictionary<string, string> normalizedCurrencyToExchangeCurrency = new Dictionary<string, string>();
-        private IReadOnlyDictionary<string, string> exchangeSymbolToNormalizedSymbol = new Dictionary<string, string>();
-        private IReadOnlyDictionary<string, string> normalizedSymbolToExchangeSymbol = new Dictionary<string, string>();
-        private IReadOnlyDictionary<string, string> exchangeCurrenciesToMarketSymbol = new Dictionary<string, string>();
+		private IReadOnlyDictionary<string, string> exchangeCurrencyToNormalizedCurrency = new Dictionary<string, string>();
+		private IReadOnlyDictionary<string, string> normalizedCurrencyToExchangeCurrency = new Dictionary<string, string>();
+		private IReadOnlyDictionary<string, string> exchangeSymbolToNormalizedSymbol = new Dictionary<string, string>();
+		private IReadOnlyDictionary<string, string> normalizedSymbolToExchangeSymbol = new Dictionary<string, string>();
+		private IReadOnlyDictionary<string, string> exchangeCurrenciesToMarketSymbol = new Dictionary<string, string>();
 
-        /// <summary>
-        /// Populate dictionaries to deal with Kraken weirdness in currency and market names, will use cache if it exists
-        /// </summary>
-        /// <returns>Task</returns>
-        private async Task PopulateLookupTables()
-        {
-            await Cache.GetOrCreate<object>(nameof(PopulateLookupTables), async () =>
-            {
-                IReadOnlyDictionary<string, ExchangeCurrency> currencies = await GetCurrenciesAsync();
-                ExchangeMarket[] markets = (await GetMarketSymbolsMetadataAsync())?.ToArray();
-                if (markets == null || markets.Length == 0)
-                {
-                    return new CachedItem<object>();
-                }
+		/// <summary>
+		/// Populate dictionaries to deal with Kraken weirdness in currency and market names, will use cache if it exists
+		/// </summary>
+		/// <returns>Task</returns>
+		private async Task PopulateLookupTables()
+		{
+			await Cache.GetOrCreate<object>(nameof(PopulateLookupTables), async() =>
+			{
+				IReadOnlyDictionary<string, ExchangeCurrency> currencies = await GetCurrenciesAsync();
+				ExchangeMarket[] markets = (await GetMarketSymbolsMetadataAsync())?.ToArray();
+				if (markets == null || markets.Length == 0)
+				{
+					return new CachedItem<object>();
+				}
 
-                Dictionary<string, string> exchangeCurrencyToNormalizedCurrencyNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                Dictionary<string, string> normalizedCurrencyToExchangeCurrencyNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                Dictionary<string, string> exchangeSymbolToNormalizedSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                Dictionary<string, string> normalizedSymbolToExchangeSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                Dictionary<string, string> exchangeCurrenciesToMarketSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+				Dictionary<string, string> exchangeCurrencyToNormalizedCurrencyNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+				Dictionary<string, string> normalizedCurrencyToExchangeCurrencyNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+				Dictionary<string, string> exchangeSymbolToNormalizedSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+				Dictionary<string, string> normalizedSymbolToExchangeSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+				Dictionary<string, string> exchangeCurrenciesToMarketSymbolNew = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (KeyValuePair<string, ExchangeCurrency> kv in currencies)
-                {
-                    string altName = kv.Value.AltName;
-                    switch (altName.ToLowerInvariant())
-                    {
-                        // wtf kraken...
-                        case "xbt": altName = "BTC"; break;
-                        case "xdg": altName = "DOGE"; break;
-                    }
-                    exchangeCurrencyToNormalizedCurrencyNew[kv.Value.Name] = altName;
-                    normalizedCurrencyToExchangeCurrencyNew[altName] = kv.Value.Name;
-                }
+				foreach (KeyValuePair<string, ExchangeCurrency> kv in currencies)
+				{
+					string altName = kv.Value.AltName;
+					switch (altName.ToLowerInvariant())
+					{
+						// wtf kraken...
+						case "xbt":
+							altName = "BTC";
+							break;
+						case "xdg":
+							altName = "DOGE";
+							break;
+					}
+					exchangeCurrencyToNormalizedCurrencyNew[kv.Value.Name] = altName;
+					normalizedCurrencyToExchangeCurrencyNew[altName] = kv.Value.Name;
+				}
 
-                foreach (ExchangeMarket market in markets.Where(m => !m.MarketSymbol.Contains(".d")))
-                {
-                    string baseSymbol = market.BaseCurrency;
-                    string quoteSymbol = market.QuoteCurrency;
-                    string baseNorm = exchangeCurrencyToNormalizedCurrencyNew[market.BaseCurrency];
-                    string quoteNorm = exchangeCurrencyToNormalizedCurrencyNew[market.QuoteCurrency];
-                    string marketSymbolNorm = baseNorm + quoteNorm;
-                    string marketSymbol = market.MarketSymbol;
-                    exchangeSymbolToNormalizedSymbolNew[marketSymbol] = marketSymbolNorm;
-                    normalizedSymbolToExchangeSymbolNew[marketSymbolNorm] = marketSymbol;
-                    exchangeCurrenciesToMarketSymbolNew[baseSymbol + quoteSymbol] = marketSymbol;
-                    exchangeCurrenciesToMarketSymbolNew[quoteSymbol + baseSymbol] = marketSymbol;
-                }
+				foreach (ExchangeMarket market in markets.Where(m => !m.MarketSymbol.Contains(".d")))
+				{
+					string baseSymbol = market.BaseCurrency;
+					string quoteSymbol = market.QuoteCurrency;
+					string baseNorm = exchangeCurrencyToNormalizedCurrencyNew[market.BaseCurrency];
+					string quoteNorm = exchangeCurrencyToNormalizedCurrencyNew[market.QuoteCurrency];
+					string marketSymbolNorm = baseNorm + quoteNorm;
+					string marketSymbol = market.MarketSymbol;
+					exchangeSymbolToNormalizedSymbolNew[marketSymbol] = marketSymbolNorm;
+					normalizedSymbolToExchangeSymbolNew[marketSymbolNorm] = marketSymbol;
+					exchangeCurrenciesToMarketSymbolNew[baseSymbol + quoteSymbol] = marketSymbol;
+					exchangeCurrenciesToMarketSymbolNew[quoteSymbol + baseSymbol] = marketSymbol;
+				}
 
 				exchangeCurrencyToNormalizedCurrency = ExchangeGlobalCurrencyReplacements = exchangeCurrencyToNormalizedCurrencyNew;
-                normalizedCurrencyToExchangeCurrency = normalizedCurrencyToExchangeCurrencyNew;
-                exchangeSymbolToNormalizedSymbol = exchangeSymbolToNormalizedSymbolNew;
-                normalizedSymbolToExchangeSymbol = normalizedSymbolToExchangeSymbolNew;
-                exchangeCurrenciesToMarketSymbol = exchangeCurrenciesToMarketSymbolNew;
+				normalizedCurrencyToExchangeCurrency = normalizedCurrencyToExchangeCurrencyNew;
+				exchangeSymbolToNormalizedSymbol = exchangeSymbolToNormalizedSymbolNew;
+				normalizedSymbolToExchangeSymbol = normalizedSymbolToExchangeSymbolNew;
+				exchangeCurrenciesToMarketSymbol = exchangeCurrenciesToMarketSymbolNew;
 				return new CachedItem<object>(new object(), CryptoUtility.UtcNow.AddHours(4.0));
-            });
-        }
+			});
+		}
 
-		public override async Task<(string baseCurrency, string quoteCurrency)> ExchangeMarketSymbolToCurrenciesAsync(string marketSymbol)
-        {
-            ExchangeMarket market = await GetExchangeMarketFromCacheAsync(marketSymbol);
-            if (market == null)
-            {
+		public override async Task < (string baseCurrency, string quoteCurrency) > ExchangeMarketSymbolToCurrenciesAsync(string marketSymbol)
+		{
+			ExchangeMarket market = await GetExchangeMarketFromCacheAsync(marketSymbol);
+			if (market == null)
+			{
 				market = await GetExchangeMarketFromCacheAsync(marketSymbol.Replace("/", string.Empty));
 				if (market == null)
 				{
 					throw new ArgumentException("Unable to get currencies for market symbol " + marketSymbol);
 				}
-            }
-            return (market.BaseCurrency, market.QuoteCurrency);
-        }
+			}
+			return (market.BaseCurrency, market.QuoteCurrency);
+		}
 
-        public override async Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
-        {
-            await PopulateLookupTables();
-            var (baseCurrency, quoteCurrency) = await ExchangeMarketSymbolToCurrenciesAsync(marketSymbol);
-            if (!exchangeCurrencyToNormalizedCurrency.TryGetValue(baseCurrency, out string baseCurrencyNormalized))
-            {
-                baseCurrencyNormalized = baseCurrency;
-            }
-            if (!exchangeCurrencyToNormalizedCurrency.TryGetValue(quoteCurrency, out string quoteCurrencyNormalized))
-            {
-                quoteCurrencyNormalized = quoteCurrency;
-            }
-            return baseCurrencyNormalized + GlobalMarketSymbolSeparatorString + quoteCurrencyNormalized;
-        }
+		public override async Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
+		{
+			await PopulateLookupTables();
+			var(baseCurrency, quoteCurrency) = await ExchangeMarketSymbolToCurrenciesAsync(marketSymbol);
+			if (!exchangeCurrencyToNormalizedCurrency.TryGetValue(baseCurrency, out string baseCurrencyNormalized))
+			{
+				baseCurrencyNormalized = baseCurrency;
+			}
+			if (!exchangeCurrencyToNormalizedCurrency.TryGetValue(quoteCurrency, out string quoteCurrencyNormalized))
+			{
+				quoteCurrencyNormalized = quoteCurrency;
+			}
+			return baseCurrencyNormalized + GlobalMarketSymbolSeparatorString + quoteCurrencyNormalized;
+		}
 
-        public override async Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
-        {
-            await PopulateLookupTables();
-            string[] pieces = marketSymbol.Split('-');
-            if (pieces.Length < 2)
-            {
-                throw new ArgumentException("Market symbol must be at least two pieces");
-            }
-            if (!normalizedCurrencyToExchangeCurrency.TryGetValue(pieces[0], out string baseCurrencyExchange))
-            {
-                baseCurrencyExchange = pieces[0];
-            }
-            if (!normalizedCurrencyToExchangeCurrency.TryGetValue(pieces[1], out string quoteCurrencyExchange))
-            {
-                quoteCurrencyExchange = pieces[1];
-            }
-            if (!exchangeCurrenciesToMarketSymbol.TryGetValue(baseCurrencyExchange + quoteCurrencyExchange, out string exchangeMarketSymbol))
-            {
-                throw new ArgumentException("Unable to find exchange market for global market symbol " + marketSymbol);
-            }
-            return exchangeMarketSymbol;
-        }
+		public override async Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
+		{
+			await PopulateLookupTables();
+			string[] pieces = marketSymbol.Split('-');
+			if (pieces.Length < 2)
+			{
+				throw new ArgumentException("Market symbol must be at least two pieces");
+			}
+			if (!normalizedCurrencyToExchangeCurrency.TryGetValue(pieces[0], out string baseCurrencyExchange))
+			{
+				baseCurrencyExchange = pieces[0];
+			}
+			if (!normalizedCurrencyToExchangeCurrency.TryGetValue(pieces[1], out string quoteCurrencyExchange))
+			{
+				quoteCurrencyExchange = pieces[1];
+			}
+			if (!exchangeCurrenciesToMarketSymbol.TryGetValue(baseCurrencyExchange + quoteCurrencyExchange, out string exchangeMarketSymbol))
+			{
+				throw new ArgumentException("Unable to find exchange market for global market symbol " + marketSymbol);
+			}
+			return exchangeMarketSymbol;
+		}
 
-        protected override JToken CheckJsonResponse(JToken json)
-        {
-            if (!(json is JArray) && json["error"] is JArray error && error.Count != 0)
-            {
-                throw new APIException(error[0].ToStringInvariant());
-            }
-            return json["result"] ?? json;
-        }
+		protected override JToken CheckJsonResponse(JToken json)
+		{
+			if (!(json is JArray) && json["error"] is JArray error && error.Count != 0)
+			{
+				throw new APIException(error[0].ToStringInvariant());
+			}
+			return json["result"] ?? json;
+		}
 
-        private ExchangeOrderResult ParseOrder(string orderId, JToken order)
-        {
-            ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
+		private ExchangeOrderResult ParseOrder(string orderId, JToken order)
+		{
+			ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
 
-            switch (order["status"].ToStringInvariant())
-            {
-                case "pending": orderResult.Result = ExchangeAPIOrderResult.Pending; break;
-                case "open": orderResult.Result = ExchangeAPIOrderResult.FilledPartially; break;
-                case "closed": orderResult.Result = ExchangeAPIOrderResult.Filled; break;
-                case "canceled": case "expired": orderResult.Result = ExchangeAPIOrderResult.Canceled; break;
-                default: orderResult.Result = ExchangeAPIOrderResult.Error; break;
-            }
-            orderResult.Message = (orderResult.Message ?? order["reason"].ToStringInvariant());
-            orderResult.OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["opentm"].ConvertInvariant<double>());
-            orderResult.MarketSymbol = order["descr"]["pair"].ToStringInvariant();
-            orderResult.IsBuy = (order["descr"]["type"].ToStringInvariant() == "buy");
-            orderResult.Amount = order["vol"].ConvertInvariant<decimal>();
-            orderResult.AmountFilled = order["vol_exec"].ConvertInvariant<decimal>();
-            orderResult.Price = order["descr"]["price"].ConvertInvariant<decimal>();
-            orderResult.AveragePrice = order["price"].ConvertInvariant<decimal>();
+			switch (order["status"].ToStringInvariant())
+			{
+				case "pending":
+					orderResult.Result = ExchangeAPIOrderResult.Pending;
+					break;
+				case "open":
+					orderResult.Result = ExchangeAPIOrderResult.FilledPartially;
+					break;
+				case "closed":
+					orderResult.Result = ExchangeAPIOrderResult.Filled;
+					break;
+				case "canceled":
+				case "expired":
+					orderResult.Result = ExchangeAPIOrderResult.Canceled;
+					break;
+				default:
+					orderResult.Result = ExchangeAPIOrderResult.Error;
+					break;
+			}
+			orderResult.Message = (orderResult.Message ?? order["reason"].ToStringInvariant());
+			orderResult.OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["opentm"].ConvertInvariant<double>());
+			orderResult.MarketSymbol = order["descr"]["pair"].ToStringInvariant();
+			orderResult.IsBuy = (order["descr"]["type"].ToStringInvariant() == "buy");
+			orderResult.Amount = order["vol"].ConvertInvariant<decimal>();
+			orderResult.AmountFilled = order["vol_exec"].ConvertInvariant<decimal>();
+			orderResult.Price = order["descr"]["price"].ConvertInvariant<decimal>();
+			orderResult.AveragePrice = order["price"].ConvertInvariant<decimal>();
 
-            return orderResult;
-        }
+			return orderResult;
+		}
 
-        private async Task<ExchangeOrderResult> ParseHistoryOrder(string orderId, JToken order)
-        {
-//            //{{
-//            "ordertxid": "ONKWWN-3LWZ7-4SDZVJ",
-//  "postxid": "TKH2SE-M7IF5-CFI7LT",
-//  "pair": "XXRPZUSD",
-//  "time": 1537779676.7525,
-//  "type": "buy",
-//  "ordertype": "limit",
-//  "price": "0.54160000",
-//  "cost": "16.22210000",
-//  "fee": "0.02595536",
-//  "vol": "29.95217873",
-//  "margin": "0.00000000",
-//  "misc": ""
-//}
-//    }
+		private async Task<ExchangeOrderResult> ParseHistoryOrder(string orderId, JToken order)
+		{
+			//            //{{
+			//            "ordertxid": "ONKWWN-3LWZ7-4SDZVJ",
+			//  "postxid": "TKH2SE-M7IF5-CFI7LT",
+			//  "pair": "XXRPZUSD",
+			//  "time": 1537779676.7525,
+			//  "type": "buy",
+			//  "ordertype": "limit",
+			//  "price": "0.54160000",
+			//  "cost": "16.22210000",
+			//  "fee": "0.02595536",
+			//  "vol": "29.95217873",
+			//  "margin": "0.00000000",
+			//  "misc": ""
+			//}
+			//    }
 
-            ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
-            orderResult.Result = ExchangeAPIOrderResult.Filled;
-            orderResult.Message = "";
-            orderResult.OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["time"].ConvertInvariant<double>());
-            orderResult.MarketSymbol = order["pair"].ToStringInvariant();
-            orderResult.IsBuy = (order["type"].ToStringInvariant() == "buy");
-            orderResult.Amount = order["vol"].ConvertInvariant<decimal>();
-            orderResult.Fees = order["fee"].ConvertInvariant<decimal>();
-            orderResult.Price = order["price"].ConvertInvariant<decimal>();
-            orderResult.AveragePrice = order["price"].ConvertInvariant<decimal>();
-            orderResult.TradeId = order["postxid"].ToStringInvariant(); //verify which is orderid & tradeid
-            orderResult.OrderId = order["ordertxid"].ToStringInvariant();  //verify which is orderid & tradeid
-            orderResult.AmountFilled = order["vol"].ConvertInvariant<decimal>();
-            orderResult.FillDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["time"].ConvertInvariant<double>());
+			ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
+			orderResult.Result = ExchangeAPIOrderResult.Filled;
+			orderResult.Message = "";
+			orderResult.OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["time"].ConvertInvariant<double>());
+			orderResult.MarketSymbol = order["pair"].ToStringInvariant();
+			orderResult.IsBuy = (order["type"].ToStringInvariant() == "buy");
+			orderResult.Amount = order["vol"].ConvertInvariant<decimal>();
+			orderResult.Fees = order["fee"].ConvertInvariant<decimal>();
+			orderResult.Price = order["price"].ConvertInvariant<decimal>();
+			orderResult.AveragePrice = order["price"].ConvertInvariant<decimal>();
+			orderResult.TradeId = order["postxid"].ToStringInvariant(); //verify which is orderid & tradeid
+			orderResult.OrderId = order["ordertxid"].ToStringInvariant(); //verify which is orderid & tradeid
+			orderResult.AmountFilled = order["vol"].ConvertInvariant<decimal>();
+			orderResult.FillDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["time"].ConvertInvariant<double>());
 
-            string[] pairs = (await ExchangeMarketSymbolToGlobalMarketSymbolAsync(order["pair"].ToStringInvariant())).Split('-');
-            orderResult.FeesCurrency = pairs[1];
+			string[] pairs = (await ExchangeMarketSymbolToGlobalMarketSymbolAsync(order["pair"].ToStringInvariant())).Split('-');
+			orderResult.FeesCurrency = pairs[1];
 
-            return orderResult;
-        }
+			return orderResult;
+		}
 
-        private async Task<IEnumerable<ExchangeOrderResult>> QueryOrdersAsync(string symbol, string path)
-        {
-            await PopulateLookupTables();
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
-            result = result["open"];
-            if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
-            {
-                foreach (JProperty order in result)
-                {
-                    if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
-                    {
-                        orders.Add(ParseOrder(order.Name, order.Value));
-                    }
-                }
-            }
+		private async Task<IEnumerable<ExchangeOrderResult>> QueryOrdersAsync(string symbol, string path)
+		{
+			await PopulateLookupTables();
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
+			result = result["open"];
+			if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
+			{
+				foreach (JProperty order in result)
+				{
+					if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
+					{
+						orders.Add(ParseOrder(order.Name, order.Value));
+					}
+				}
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        private async Task<IEnumerable<ExchangeOrderResult>> QueryClosedOrdersAsync(string symbol, string path)
-        {
-            await PopulateLookupTables();
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
-            result = result["closed"];
-            if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
-            {
-                foreach (JProperty order in result)
-                {
-                    if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
-                    {
-                        orders.Add(ParseOrder(order.Name, order.Value));
-                    }
-                }
-            }
-            else
-            {
-                foreach (JProperty order in result)
-                {
-                    orders.Add(ParseOrder(order.Name, order.Value));
-                }
-            }
+		private async Task<IEnumerable<ExchangeOrderResult>> QueryClosedOrdersAsync(string symbol, string path)
+		{
+			await PopulateLookupTables();
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
+			result = result["closed"];
+			if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
+			{
+				foreach (JProperty order in result)
+				{
+					if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
+					{
+						orders.Add(ParseOrder(order.Name, order.Value));
+					}
+				}
+			}
+			else
+			{
+				foreach (JProperty order in result)
+				{
+					orders.Add(ParseOrder(order.Name, order.Value));
+				}
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        private async Task<IEnumerable<ExchangeOrderResult>> QueryHistoryOrdersAsync(string symbol, string path)
-        {
-            await PopulateLookupTables();
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
-            result = result["trades"];
-            if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
-            {
-                foreach (JProperty order in result)
-                {
-                    if (normalizedSymbol == null || order.Value["pair"].ToStringInvariant() == symbol.ToUpperInvariant())
-                    {
-                        orders.Add(await ParseHistoryOrder(order.Name, order.Value));
-                    }
-                }
-            }
-            else
-            {
-                foreach (JProperty order in result)
-                {
-                    orders.Add(await ParseHistoryOrder(order.Name, order.Value));
-                }
-            }
+		private async Task<IEnumerable<ExchangeOrderResult>> QueryHistoryOrdersAsync(string symbol, string path)
+		{
+			await PopulateLookupTables();
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
+			result = result["trades"];
+			if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
+			{
+				foreach (JProperty order in result)
+				{
+					if (normalizedSymbol == null || order.Value["pair"].ToStringInvariant() == symbol.ToUpperInvariant())
+					{
+						orders.Add(await ParseHistoryOrder(order.Name, order.Value));
+					}
+				}
+			}
+			else
+			{
+				foreach (JProperty order in result)
+				{
+					orders.Add(await ParseHistoryOrder(order.Name, order.Value));
+				}
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        //private async Task<IEnumerable<ExchangeOrderResult>> QueryClosedOrdersAsync(string symbol, string path)
-        //{
-        //    List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-        //    JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
-        //    //result = result["closed"];
-        //    foreach (JProperty order in result)
-        //    {
-        //        orders.Add(ParseOrder(order.Name, order.Value));
-        //    }
+		//private async Task<IEnumerable<ExchangeOrderResult>> QueryClosedOrdersAsync(string symbol, string path)
+		//{
+		//    List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+		//    JToken result = await MakeJsonRequestAsync<JToken>(path, null, await GetNoncePayloadAsync());
+		//    //result = result["closed"];
+		//    foreach (JProperty order in result)
+		//    {
+		//        orders.Add(ParseOrder(order.Name, order.Value));
+		//    }
 
+		//    //if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
+		//    //{
+		//    //    foreach (JProperty order in result)
+		//    //    {
+		//    //        if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
+		//    //        {
+		//    //            orders.Add(ParseOrder(order.Name, order.Value));
+		//    //        }
+		//    //    }
+		//    //}
 
-        //    //if (exchangeSymbolToNormalizedSymbol.TryGetValue(symbol, out string normalizedSymbol))
-        //    //{
-        //    //    foreach (JProperty order in result)
-        //    //    {
-        //    //        if (normalizedSymbol == null || order.Value["descr"]["pair"].ToStringInvariant() == normalizedSymbol.ToUpperInvariant())
-        //    //        {
-        //    //            orders.Add(ParseOrder(order.Name, order.Value));
-        //    //        }
-        //    //    }
-        //    //}
+		//    return orders;
+		//}
 
-        //    return orders;
-        //}
+		protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
+		{
+			if (payload == null || PrivateApiKey == null || PublicApiKey == null || !payload.ContainsKey("nonce"))
+			{
+				await CryptoUtility.WritePayloadFormToRequestAsync(request, payload);
+			}
+			else
+			{
+				string nonce = payload["nonce"].ToStringInvariant();
+				payload.Remove("nonce");
+				string form = CryptoUtility.GetFormForPayload(payload);
+				// nonce must be first on Kraken
+				form = "nonce=" + nonce + (string.IsNullOrWhiteSpace(form) ? string.Empty : "&" + form);
+				using(SHA256 sha256 = SHA256Managed.Create())
+				{
+					string hashString = nonce + form;
+					byte[] sha256Bytes = sha256.ComputeHash(hashString.ToBytesUTF8());
+					byte[] pathBytes = request.RequestUri.AbsolutePath.ToBytesUTF8();
+					byte[] sigBytes = new byte[sha256Bytes.Length + pathBytes.Length];
+					pathBytes.CopyTo(sigBytes, 0);
+					sha256Bytes.CopyTo(sigBytes, pathBytes.Length);
+					byte[] privateKey = System.Convert.FromBase64String(CryptoUtility.ToUnsecureString(PrivateApiKey));
+					using(System.Security.Cryptography.HMACSHA512 hmac = new System.Security.Cryptography.HMACSHA512(privateKey))
+					{
+						string sign = System.Convert.ToBase64String(hmac.ComputeHash(sigBytes));
+						request.AddHeader("API-Sign", sign);
+					}
+				}
+				request.AddHeader("API-Key", CryptoUtility.ToUnsecureString(PublicApiKey));
+				await CryptoUtility.WriteToRequestAsync(request, form);
+			}
+		}
 
+		protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
+		{
+			// https://api.kraken.com/0/public/Assets
+			Dictionary<string, ExchangeCurrency> allCoins = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
 
-        protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
-        {
-            if (payload == null || PrivateApiKey == null || PublicApiKey == null || !payload.ContainsKey("nonce"))
-            {
-                await CryptoUtility.WritePayloadFormToRequestAsync(request, payload);
-            }
-            else
-            {
-                string nonce = payload["nonce"].ToStringInvariant();
-                payload.Remove("nonce");
-                string form = CryptoUtility.GetFormForPayload(payload);
-                // nonce must be first on Kraken
-                form = "nonce=" + nonce + (string.IsNullOrWhiteSpace(form) ? string.Empty : "&" + form);
-                using (SHA256 sha256 = SHA256Managed.Create())
-                {
-                    string hashString = nonce + form;
-                    byte[] sha256Bytes = sha256.ComputeHash(hashString.ToBytesUTF8());
-                    byte[] pathBytes = request.RequestUri.AbsolutePath.ToBytesUTF8();
-                    byte[] sigBytes = new byte[sha256Bytes.Length + pathBytes.Length];
-                    pathBytes.CopyTo(sigBytes, 0);
-                    sha256Bytes.CopyTo(sigBytes, pathBytes.Length);
-                    byte[] privateKey = System.Convert.FromBase64String(CryptoUtility.ToUnsecureString(PrivateApiKey));
-                    using (System.Security.Cryptography.HMACSHA512 hmac = new System.Security.Cryptography.HMACSHA512(privateKey))
-                    {
-                        string sign = System.Convert.ToBase64String(hmac.ComputeHash(sigBytes));
-                        request.AddHeader("API-Sign", sign);
-                    }
-                }
-                request.AddHeader("API-Key", CryptoUtility.ToUnsecureString(PublicApiKey));
-                await CryptoUtility.WriteToRequestAsync(request, form);
-            }
-        }
+			var currencies = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
+			JToken array = await MakeJsonRequestAsync<JToken>("/0/public/Assets");
+			foreach (JProperty token in array)
+			{
+				var coin = new ExchangeCurrency
+				{
+					CoinType = token.Value["aclass"].ToStringInvariant(),
+						Name = token.Name,
+						FullName = token.Name,
+						AltName = token.Value["altname"].ToStringInvariant()
+				};
 
-        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
-        {
-            // https://api.kraken.com/0/public/Assets
-            Dictionary<string, ExchangeCurrency> allCoins = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
+				currencies[coin.Name] = coin;
+			}
 
-            var currencies = new Dictionary<string, ExchangeCurrency>(StringComparer.OrdinalIgnoreCase);
-            JToken array = await MakeJsonRequestAsync<JToken>("/0/public/Assets");
-            foreach (JProperty token in array)
-            {
-                var coin = new ExchangeCurrency
-                {
-                    CoinType = token.Value["aclass"].ToStringInvariant(),
-                    Name = token.Name,
-                    FullName = token.Name,
-                    AltName = token.Value["altname"].ToStringInvariant()
-                };
+			return currencies;
+		}
 
-                currencies[coin.Name] = coin;
-            }
+		protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
+		{
+			JToken result = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
+			return result.Children<JProperty>().Where(p => !p.Name.Contains(".d")).Select(p => p.Name).ToArray();
+		}
 
-            return currencies;
-        }
-
-        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
-        {
-            JToken result = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
-            return result.Children<JProperty>().Where(p => !p.Name.Contains(".d")).Select(p => p.Name).ToArray();
-        }
-
-        protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
-        {   //{"ADACAD": {
+		protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
+		{ //{"ADACAD": {
 			//  "altname": "ADACAD",
 			//  "wsname": "ADA/CAD",
 			//  "aclass_base": "currency",
@@ -480,93 +492,93 @@ namespace ExchangeSharp
 			//  "margin_stop": 40
 			//}}
 			var markets = new List<ExchangeMarket>();
-            JToken allPairs = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
-            var res = (from prop in allPairs.Children<JProperty>() select prop).ToArray();
+			JToken allPairs = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
+			var res = (from prop in allPairs.Children<JProperty>()select prop).ToArray();
 
-            foreach (JProperty prop in res.Where(p => !p.Name.EndsWith(".d")))
-            {
-                JToken pair = prop.Value;
-                JToken child = prop.Children().FirstOrDefault();
-                var quantityStepSize = Math.Pow(0.1, pair["lot_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>();
-                var market = new ExchangeMarket
-                {
-                    IsActive = true,
-                    MarketSymbol = prop.Name,
-					AltMarketSymbol = child["altname"].ToStringInvariant(),
-					AltMarketSymbol2 = child["wsname"].ToStringInvariant(),
-                    MinTradeSize = quantityStepSize,
-                    MarginEnabled = pair["leverage_buy"].Children().Any() || pair["leverage_sell"].Children().Any(),
-                    BaseCurrency = pair["base"].ToStringInvariant(),
-                    QuoteCurrency = pair["quote"].ToStringInvariant(),
-                    QuantityStepSize = quantityStepSize,
-                    PriceStepSize = Math.Pow(0.1, pair["pair_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>()
-                };
-                markets.Add(market);
-            }
+			foreach (JProperty prop in res.Where(p => !p.Name.EndsWith(".d")))
+			{
+				JToken pair = prop.Value;
+				JToken child = prop.Children().FirstOrDefault();
+				var quantityStepSize = Math.Pow(0.1, pair["lot_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>();
+				var market = new ExchangeMarket
+				{
+					IsActive = true,
+						MarketSymbol = prop.Name,
+						AltMarketSymbol = child["altname"].ToStringInvariant(),
+						AltMarketSymbol2 = child["wsname"].ToStringInvariant(),
+						MinTradeSize = quantityStepSize,
+						MarginEnabled = pair["leverage_buy"].Children().Any() || pair["leverage_sell"].Children().Any(),
+						BaseCurrency = pair["base"].ToStringInvariant(),
+						QuoteCurrency = pair["quote"].ToStringInvariant(),
+						QuantityStepSize = quantityStepSize,
+						PriceStepSize = Math.Pow(0.1, pair["pair_decimals"].ConvertInvariant<int>()).ConvertInvariant<decimal>()
+				};
+				markets.Add(market);
+			}
 
-            return markets;
-        }
+			return markets;
+		}
 
-        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
-        {
-            var marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
-            var normalizedPairsList = marketSymbols.Select(symbol => NormalizeMarketSymbol(symbol)).ToList();
-            var csvPairsList = string.Join(",", normalizedPairsList);
-            JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", csvPairsList } });
-            var tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            foreach (string marketSymbol in normalizedPairsList)
-            {
-                JToken ticker = apiTickers[marketSymbol];
+		protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+		{
+			var marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
+			var normalizedPairsList = marketSymbols.Select(symbol => NormalizeMarketSymbol(symbol)).ToList();
+			var csvPairsList = string.Join(",", normalizedPairsList);
+			JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", csvPairsList } });
+			var tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+			foreach (string marketSymbol in normalizedPairsList)
+			{
+				JToken ticker = apiTickers[marketSymbol];
 
-                #region Fix for pairs that are not found like USDTZUSD
-                if (ticker == null)
-                {
-                    // Some pairs like USDTZUSD are not found, but they can be found using Metadata.
-                    var symbols = (await GetMarketSymbolsMetadataAsync()).ToList();
-                    var symbol = symbols.FirstOrDefault(a => a.MarketSymbol.Replace("/", "").Equals(marketSymbol));
-                    ticker = apiTickers[symbol.BaseCurrency + symbol.QuoteCurrency];
-                }
-                #endregion
+				#region Fix for pairs that are not found like USDTZUSD
+				if (ticker == null)
+				{
+					// Some pairs like USDTZUSD are not found, but they can be found using Metadata.
+					var symbols = (await GetMarketSymbolsMetadataAsync()).ToList();
+					var symbol = symbols.FirstOrDefault(a => a.MarketSymbol.Replace("/", "").Equals(marketSymbol));
+					ticker = apiTickers[symbol.BaseCurrency + symbol.QuoteCurrency];
+				}
+				#endregion
 
-                try
-                {
-                    tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, await ConvertToExchangeTickerAsync(marketSymbol, ticker)));
-                }
-                catch
-                {
-                    // if Kraken throws bogus json at us, just eat it
-                }
-            }
-            return tickers;
-        }
+				try
+				{
+					tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, await ConvertToExchangeTickerAsync(marketSymbol, ticker)));
+				}
+				catch
+				{
+					// if Kraken throws bogus json at us, just eat it
+				}
+			}
+			return tickers;
+		}
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
-        {
-            JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeMarketSymbol(marketSymbol) } });
-            JToken ticker = apiTickers[marketSymbol];
-            return await ConvertToExchangeTickerAsync(marketSymbol, ticker);
-        }
+		protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
+		{
+			JToken apiTickers = await MakeJsonRequestAsync<JToken>("/0/public/Ticker", null, new Dictionary<string, object> { { "pair", NormalizeMarketSymbol(marketSymbol) } });
+			JToken ticker = apiTickers[marketSymbol];
+			return await ConvertToExchangeTickerAsync(marketSymbol, ticker);
+		}
 
-        private async Task<ExchangeTicker> ConvertToExchangeTickerAsync(string symbol, JToken ticker)
-        {
-            decimal last = ticker["c"][0].ConvertInvariant<decimal>();
-            var (baseCurrency, quoteCurrency) = await ExchangeMarketSymbolToCurrenciesAsync(symbol);
-            return new ExchangeTicker
-            {
-                MarketSymbol = symbol,
-                Ask = ticker["a"][0].ConvertInvariant<decimal>(),
-                Bid = ticker["b"][0].ConvertInvariant<decimal>(),
-                Last = last,
-                Volume = new ExchangeVolume
-                {
-                    QuoteCurrencyVolume = ticker["v"][1].ConvertInvariant<decimal>(),
-                    QuoteCurrency = quoteCurrency,
-                    BaseCurrencyVolume = ticker["v"][1].ConvertInvariant<decimal>() * ticker["p"][1].ConvertInvariant<decimal>(),
-                    BaseCurrency = baseCurrency,
-                    Timestamp = CryptoUtility.UtcNow
-                }
-            };
-        }
+		private async Task<ExchangeTicker> ConvertToExchangeTickerAsync(string symbol, JToken ticker)
+		{
+			decimal last = ticker["c"][0].ConvertInvariant<decimal>();
+			var(baseCurrency, quoteCurrency) = await ExchangeMarketSymbolToCurrenciesAsync(symbol);
+			return new ExchangeTicker
+			{
+				MarketSymbol = symbol,
+					Ask = ticker["a"][0].ConvertInvariant<decimal>(),
+					Bid = ticker["b"][0].ConvertInvariant<decimal>(),
+					Last = last,
+					Volume = new ExchangeVolume
+					{
+						QuoteCurrencyVolume = ticker["v"][1].ConvertInvariant<decimal>(),
+							QuoteCurrency = quoteCurrency,
+							BaseCurrencyVolume = ticker["v"][1].ConvertInvariant<decimal>() * ticker["p"][1].ConvertInvariant<decimal>(),
+							BaseCurrency = baseCurrency,
+							Timestamp = CryptoUtility.UtcNow
+					}
+			};
+		}
 
 		protected override Task OnInitializeAsync()
 		{
@@ -574,29 +586,31 @@ namespace ExchangeSharp
 		}
 
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
-        {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/0/public/Depth?pair=" + marketSymbol + "&count=" + maxCount);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj[marketSymbol], maxCount: maxCount);
-        }
+		{
+			JToken obj = await MakeJsonRequestAsync<JToken>("/0/public/Depth?pair=" + marketSymbol + "&count=" + maxCount);
+			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj[marketSymbol], maxCount : maxCount);
+		}
 
 		protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol, int? limit = null)
 		{
 			List<ExchangeTrade> trades = new List<ExchangeTrade>();
 
 			//https://www.kraken.com/features/api#public-market-data note kraken does not specify but it appears the limit is around 1860 (weird)
-            //https://api.kraken.com/0/public/Trades?pair=BCHUSD&count=1860
+			//https://api.kraken.com/0/public/Trades?pair=BCHUSD&count=1860
 			//needs testing of different marketsymbols to establish if limit varies
 			//gonna use 1500 for now
 
 			int requestLimit = (limit == null || limit < 1 || limit > 1500) ? 1500 : (int)limit;
-			string url = "/0/public/Trades?pair=" + marketSymbol +  "&count=" + requestLimit;
+			string url = "/0/public/Trades?pair=" + marketSymbol + "&count=" + requestLimit;
 			//string url = "/trades/t" + marketSymbol + "/hist?sort=" + "-1"  + "&limit=" + requestLimit;
 
 			JToken result = await MakeJsonRequestAsync<JToken>(url);
 
 			//if (result != null && (!(result[marketSymbol] is JArray outerArray) || outerArray.Count == 0)) {
-				if(result != null && result[marketSymbol] is JArray outerArray && outerArray.Count > 0)  {
-					foreach(JToken trade in outerArray.Children()) {
+			if (result != null && result[marketSymbol] is JArray outerArray && outerArray.Count > 0)
+			{
+				foreach (JToken trade in outerArray.Children())
+				{
 					trades.Add(trade.ParseTrade(1, 0, 3, 2, TimestampType.UnixSecondsDouble, null, "b"));
 				}
 			}
@@ -605,209 +619,199 @@ namespace ExchangeSharp
 		}
 
 		protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            string baseUrl = "/0/public/Trades?pair=" + marketSymbol;
-            string url;
-            List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            while (true)
-            {
-                url = baseUrl;
-                if (startDate != null)
-                {
-                    url += "&since=" + (long)(CryptoUtility.UnixTimestampFromDateTimeMilliseconds(startDate.Value) * 1000000.0);
-                }
-                JToken result = await MakeJsonRequestAsync<JToken>(url);
-                if (result == null)
-                {
-                    break;
-                }
-                if (!(result[marketSymbol] is JArray outerArray) || outerArray.Count == 0)
-                {
-                    break;
-                }
-                if (startDate != null)
-                {
-                    startDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(result["last"].ConvertInvariant<double>() / 1000000.0d);
-                }
-                foreach (JToken trade in outerArray.Children())
-                {
-                    trades.Add(trade.ParseTrade(1, 0, 3, 2, TimestampType.UnixSecondsDouble, null, "b"));
-                }
-                trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));
-                if (!callback(trades))
-                {
-                    break;
-                }
-                trades.Clear();
-                if (startDate == null)
-                {
-                    break;
-                }
-                Task.Delay(1000).Wait();
-            }
-        }
+		{
+			string baseUrl = "/0/public/Trades?pair=" + marketSymbol;
+			string url;
+			List<ExchangeTrade> trades = new List<ExchangeTrade>();
+			while (true)
+			{
+				url = baseUrl;
+				if (startDate != null)
+				{
+					url += "&since=" + (long)(CryptoUtility.UnixTimestampFromDateTimeMilliseconds(startDate.Value) * 1000000.0);
+				}
+				JToken result = await MakeJsonRequestAsync<JToken>(url);
+				if (result == null)
+				{
+					break;
+				}
+				if (!(result[marketSymbol] is JArray outerArray) || outerArray.Count == 0)
+				{
+					break;
+				}
+				if (startDate != null)
+				{
+					startDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(result["last"].ConvertInvariant<double>() / 1000000.0d);
+				}
+				foreach (JToken trade in outerArray.Children())
+				{
+					trades.Add(trade.ParseTrade(1, 0, 3, 2, TimestampType.UnixSecondsDouble, null, "b"));
+				}
+				trades.Sort((t1, t2) => t1.Timestamp.CompareTo(t2.Timestamp));
+				if (!callback(trades))
+				{
+					break;
+				}
+				trades.Clear();
+				if (startDate == null)
+				{
+					break;
+				}
+				Task.Delay(1000).Wait();
+			}
+		}
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            if (limit != null)
-            {
-                throw new APIException("Limit parameter not supported");
-            }
+		protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			if (limit != null)
+			{
+				throw new APIException("Limit parameter not supported");
+			}
 
-            // https://api.kraken.com/0/public/OHLC
-            // pair = asset pair to get OHLC data for, interval = time frame interval in minutes(optional):, 1(default), 5, 15, 30, 60, 240, 1440, 10080, 21600, since = return committed OHLC data since given id(optional.exclusive)
-            // array of array entries(<time>, <open>, <high>, <low>, <close>, <vwap>, <volume>, <count>)
-            startDate = startDate ?? CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(1.0));
-            endDate = endDate ?? CryptoUtility.UtcNow;
-            JToken json = await MakeJsonRequestAsync<JToken>("/0/public/OHLC?pair=" + marketSymbol + "&interval=" + (periodSeconds / 60).ToStringInvariant() + "&since=" + startDate);
-            List<MarketCandle> candles = new List<MarketCandle>();
-            if (json.Children().Count() != 0)
-            {
-                JProperty prop = json.Children().First() as JProperty;
-                foreach (JToken jsonCandle in prop.Value)
-                {
-                    MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5);
-                    if (candle.Timestamp >= startDate.Value && candle.Timestamp <= endDate.Value)
-                    {
-                        candles.Add(candle);
-                    }
-                }
-            }
+			// https://api.kraken.com/0/public/OHLC
+			// pair = asset pair to get OHLC data for, interval = time frame interval in minutes(optional):, 1(default), 5, 15, 30, 60, 240, 1440, 10080, 21600, since = return committed OHLC data since given id(optional.exclusive)
+			// array of array entries(<time>, <open>, <high>, <low>, <close>, <vwap>, <volume>, <count>)
+			startDate = startDate ?? CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(1.0));
+			endDate = endDate ?? CryptoUtility.UtcNow;
+			JToken json = await MakeJsonRequestAsync<JToken>("/0/public/OHLC?pair=" + marketSymbol + "&interval=" + (periodSeconds / 60).ToStringInvariant() + "&since=" + startDate);
+			List<MarketCandle> candles = new List<MarketCandle>();
+			if (json.Children().Count() != 0)
+			{
+				JProperty prop = json.Children().First()as JProperty;
+				foreach (JToken jsonCandle in prop.Value)
+				{
+					MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5);
+					if (candle.Timestamp >= startDate.Value && candle.Timestamp <= endDate.Value)
+					{
+						candles.Add(candle);
+					}
+				}
+			}
 
-            return candles;
-        }
+			return candles;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
-        {
-            JToken result = await MakeJsonRequestAsync<JToken>("/0/private/Balance", null, await GetNoncePayloadAsync());
-            Dictionary<string, decimal> balances = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
-            foreach (JProperty prop in result)
-            {
-                decimal amount = prop.Value.ConvertInvariant<decimal>();
-                if (amount > 0m)
-                {
-                    balances[prop.Name] = amount;
-                }
-            }
-            return balances;
-        }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+		{
+			JToken result = await MakeJsonRequestAsync<JToken>("/0/private/Balance", null, await GetNoncePayloadAsync());
+			Dictionary<string, decimal> balances = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+			foreach (JProperty prop in result)
+			{
+				decimal amount = prop.Value.ConvertInvariant<decimal>();
+				if (amount > 0m)
+				{
+					balances[prop.Name] = amount;
+				}
+			}
+			return balances;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
-        {
-            JToken result = await MakeJsonRequestAsync<JToken>("/0/private/TradeBalance", null, await GetNoncePayloadAsync());
-            Dictionary<string, decimal> balances = new Dictionary<string, decimal>();
-            foreach (JProperty prop in result)
-            {
-                decimal amount = prop.Value.ConvertInvariant<decimal>();
-                if (amount > 0m)
-                {
-                    balances[prop.Name] = amount;
-                }
-            }
-            return balances;
-        }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+		{
+			JToken result = await MakeJsonRequestAsync<JToken>("/0/private/TradeBalance", null, await GetNoncePayloadAsync());
+			Dictionary<string, decimal> balances = new Dictionary<string, decimal>();
+			foreach (JProperty prop in result)
+			{
+				decimal amount = prop.Value.ConvertInvariant<decimal>();
+				if (amount > 0m)
+				{
+					balances[prop.Name] = amount;
+				}
+			}
+			return balances;
+		}
 
-        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
-        {
-            object nonce = await GenerateNonceAsync();
-            Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "pair", order.MarketSymbol },
-                { "type", (order.IsBuy ? "buy" : "sell") },
-                { "ordertype", order.OrderType.ToString().ToLowerInvariant() },
-                { "volume", order.RoundAmount().ToStringInvariant() },
-                { "trading_agreement", "agree" },
-                { "nonce", nonce }
-            };
-            if (order.OrderType != OrderType.Market)
-            {
-                payload.Add("price", order.Price.ToStringInvariant());
-            }
-            order.ExtraParameters.CopyTo(payload);
+		protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+		{
+			object nonce = await GenerateNonceAsync();
+			Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+			{ { "pair", order.MarketSymbol }, { "type", (order.IsBuy ? "buy" : "sell") }, { "ordertype", order.OrderType.ToString().ToLowerInvariant() }, { "volume", order.RoundAmount().ToStringInvariant() }, { "trading_agreement", "agree" }, { "nonce", nonce }
+			};
+			if (order.OrderType != OrderType.Market)
+			{
+				payload.Add("price", order.Price.ToStringInvariant());
+			}
+			order.ExtraParameters.CopyTo(payload);
 
-            JToken token = await MakeJsonRequestAsync<JToken>("/0/private/AddOrder", null, payload);
-            ExchangeOrderResult result = new ExchangeOrderResult
-            {
-                OrderDate = CryptoUtility.UtcNow
-            };
-            if (token["txid"] is JArray array)
-            {
-                result.OrderId = array[0].ToStringInvariant();
-            }
-            return result;
-        }
+			JToken token = await MakeJsonRequestAsync<JToken>("/0/private/AddOrder", null, payload);
+			ExchangeOrderResult result = new ExchangeOrderResult
+			{
+				OrderDate = CryptoUtility.UtcNow
+			};
+			if (token["txid"] is JArray array)
+			{
+				result.OrderId = array[0].ToStringInvariant();
+			}
+			return result;
+		}
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
-        {
-            if (string.IsNullOrWhiteSpace(orderId))
-            {
-                return null;
-            }
+		protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
+		{
+			if (string.IsNullOrWhiteSpace(orderId))
+			{
+				return null;
+			}
 
-            object nonce = await GenerateNonceAsync();
-            Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "txid", orderId },
-                { "nonce", nonce }
-            };
-            JToken result = await MakeJsonRequestAsync<JToken>("/0/private/QueryOrders", null, payload);
-            ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
-            if (result == null || result[orderId] == null)
-            {
-                orderResult.Message = "Unknown Error";
-                return orderResult;
-            }
+			object nonce = await GenerateNonceAsync();
+			Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+			{ { "txid", orderId }, { "nonce", nonce }
+			};
+			JToken result = await MakeJsonRequestAsync<JToken>("/0/private/QueryOrders", null, payload);
+			ExchangeOrderResult orderResult = new ExchangeOrderResult { OrderId = orderId };
+			if (result == null || result[orderId] == null)
+			{
+				orderResult.Message = "Unknown Error";
+				return orderResult;
+			}
 
-            return ParseOrder(orderId, result[orderId]); ;
-        }
+			return ParseOrder(orderId, result[orderId]);;
+		}
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
-        {
-            return await QueryOrdersAsync(marketSymbol, "/0/private/OpenOrders");
-        }
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
+		{
+			return await QueryOrdersAsync(marketSymbol, "/0/private/OpenOrders");
+		}
 
-        //protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
-        //{
-        //    string path = "/0/private/ClosedOrders";
-        //    if (afterDate != null)
-        //    {
-        //        path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
-        //    }
-        //    return await QueryClosedOrdersAsync(marketSymbol, path);
-        //}
+		//protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
+		//{
+		//    string path = "/0/private/ClosedOrders";
+		//    if (afterDate != null)
+		//    {
+		//        path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
+		//    }
+		//    return await QueryClosedOrdersAsync(marketSymbol, path);
+		//}
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
-        {
-            string path = "/0/private/TradesHistory";
-            if (afterDate != null)
-            {
-                path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
-            }
-            return await QueryHistoryOrdersAsync(marketSymbol, path);
-        }
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
+		{
+			string path = "/0/private/TradesHistory";
+			if (afterDate != null)
+			{
+				path += "?start=" + ((long)afterDate.Value.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
+			}
+			return await QueryHistoryOrdersAsync(marketSymbol, path);
+		}
 
-        //protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
-        //{
-        //    var payload = await GetNoncePayloadAsync();
-        //    if (marketSymbol == null)
-        //        throw new APIException("BitBank requires marketSymbol when getting completed orders");
-        //    payload.Add("pair", NormalizeMarketSymbol(marketSymbol));
-        //    if (afterDate != null)
-        //        payload.Add("since", afterDate.ConvertInvariant<double>());
-        //    JToken token = await MakeJsonRequestAsync<JToken>($"/user/spot/trade_history", baseUrl: BaseUrlPrivate, payload: payload);
-        //    return token["trades"].Select(t => TradeHistoryToExchangeOrderResult(t));
-        //}
+		//protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
+		//{
+		//    var payload = await GetNoncePayloadAsync();
+		//    if (marketSymbol == null)
+		//        throw new APIException("BitBank requires marketSymbol when getting completed orders");
+		//    payload.Add("pair", NormalizeMarketSymbol(marketSymbol));
+		//    if (afterDate != null)
+		//        payload.Add("since", afterDate.ConvertInvariant<double>());
+		//    JToken token = await MakeJsonRequestAsync<JToken>($"/user/spot/trade_history", baseUrl: BaseUrlPrivate, payload: payload);
+		//    return token["trades"].Select(t => TradeHistoryToExchangeOrderResult(t));
+		//}
 
-        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
-        {
-            object nonce = await GenerateNonceAsync();
-            Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "txid", orderId },
-                { "nonce", nonce }
-            };
-            await MakeJsonRequestAsync<JToken>("/0/private/CancelOrder", null, payload);
-        }
+		protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
+		{
+			object nonce = await GenerateNonceAsync();
+			Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+			{ { "txid", orderId }, { "nonce", nonce }
+			};
+			await MakeJsonRequestAsync<JToken>("/0/private/CancelOrder", null, payload);
+		}
 
 		protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols)
 		{
@@ -815,22 +819,22 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
+			return await ConnectWebSocketAsync(null, messageCallback : async(_socket, msg) =>
 			{
-				if (JToken.Parse(msg.ToStringFromUTF8()) is JArray token)
+				if (JToken.Parse(msg.ToStringFromUTF8())is JArray token)
 				{
 					var exchangeTicker = await ConvertToExchangeTickerAsync(token[3].ToString(), token[1]);
 					var kv = new KeyValuePair<string, ExchangeTicker>(exchangeTicker.MarketSymbol, exchangeTicker);
 					tickers(new List<KeyValuePair<string, ExchangeTicker>> { kv });
 				}
-			}, connectCallback: async (_socket) =>
+			}, connectCallback : async(_socket) =>
 			{
 				List<string> marketSymbolList = await GetMarketSymbolList(marketSymbols);
 				await _socket.SendMessageAsync(new
 				{
 					@event = "subscribe",
-					pair = marketSymbolList,
-					subscription = new { name = "ticker" }
+						pair = marketSymbolList,
+						subscription = new { name = "ticker" }
 				});
 			});
 		}
@@ -841,11 +845,11 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
+			return await ConnectWebSocketAsync(null, messageCallback : async(_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token.Type == JTokenType.Array && token[2].ToStringInvariant() == "trade")
-				{   //[
+				{ //[
 					//  0,
 					//  [
 
@@ -874,15 +878,15 @@ namespace ExchangeSharp
 					foreach (var tradesToken in token[1])
 					{
 						var trade = tradesToken.ParseTradeKraken(amountKey: 1, priceKey: 0,
-								typeKey: 3, timestampKey: 2,
-								TimestampType.UnixSecondsDouble, idKey: null,
-								typeKeyIsBuyValue: "b");
+							typeKey: 3, timestampKey: 2,
+							TimestampType.UnixSecondsDouble, idKey : null,
+							typeKeyIsBuyValue: "b");
 						await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
 					}
 				}
-				else if (token["event"].ToStringInvariant() == "heartbeat") { }
+				else if (token["event"].ToStringInvariant() == "heartbeat") {}
 				else if (token["status"].ToStringInvariant() == "error")
-				{   //{{
+				{ //{{
 					//  "errorMessage": "Currency pair not in ISO 4217-A3 format ADACAD",
 					//  "event": "subscriptionStatus",
 					//  "pair": "ADACAD",
@@ -894,14 +898,14 @@ namespace ExchangeSharp
 					Logger.Info(token["errorMessage"].ToStringInvariant());
 				}
 				else if (token["status"].ToStringInvariant() == "online")
-				{   //{{
+				{ //{{
 					//  "connectionID": 9077277725533272053,
 					//  "event": "systemStatus",
 					//  "status": "online",
 					//  "version": "0.2.0"
 					//}}
 				}
-			}, connectCallback: async (_socket) =>
+			}, connectCallback : async(_socket) =>
 			{
 				//{
 				//  "event": "subscribe",
@@ -913,11 +917,11 @@ namespace ExchangeSharp
 				//  }
 				//}
 				List<string> marketSymbolList = await GetMarketSymbolList(marketSymbols);
-                await _socket.SendMessageAsync(new
+				await _socket.SendMessageAsync(new
 				{
 					@event = "subscribe",
-					pair = marketSymbolList,
-                    subscription = new { name = "trade" }
+						pair = marketSymbolList,
+						subscription = new { name = "trade" }
 				});
 			});
 		}
@@ -925,7 +929,7 @@ namespace ExchangeSharp
 		private async Task<List<string>> GetMarketSymbolList(string[] marketSymbols)
 		{
 			await PopulateLookupTables(); // prime cache
-			Task<string>[] marketSymbolsArray = marketSymbols.Select(async (m) =>
+			Task<string>[] marketSymbolsArray = marketSymbols.Select(async(m) =>
 			{
 				ExchangeMarket market = await GetExchangeMarketFromCacheAsync(m);
 				if (market == null)
@@ -947,5 +951,5 @@ namespace ExchangeSharp
 		}
 	}
 
-    public partial class ExchangeName { public const string Kraken = "Kraken"; }
+	public partial class ExchangeName { public const string Kraken = "Kraken"; }
 }

--- a/src/ExchangeSharp/API/Exchanges/Kraken/Models/Request/ChannelAction.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/Models/Request/ChannelAction.cs
@@ -1,0 +1,22 @@
+using ExchangeSharp.API.Exchanges.Kraken.Models.Types;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExchangeSharp.API.Exchanges.Kraken.Models.Request
+{
+	internal class ChannelAction
+	{
+		[JsonConverter(typeof(StringEnumConverter))]
+		[JsonProperty("event")]
+		public ActionType Event { get; set; }
+
+		[JsonProperty("pair")]
+		public List<string> Pairs { get; set; }
+
+		[JsonProperty("subscription")]
+		public Subscription SubscriptionSettings { get; set; }
+	}
+}

--- a/src/ExchangeSharp/API/Exchanges/Kraken/Models/Types/ActionType.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/Models/Types/ActionType.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace ExchangeSharp.API.Exchanges.Kraken.Models.Types
+{
+	internal enum ActionType
+	{
+		[EnumMember(Value = "subscribe")]
+		Subscribe,
+
+		[EnumMember(Value = "unsubscribe")]
+		Unsubscribe
+	}
+}

--- a/src/ExchangeSharp/API/Exchanges/Kraken/Models/Types/Subscription.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/Models/Types/Subscription.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExchangeSharp.API.Exchanges.Kraken.Models.Types
+{
+	internal class Subscription
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+		[JsonProperty("depth")]
+		public int Depth { get; set; }
+	}
+}

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -21,26 +21,26 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
-    /// <summary>
-    /// Base class for all exchange API
-    /// </summary>
-    public abstract partial class ExchangeAPI : BaseAPI, IExchangeAPI
-    {
-        /// <summary>
-        /// Separator for global symbols (char)
-        /// </summary>
-        public const char GlobalMarketSymbolSeparator = '-';
+	/// <summary>
+	/// Base class for all exchange API
+	/// </summary>
+	public abstract partial class ExchangeAPI : BaseAPI, IExchangeAPI
+	{
+		/// <summary>
+		/// Separator for global symbols (char)
+		/// </summary>
+		public const char GlobalMarketSymbolSeparator = '-';
 
-        /// <summary>
-        /// Separator for global symbols (string)
-        /// </summary>
-        public const string GlobalMarketSymbolSeparatorString = "-";
+		/// <summary>
+		/// Separator for global symbols (string)
+		/// </summary>
+		public const string GlobalMarketSymbolSeparatorString = "-";
 
-        /// <summary>
-        /// Whether to use the default method cache policy, default is true.
-        /// The default cache policy caches things like get symbols, tickers, order book, order details, etc. See ExchangeAPI constructor for full list.
-        /// </summary>
-        public static bool UseDefaultMethodCachePolicy { get; set; } = true;
+		/// <summary>
+		/// Whether to use the default method cache policy, default is true.
+		/// The default cache policy caches things like get symbols, tickers, order book, order details, etc. See ExchangeAPI constructor for full list.
+		/// </summary>
+		public static bool UseDefaultMethodCachePolicy { get; set; } = true;
 
 		#region Private methods
 
@@ -48,7 +48,7 @@ namespace ExchangeSharp
 		private static readonly ConcurrentDictionary<Type, ExchangeAPI> apis = new ConcurrentDictionary<Type, ExchangeAPI>();
 
 		private bool initialized;
-        private bool disposed;
+		private bool disposed;
 
 		#endregion Private methods
 
@@ -81,33 +81,33 @@ namespace ExchangeSharp
 		/// <returns>Task</returns>
 		protected virtual Task OnInitializeAsync() => Task.CompletedTask;
 
-        protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
-        {
-            List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
-            var marketSymbols = await GetMarketSymbolsAsync();
-            foreach (string marketSymbol in marketSymbols)
-            {
-                var ticker = await GetTickerAsync(marketSymbol);
-                tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ticker));
-            }
-            return tickers;
-        }
+		protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+		{
+			List<KeyValuePair<string, ExchangeTicker>> tickers = new List<KeyValuePair<string, ExchangeTicker>>();
+			var marketSymbols = await GetMarketSymbolsAsync();
+			foreach (string marketSymbol in marketSymbols)
+			{
+				var ticker = await GetTickerAsync(marketSymbol);
+				tickers.Add(new KeyValuePair<string, ExchangeTicker>(marketSymbol, ticker));
+			}
+			return tickers;
+		}
 
-        protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(
-	        int maxCount = 100
-        )
-        {
-	        var marketSymbols = await GetMarketSymbolsAsync();
-	        var orderBooks = await Task.WhenAll(
-		        marketSymbols.Select(async ms =>
-		        {
-			        var orderBook = await GetOrderBookAsync(ms, maxCount);
-			        orderBook.MarketSymbol ??= ms;
-			        return orderBook;
-		        })
-	        );
-	        return orderBooks.ToDictionary(k => k.MarketSymbol, v => v);
-        }
+		protected virtual async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(
+			int maxCount = 100
+		)
+		{
+			var marketSymbols = await GetMarketSymbolsAsync();
+			var orderBooks = await Task.WhenAll(
+				marketSymbols.Select(async ms =>
+				{
+					var orderBook = await GetOrderBookAsync(ms, maxCount);
+					orderBook.MarketSymbol ??= ms;
+					return orderBook;
+				})
+			);
+			return orderBooks.ToDictionary(k => k.MarketSymbol, v => v);
+		}
 
 		/// <summary>
 		/// When possible, the sort order will be Descending (ie newest trades first)
@@ -116,47 +116,76 @@ namespace ExchangeSharp
 		/// <param name="limit">max number of results returned, if limiting is supported by the exchange</param>
 		/// <returns></returns>
 		protected virtual async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol, int? limit = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            await GetHistoricalTradesAsync((e) =>
-            {
-                trades.AddRange(e);
-                return true;
-            }, marketSymbol, limit:limit); //KK2020
-            return trades;
-        }
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			List<ExchangeTrade> trades = new List<ExchangeTrade>();
+			await GetHistoricalTradesAsync((e) =>
+			{
+				trades.AddRange(e);
+				return true;
+			}, marketSymbol, limit : limit); //KK2020
+			return trades;
+		}
 
-        protected virtual Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync() => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<string>> OnGetMarketSymbolsAsync() => throw new NotImplementedException();
-        protected internal virtual Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync() => throw new NotImplementedException();
-        protected virtual Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol) => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100) => throw new NotImplementedException();
-        protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
+		protected virtual Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync() =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<string>> OnGetMarketSymbolsAsync() =>
+			throw new NotImplementedException();
+		protected internal virtual Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync() =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100) =>
+			throw new NotImplementedException();
+		protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) =>
+			throw new NotImplementedException();
 		//protected virtual Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null) => throw new NotImplementedException();
-        protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) => throw new NotImplementedException();
-        protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAsync() => throw new NotImplementedException();
-        protected virtual Task<Dictionary<string, decimal>> OnGetFeesAsync() => throw new NotImplementedException();
-        protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync() => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order) => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderResult[]> OnPlaceOrdersAsync(params ExchangeOrderRequest[] order) => throw new NotImplementedException();
-        protected virtual Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string? marketSymbol = null) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string? marketSymbol = null) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null) => throw new NotImplementedException();
-        protected virtual Task OnCancelOrderAsync(string orderId, string? marketSymbol = null) => throw new NotImplementedException();
-        protected virtual Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest) => throw new NotImplementedException();
-        protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetWithdrawHistoryAsync(string currency) => throw new NotImplementedException();
-        protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances) => throw new NotImplementedException();
-        protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string marketSymbol) => throw new NotImplementedException();
-        protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string marketSymbol) => throw new NotImplementedException();
-        protected virtual Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols) => throw new NotImplementedException();
-        protected virtual Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols) => throw new NotImplementedException();
-        protected virtual Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols) => throw new NotImplementedException();
-        protected virtual Task<IWebSocket> OnGetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
-        protected virtual Task<IWebSocket> OnGetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback) => throw new NotImplementedException();
-		protected virtual Task<IWebSocket> OnUserDataWebSocketAsync(Action<object> callback, string listenKey) => throw new NotImplementedException();
+		protected virtual Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string currency, bool forceRegenerate = false) =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetDepositHistoryAsync(string currency) =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null) =>
+			throw new NotImplementedException();
+		protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAsync() =>
+			throw new NotImplementedException();
+		protected virtual Task<Dictionary<string, decimal>> OnGetFeesAsync() =>
+			throw new NotImplementedException();
+		protected virtual Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync() =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeOrderResult[]> OnPlaceOrdersAsync(params ExchangeOrderRequest[] order) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string? marketSymbol = null) =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string? marketSymbol = null) =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null) =>
+			throw new NotImplementedException();
+		protected virtual Task OnCancelOrderAsync(string orderId, string? marketSymbol = null) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeWithdrawalResponse> OnWithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest) =>
+			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<ExchangeTransaction>> OnGetWithdrawHistoryAsync(string currency) =>
+			throw new NotImplementedException();
+		protected virtual Task<Dictionary<string, decimal>> OnGetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeMarginPositionResult> OnGetOpenPositionAsync(string marketSymbol) =>
+			throw new NotImplementedException();
+		protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string marketSymbol) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback) =>
+			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnUserDataWebSocketAsync(Action<object> callback, string listenKey) =>
+			throw new NotImplementedException();
 
 		#endregion API implementation
 
@@ -169,39 +198,39 @@ namespace ExchangeSharp
 		/// <param name="outputPrice">Price</param>
 		/// <returns>Clamped price</returns>
 		protected async Task<decimal> ClampOrderPrice(string marketSymbol, decimal outputPrice)
-        {
-            ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
-            return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice, market.MaxPrice, market.PriceStepSize, outputPrice);
-        }
+		{
+			ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
+			return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice, market.MaxPrice, market.PriceStepSize, outputPrice);
+		}
 
-        /// <summary>
-        /// Clamp quantiy using market info. If necessary, a network request will be made to retrieve symbol metadata.
-        /// </summary>
-        /// <param name="marketSymbol">Market Symbol</param>
-        /// <param name="outputQuantity">Quantity</param>
-        /// <returns>Clamped quantity</returns>
-        protected async Task<decimal> ClampOrderQuantity(string marketSymbol, decimal outputQuantity)
-        {
-            ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
-            return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, outputQuantity);
-        }
+		/// <summary>
+		/// Clamp quantiy using market info. If necessary, a network request will be made to retrieve symbol metadata.
+		/// </summary>
+		/// <param name="marketSymbol">Market Symbol</param>
+		/// <param name="outputQuantity">Quantity</param>
+		/// <returns>Clamped quantity</returns>
+		protected async Task<decimal> ClampOrderQuantity(string marketSymbol, decimal outputQuantity)
+		{
+			ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
+			return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, outputQuantity);
+		}
 
 		/// <summary>
 		/// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
 		/// Global symbols are always uppercase and separate the currency pair with a hyphen (-).
 		/// Global symbols list the base currency first (i.e. BTC) and quote/conversion currency
 		/// second (i.e. USD). Global symbols are of the form BASE-QUOTE. BASE-QUOTE is read as
-		/// 1 BASE is worth y QUOTE. 
+		/// 1 BASE is worth y QUOTE.
 		///
 		/// Examples:
 		///		On 1/25/2020,
 		///			- BTC-USD: $8,371; 1 BTC (base) is worth $8,371 USD (quote)
 		///			- ETH-BTC: 0.01934; 1 ETH is worth 0.01934 BTC
 		///			- EUR-USD: 1.2; 1 EUR worth 1.2 USD
-		/// 
+		///
 		/// A value greater than 1 means one unit of base currency is more valuable than one unit of
 		/// quote currency.
-		/// 
+		///
 		/// </summary>
 		/// <param name="marketSymbol">Exchange market symbol</param>
 		/// <param name="separator">Separator</param>
@@ -225,17 +254,17 @@ namespace ExchangeSharp
 		/// </summary>
 		/// <param name="marketSymbol">Market symbol</param>
 		/// <returns>Base and quote currency</returns>
-		protected virtual (string baseCurrency, string quoteCurrency) OnSplitMarketSymbolToCurrencies(string marketSymbol)
-        {
-            var pieces = marketSymbol.Split(MarketSymbolSeparator[0]);
-            if (pieces.Length < 2)
-            {
-                throw new InvalidOperationException($"Splitting {Name} symbol '{marketSymbol}' with symbol separator '{MarketSymbolSeparator}' must result in at least 2 pieces.");
-            }
-            string baseCurrency = MarketSymbolIsReversed ? pieces[1] : pieces[0];
-            string quoteCurrency = MarketSymbolIsReversed ? pieces[0] : pieces[1];
-            return (baseCurrency, quoteCurrency);
-        }
+		protected virtual(string baseCurrency, string quoteCurrency)OnSplitMarketSymbolToCurrencies(string marketSymbol)
+		{
+			var pieces = marketSymbol.Split(MarketSymbolSeparator[0]);
+			if (pieces.Length < 2)
+			{
+				throw new InvalidOperationException($"Splitting {Name} symbol '{marketSymbol}' with symbol separator '{MarketSymbolSeparator}' must result in at least 2 pieces.");
+			}
+			string baseCurrency = MarketSymbolIsReversed ? pieces[1] : pieces[0];
+			string quoteCurrency = MarketSymbolIsReversed ? pieces[0] : pieces[1];
+			return (baseCurrency, quoteCurrency);
+		}
 
 		/// <summary>
 		/// Get a dictionary of mapping exchange currencies to global currencies
@@ -259,38 +288,38 @@ namespace ExchangeSharp
 		/// <summary>
 		/// Override to dispose of resources when the exchange is disposed
 		/// </summary>
-		protected virtual void OnDispose() { }
+		protected virtual void OnDispose() {}
 
 		#endregion Protected methods
 
 		#region Other
 
-        /// <summary>
-        /// Finalizer
-        /// </summary>
-        ~ExchangeAPI()
-        {
-            Dispose();
-        }
+		/// <summary>
+		/// Finalizer
+		/// </summary>
+		~ExchangeAPI()
+		{
+			Dispose();
+		}
 
-        /// <summary>
-        /// Dispose and cleanup all resources
-        /// </summary>
-        public void Dispose()
-        {
-            if (!disposed)
-            {
-                disposed = true;
-                OnDispose();
-                Cache?.Dispose();
+		/// <summary>
+		/// Dispose and cleanup all resources
+		/// </summary>
+		public void Dispose()
+		{
+			if (!disposed)
+			{
+				disposed = true;
+				OnDispose();
+				Cache?.Dispose();
 
 				// take out of global api dictionary if disposed and we are the current exchange in the dictionary
 				if (apis.TryGetValue(GetType(), out ExchangeAPI existing) && this == existing)
 				{
 					apis.TryRemove(GetType(), out _);
 				}
-            }
-        }
+			}
+		}
 
 		/// <summary>
 		/// Initialize state for this exchange
@@ -316,7 +345,7 @@ namespace ExchangeSharp
 			// find the exchange with the name and creat it
 			foreach (Type type in exchangeTypes)
 			{
-				ExchangeAPI api = (Activator.CreateInstance(type, true) as ExchangeAPI)!;
+				ExchangeAPI api = (Activator.CreateInstance(type, true)as ExchangeAPI) !;
 				if (api.Name.Equals(exchangeName, StringComparison.OrdinalIgnoreCase))
 				{
 					return GetExchangeAPI(type);
@@ -330,11 +359,11 @@ namespace ExchangeSharp
 		/// </summary>
 		/// <typeparam name="T">Type of exchange to get</typeparam>
 		/// <returns>Exchange API or null if not found</returns>
-		public static IExchangeAPI GetExchangeAPI<T>() where T : ExchangeAPI
+		public static IExchangeAPI GetExchangeAPI<T>()where T : ExchangeAPI
 		{
 			// note: this method will be slightly slow (milliseconds) the first time it is called due to cache miss and initialization
 			// subsequent calls with cache hits will be nanoseconds
-			Type type = typeof(T)!;
+			Type type = typeof(T) !;
 			return GetExchangeAPI(type);
 		}
 
@@ -354,7 +383,7 @@ namespace ExchangeSharp
 				Type? foundType = exchangeTypes.FirstOrDefault(t => t == type);
 				if (foundType != null)
 				{
-					api = (Activator.CreateInstance(foundType, true) as ExchangeAPI)!;
+					api = (Activator.CreateInstance(foundType, true)as ExchangeAPI) !;
 					Exception? ex = null;
 
 					// try up to 3 times to init
@@ -387,30 +416,30 @@ namespace ExchangeSharp
 			});
 		}
 
-        /// <summary>
-        /// Get all exchange APIs
-        /// </summary>
-        /// <returns>All APIs</returns>
-        public static IExchangeAPI[] GetExchangeAPIs()
-        {
-            foreach (Type type in exchangeTypes)
-            {
-                List<IExchangeAPI> apiList = new List<IExchangeAPI>();
-                foreach (var kv in apis.ToArray())
-                {
-                    if (kv.Value == null)
-                    {
-                        apiList.Add(GetExchangeAPI(kv.Key));
-                    }
-                    else
-                    {
-                        apiList.Add(kv.Value);
-                    }
-                }
-                return apiList.ToArray();
-            }
+		/// <summary>
+		/// Get all exchange APIs
+		/// </summary>
+		/// <returns>All APIs</returns>
+		public static IExchangeAPI[] GetExchangeAPIs()
+		{
+			foreach (Type type in exchangeTypes)
+			{
+				List<IExchangeAPI> apiList = new List<IExchangeAPI>();
+				foreach (var kv in apis.ToArray())
+				{
+					if (kv.Value == null)
+					{
+						apiList.Add(GetExchangeAPI(kv.Key));
+					}
+					else
+					{
+						apiList.Add(kv.Value);
+					}
+				}
+				return apiList.ToArray();
+			}
 			return apis.Values.ToArray();
-        }
+		}
 
 		/// <summary>
 		/// Convert an exchange currency to a global currency. For example, on Binance,
@@ -445,359 +474,359 @@ namespace ExchangeSharp
 		/// <param name="currency">Global currency</param>
 		/// <returns>Exchange currency</returns>
 		public string GlobalCurrencyToExchangeCurrency(string currency)
-        {
+		{
 			currency ??= string.Empty;
 			var dict = ExchangeGlobalCurrencyReplacements;
 			foreach (var kv in dict)
-            {
-                currency = currency.Replace(kv.Value, kv.Key);
-            }
-            return (MarketSymbolIsUppercase ? currency.ToUpperInvariant() : currency.ToLowerInvariant());
-        }
+			{
+				currency = currency.Replace(kv.Value, kv.Key);
+			}
+			return (MarketSymbolIsUppercase ? currency.ToUpperInvariant() : currency.ToLowerInvariant());
+		}
 
-        /// <summary>
-        /// Normalize an exchange specific symbol. The symbol should already be in the correct order,
-        /// this method just deals with casing and putting in the right separator.
-        /// </summary>
-        /// <param name="marketSymbol">Symbol</param>
-        /// <returns>Normalized symbol</returns>
-        public virtual string NormalizeMarketSymbol(string? marketSymbol)
-        {
-            marketSymbol = (marketSymbol ?? string.Empty).Trim();
-            marketSymbol = marketSymbol.Replace("-", MarketSymbolSeparator)
-                .Replace("/", MarketSymbolSeparator)
-                .Replace("_", MarketSymbolSeparator)
-                .Replace(" ", MarketSymbolSeparator)
-                .Replace(":", MarketSymbolSeparator);
-            if (MarketSymbolIsUppercase)
-            {
-                return marketSymbol.ToUpperInvariant();
-            }
-            return marketSymbol.ToLowerInvariant();
-        }
+		/// <summary>
+		/// Normalize an exchange specific symbol. The symbol should already be in the correct order,
+		/// this method just deals with casing and putting in the right separator.
+		/// </summary>
+		/// <param name="marketSymbol">Symbol</param>
+		/// <returns>Normalized symbol</returns>
+		public virtual string NormalizeMarketSymbol(string? marketSymbol)
+		{
+			marketSymbol = (marketSymbol ?? string.Empty).Trim();
+			marketSymbol = marketSymbol.Replace("-", MarketSymbolSeparator)
+				.Replace("/", MarketSymbolSeparator)
+				.Replace("_", MarketSymbolSeparator)
+				.Replace(" ", MarketSymbolSeparator)
+				.Replace(":", MarketSymbolSeparator);
+			if (MarketSymbolIsUppercase)
+			{
+				return marketSymbol.ToUpperInvariant();
+			}
+			return marketSymbol.ToLowerInvariant();
+		}
 
 		/// <summary>
 		/// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
 		/// Global symbols are always uppercase and separate the currency pair with a hyphen (-).
 		/// Global symbols list the base currency first (i.e. BTC) and quote/conversion currency
 		/// second (i.e. USD). Global symbols are of the form BASE-QUOTE. BASE-QUOTE is read as
-		/// 1 BASE is worth y QUOTE. 
+		/// 1 BASE is worth y QUOTE.
 		///
 		/// Examples:
 		///		On 1/25/2020,
 		///			- BTC-USD: $8,371; 1 BTC (base) is worth $8,371 USD (quote)
 		///			- ETH-BTC: 0.01934; 1 ETH is worth 0.01934 BTC
 		///			- EUR-USD: 1.2; 1 EUR worth 1.2 USD
-		/// 
+		///
 		/// A value greater than 1 means one unit of base currency is more valuable than one unit of
 		/// quote currency.
 		/// </summary>
 		/// <param name="marketSymbol">Exchange symbol</param>
 		/// <returns>Global symbol</returns>
 		public virtual async Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
-        {
-            string modifiedMarketSymbol = marketSymbol;
-            char separator;
+		{
+			string modifiedMarketSymbol = marketSymbol;
+			char separator;
 
-            // if no separator, we must query metadata and build the pair
-            if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
-            {
-                // we must look it up via metadata, most often this call will be cached and fast
-                ExchangeMarket marketSymbolMetadata = await GetExchangeMarketFromCacheAsync(marketSymbol);
-                if (marketSymbolMetadata == null)
-                {
-                    throw new InvalidDataException($"No market symbol metadata returned or unable to find symbol metadata for {marketSymbol}");
-                }
-                modifiedMarketSymbol = marketSymbolMetadata.BaseCurrency + GlobalMarketSymbolSeparatorString + marketSymbolMetadata.QuoteCurrency;
-                separator = GlobalMarketSymbolSeparator;
-            }
-            else
-            {
-                separator = MarketSymbolSeparator[0];
-            }
-            return await ExchangeMarketSymbolToGlobalMarketSymbolWithSeparatorAsync(modifiedMarketSymbol, separator);
-        }
+			// if no separator, we must query metadata and build the pair
+			if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
+			{
+				// we must look it up via metadata, most often this call will be cached and fast
+				ExchangeMarket marketSymbolMetadata = await GetExchangeMarketFromCacheAsync(marketSymbol);
+				if (marketSymbolMetadata == null)
+				{
+					throw new InvalidDataException($"No market symbol metadata returned or unable to find symbol metadata for {marketSymbol}");
+				}
+				modifiedMarketSymbol = marketSymbolMetadata.BaseCurrency + GlobalMarketSymbolSeparatorString + marketSymbolMetadata.QuoteCurrency;
+				separator = GlobalMarketSymbolSeparator;
+			}
+			else
+			{
+				separator = MarketSymbolSeparator[0];
+			}
+			return await ExchangeMarketSymbolToGlobalMarketSymbolWithSeparatorAsync(modifiedMarketSymbol, separator);
+		}
 
-        /// <summary>
-        /// Convert currencies to exchange market symbol
-        /// </summary>
-        /// <param name="baseCurrency">Base currency</param>
-        /// <param name="quoteCurrency">Quote currency</param>
-        /// <returns>Exchange market symbol</returns>
-        public virtual Task<string> CurrenciesToExchangeMarketSymbol(string baseCurrency, string quoteCurrency)
-        {
-            string symbol = (MarketSymbolIsReversed ? $"{quoteCurrency}{MarketSymbolSeparator}{baseCurrency}" : $"{baseCurrency}{MarketSymbolSeparator}{quoteCurrency}");
-            return Task.FromResult(MarketSymbolIsUppercase ? symbol.ToUpperInvariant() : symbol);
-        }
+		/// <summary>
+		/// Convert currencies to exchange market symbol
+		/// </summary>
+		/// <param name="baseCurrency">Base currency</param>
+		/// <param name="quoteCurrency">Quote currency</param>
+		/// <returns>Exchange market symbol</returns>
+		public virtual Task<string> CurrenciesToExchangeMarketSymbol(string baseCurrency, string quoteCurrency)
+		{
+			string symbol = (MarketSymbolIsReversed ? $"{quoteCurrency}{MarketSymbolSeparator}{baseCurrency}" : $"{baseCurrency}{MarketSymbolSeparator}{quoteCurrency}");
+			return Task.FromResult(MarketSymbolIsUppercase ? symbol.ToUpperInvariant() : symbol);
+		}
 
-        /// <summary>
-        /// Get currencies from exchange market symbol. This method will call GetMarketSymbolsMetadataAsync if no MarketSymbolSeparator is defined for the exchange.
-        /// </summary>
-        /// <param name="marketSymbol">Market symbol</param>
-        /// <returns>Base and quote currency</returns>
-        public virtual async Task<(string baseCurrency, string quoteCurrency)> ExchangeMarketSymbolToCurrenciesAsync(string marketSymbol)
-        {
-            marketSymbol.ThrowIfNullOrWhitespace(nameof(marketSymbol));
+		/// <summary>
+		/// Get currencies from exchange market symbol. This method will call GetMarketSymbolsMetadataAsync if no MarketSymbolSeparator is defined for the exchange.
+		/// </summary>
+		/// <param name="marketSymbol">Market symbol</param>
+		/// <returns>Base and quote currency</returns>
+		public virtual async Task < (string baseCurrency, string quoteCurrency) > ExchangeMarketSymbolToCurrenciesAsync(string marketSymbol)
+		{
+			marketSymbol.ThrowIfNullOrWhitespace(nameof(marketSymbol));
 
-            // no separator logic...
-            if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
-            {
-                // we must look it up via metadata, most often this call will be cached and fast
-                ExchangeMarket marketSymbolMetadata = await GetExchangeMarketFromCacheAsync(marketSymbol);
-                if (marketSymbolMetadata == null)
-                {
-                    throw new InvalidDataException($"No market symbol metadata returned or unable to find symbol metadata for {marketSymbol}");
-                }
-                return (marketSymbolMetadata.BaseCurrency, marketSymbolMetadata.QuoteCurrency);
-            }
+			// no separator logic...
+			if (string.IsNullOrWhiteSpace(MarketSymbolSeparator))
+			{
+				// we must look it up via metadata, most often this call will be cached and fast
+				ExchangeMarket marketSymbolMetadata = await GetExchangeMarketFromCacheAsync(marketSymbol);
+				if (marketSymbolMetadata == null)
+				{
+					throw new InvalidDataException($"No market symbol metadata returned or unable to find symbol metadata for {marketSymbol}");
+				}
+				return (marketSymbolMetadata.BaseCurrency, marketSymbolMetadata.QuoteCurrency);
+			}
 
-            // default behavior with separator
-            return OnSplitMarketSymbolToCurrencies(marketSymbol);
-        }
+			// default behavior with separator
+			return OnSplitMarketSymbolToCurrencies(marketSymbol);
+		}
 
-        /// <summary>
-        /// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
-        /// </summary>
-        /// <param name="marketSymbol">Global market symbol</param>
-        /// <returns>Exchange market symbol</returns>
-        public virtual Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
-        {
-            if (string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                throw new ArgumentException("Market symbol must be non null and non empty");
-            }
-            int pos = marketSymbol.IndexOf(GlobalMarketSymbolSeparator);
-            if (pos < 0)
-            {
-                throw new ArgumentException($"Market symbol {marketSymbol} is missing the global symbol separator '{GlobalMarketSymbolSeparator}'");
-            }
-            if (MarketSymbolIsReversed == false)
-            {
-                marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1));
-            }
-            else
-            {
-                marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos));
-            }
-            return Task.FromResult(MarketSymbolIsUppercase ? marketSymbol.ToUpperInvariant() : marketSymbol.ToLowerInvariant());
-        }
+		/// <summary>
+		/// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
+		/// </summary>
+		/// <param name="marketSymbol">Global market symbol</param>
+		/// <returns>Exchange market symbol</returns>
+		public virtual Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
+		{
+			if (string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				throw new ArgumentException("Market symbol must be non null and non empty");
+			}
+			int pos = marketSymbol.IndexOf(GlobalMarketSymbolSeparator);
+			if (pos < 0)
+			{
+				throw new ArgumentException($"Market symbol {marketSymbol} is missing the global symbol separator '{GlobalMarketSymbolSeparator}'");
+			}
+			if (MarketSymbolIsReversed == false)
+			{
+				marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1));
+			}
+			else
+			{
+				marketSymbol = GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(pos + 1)) + MarketSymbolSeparator + GlobalCurrencyToExchangeCurrency(marketSymbol.Substring(0, pos));
+			}
+			return Task.FromResult(MarketSymbolIsUppercase ? marketSymbol.ToUpperInvariant() : marketSymbol.ToLowerInvariant());
+		}
 
-        /// <summary>
-        /// Convert seconds to a period string, or throw exception if seconds invalid. Example: 60 seconds becomes 1m.
-        /// </summary>
-        /// <param name="seconds">Seconds</param>
-        /// <returns>Period string</returns>
-        public virtual string PeriodSecondsToString(int seconds) => CryptoUtility.SecondsToPeriodString(seconds);
+		/// <summary>
+		/// Convert seconds to a period string, or throw exception if seconds invalid. Example: 60 seconds becomes 1m.
+		/// </summary>
+		/// <param name="seconds">Seconds</param>
+		/// <returns>Period string</returns>
+		public virtual string PeriodSecondsToString(int seconds) => CryptoUtility.SecondsToPeriodString(seconds);
 
-        #endregion Other
+		#endregion Other
 
-        #region REST API
+		#region REST API
 
-        /// <summary>
-        /// Gets currencies and related data such as IsEnabled and TxFee (if available)
-        /// </summary>
-        /// <returns>Collection of Currencies</returns>
-        public virtual async Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
-        {
-			var currencies = await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetCurrenciesAsync(), nameof(GetCurrenciesAsync));
+		/// <summary>
+		/// Gets currencies and related data such as IsEnabled and TxFee (if available)
+		/// </summary>
+		/// <returns>Collection of Currencies</returns>
+		public virtual async Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync()
+		{
+			var currencies = await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetCurrenciesAsync(), nameof(GetCurrenciesAsync));
 			return await ExchangeCurrenciesDictionaryToGlobalCurrenciesDictionaryAsync(currencies);
 		}
 
-        /// <summary>
-        /// Get exchange symbols
-        /// </summary>
-        /// <returns>Array of symbols</returns>
-        public virtual async Task<IEnumerable<string>> GetMarketSymbolsAsync()
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetMarketSymbolsAsync()).ToArray(), nameof(GetMarketSymbolsAsync));
-        }
+		/// <summary>
+		/// Get exchange symbols
+		/// </summary>
+		/// <returns>Array of symbols</returns>
+		public virtual async Task<IEnumerable<string>> GetMarketSymbolsAsync()
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetMarketSymbolsAsync()).ToArray(), nameof(GetMarketSymbolsAsync));
+		}
 
-        /// <summary>
-        /// Get exchange symbols including available metadata such as min trade size and whether the market is active
-        /// </summary>
-        /// <returns>Collection of ExchangeMarkets</returns>
-        public virtual async Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync()
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetMarketSymbolsMetadataAsync()).ToArray(), nameof(GetMarketSymbolsMetadataAsync));
-        }
+		/// <summary>
+		/// Get exchange symbols including available metadata such as min trade size and whether the market is active
+		/// </summary>
+		/// <returns>Collection of ExchangeMarkets</returns>
+		public virtual async Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync()
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetMarketSymbolsMetadataAsync()).ToArray(), nameof(GetMarketSymbolsMetadataAsync));
+		}
 
-        /// <summary>
-        /// Gets the exchange market from this exchange's SymbolsMetadata cache. This will make a network request if needed to retrieve fresh markets from the exchange using GetSymbolsMetadataAsync().
-        /// Please note that sending a symbol that is not found over and over will result in many network requests. Only send symbols that you are confident exist on the exchange.
-        /// </summary>
-        /// <param name="marketSymbol">The market symbol. Ex. ADA/BTC. This is assumed to be normalized and already correct for the exchange.</param>
-        /// <returns>The ExchangeMarket or null if it doesn't exist in the cache or there was an error</returns>
-        public virtual async Task<ExchangeMarket?> GetExchangeMarketFromCacheAsync(string marketSymbol)
-        {
-            try
-            {
-                // *NOTE*: custom caching, do not wrap in CacheMethodCall...
-                // *NOTE*: vulnerability exists where if spammed with not found symbols, lots of network calls will happen, stalling the application
-                // TODO: Add not found dictionary, or some mechanism to mitigate this risk
-                // not sure if this is needed, but adding it just in case
-                await new SynchronizationContextRemover();
-                Dictionary<string, ExchangeMarket> lookup = await this.GetExchangeMarketDictionaryFromCacheAsync();
-                if (lookup != null && lookup.TryGetValue(marketSymbol, out ExchangeMarket market))
-                {
-                    return market;
-                }
+		/// <summary>
+		/// Gets the exchange market from this exchange's SymbolsMetadata cache. This will make a network request if needed to retrieve fresh markets from the exchange using GetSymbolsMetadataAsync().
+		/// Please note that sending a symbol that is not found over and over will result in many network requests. Only send symbols that you are confident exist on the exchange.
+		/// </summary>
+		/// <param name="marketSymbol">The market symbol. Ex. ADA/BTC. This is assumed to be normalized and already correct for the exchange.</param>
+		/// <returns>The ExchangeMarket or null if it doesn't exist in the cache or there was an error</returns>
+		public virtual async Task<ExchangeMarket?> GetExchangeMarketFromCacheAsync(string marketSymbol)
+		{
+			try
+			{
+				// *NOTE*: custom caching, do not wrap in CacheMethodCall...
+				// *NOTE*: vulnerability exists where if spammed with not found symbols, lots of network calls will happen, stalling the application
+				// TODO: Add not found dictionary, or some mechanism to mitigate this risk
+				// not sure if this is needed, but adding it just in case
+				await new SynchronizationContextRemover();
+				Dictionary<string, ExchangeMarket> lookup = await this.GetExchangeMarketDictionaryFromCacheAsync();
+				if (lookup != null && lookup.TryGetValue(marketSymbol, out ExchangeMarket market))
+				{
+					return market;
+				}
 
-                // try again with a fresh request
-                Cache.Remove(nameof(GetMarketSymbolsMetadataAsync));
-                Cache.Remove(nameof(ExchangeAPIExtensions.GetExchangeMarketDictionaryFromCacheAsync));
-                lookup = await this.GetExchangeMarketDictionaryFromCacheAsync();
-                if (lookup != null && lookup.TryGetValue(marketSymbol, out market))
-                {
-                    return market;
-                }
-            }
-            catch
-            {
-                // TODO: Report the error somehow, for now a failed network request will just return null symbol which will force the caller to use default handling
-            }
-            return null;
-        }
+				// try again with a fresh request
+				Cache.Remove(nameof(GetMarketSymbolsMetadataAsync));
+				Cache.Remove(nameof(ExchangeAPIExtensions.GetExchangeMarketDictionaryFromCacheAsync));
+				lookup = await this.GetExchangeMarketDictionaryFromCacheAsync();
+				if (lookup != null && lookup.TryGetValue(marketSymbol, out market))
+				{
+					return market;
+				}
+			}
+			catch
+			{
+				// TODO: Report the error somehow, for now a failed network request will just return null symbol which will force the caller to use default handling
+			}
+			return null;
+		}
 
-        /// <summary>
-        /// Get exchange ticker
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get ticker for</param>
-        /// <returns>Ticker</returns>
-        public virtual async Task<ExchangeTicker> GetTickerAsync(string marketSymbol)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetTickerAsync(marketSymbol), nameof(GetTickerAsync), nameof(marketSymbol), marketSymbol);
-        }
+		/// <summary>
+		/// Get exchange ticker
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get ticker for</param>
+		/// <returns>Ticker</returns>
+		public virtual async Task<ExchangeTicker> GetTickerAsync(string marketSymbol)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetTickerAsync(marketSymbol), nameof(GetTickerAsync), nameof(marketSymbol), marketSymbol);
+		}
 
-        /// <summary>
-        /// Get all tickers in one request. If the exchange does not support this, a ticker will be requested for each symbol.
-        /// </summary>
-        /// <returns>Key value pair of symbol and tickers array</returns>
-        public virtual async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetTickersAsync(), nameof(GetTickersAsync));
-        }
+		/// <summary>
+		/// Get all tickers in one request. If the exchange does not support this, a ticker will be requested for each symbol.
+		/// </summary>
+		/// <returns>Key value pair of symbol and tickers array</returns>
+		public virtual async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync()
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetTickersAsync(), nameof(GetTickersAsync));
+		}
 
-        /// <summary>
-        /// Get exchange order book
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get order book for</param>
-        /// <param name="maxCount">Max count, not all exchanges will honor this parameter</param>
-        /// <returns>Exchange order book or null if failure</returns>
-        public virtual async Task<ExchangeOrderBook> GetOrderBookAsync(string marketSymbol, int maxCount = 100)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderBookAsync(marketSymbol, maxCount), nameof(GetOrderBookAsync), nameof(marketSymbol), marketSymbol, nameof(maxCount), maxCount);
-        }
+		/// <summary>
+		/// Get exchange order book
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get order book for</param>
+		/// <param name="maxCount">Max count, not all exchanges will honor this parameter</param>
+		/// <returns>Exchange order book or null if failure</returns>
+		public virtual async Task<ExchangeOrderBook> GetOrderBookAsync(string marketSymbol, int maxCount = 100)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetOrderBookAsync(marketSymbol, maxCount), nameof(GetOrderBookAsync), nameof(marketSymbol), marketSymbol, nameof(maxCount), maxCount);
+		}
 
-        /// <summary>
-        /// Get all exchange order book symbols in one request. If the exchange does not support this, an order book will be requested for each symbol. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
-        /// </summary>
-        /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
-        /// <returns>Symbol and order books pairs</returns>
-        public virtual async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100)
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderBooksAsync(maxCount), nameof(GetOrderBooksAsync), nameof(maxCount), maxCount);
-        }
+		/// <summary>
+		/// Get all exchange order book symbols in one request. If the exchange does not support this, an order book will be requested for each symbol. Depending on the exchange, the number of bids and asks will have different counts, typically 50-100.
+		/// </summary>
+		/// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
+		/// <returns>Symbol and order books pairs</returns>
+		public virtual async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> GetOrderBooksAsync(int maxCount = 100)
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetOrderBooksAsync(maxCount), nameof(GetOrderBooksAsync), nameof(maxCount), maxCount);
+		}
 
-        /// <summary>
-        /// Get historical trades for the exchange. TODO: Change to async enumerator when available.
-        /// </summary>
-        /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
-        /// <param name="marketSymbol">Symbol to get historical data for</param>
-        /// <param name="startDate">Optional UTC start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        /// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        public virtual async Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            // *NOTE*: Do not wrap in CacheMethodCall, uses a callback with custom queries, not easy to cache
-            await new SynchronizationContextRemover();
-            await OnGetHistoricalTradesAsync(callback, NormalizeMarketSymbol(marketSymbol), startDate, endDate, limit);
-        }
+		/// <summary>
+		/// Get historical trades for the exchange. TODO: Change to async enumerator when available.
+		/// </summary>
+		/// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
+		/// <param name="marketSymbol">Symbol to get historical data for</param>
+		/// <param name="startDate">Optional UTC start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
+		/// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
+		public virtual async Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			// *NOTE*: Do not wrap in CacheMethodCall, uses a callback with custom queries, not easy to cache
+			await new SynchronizationContextRemover();
+			await OnGetHistoricalTradesAsync(callback, NormalizeMarketSymbol(marketSymbol), startDate, endDate, limit);
+		}
 
-        /// <summary>
-        /// Get recent trades on the exchange - the default implementation simply calls GetHistoricalTrades with a null sinceDateTime.
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get recent trades for</param>
-        /// <returns>An enumerator that loops through all recent trades</returns>
-        public virtual async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol, int? limit = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetRecentTradesAsync(marketSymbol, limit), nameof(GetRecentTradesAsync), nameof(marketSymbol), marketSymbol, nameof(limit), limit);
+		/// <summary>
+		/// Get recent trades on the exchange - the default implementation simply calls GetHistoricalTrades with a null sinceDateTime.
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get recent trades for</param>
+		/// <returns>An enumerator that loops through all recent trades</returns>
+		public virtual async Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol, int? limit = null)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetRecentTradesAsync(marketSymbol, limit), nameof(GetRecentTradesAsync), nameof(marketSymbol), marketSymbol, nameof(limit), limit);
 			//return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetRecentTradesAsync(marketSymbol), nameof(GetRecentTradesAsync), nameof(marketSymbol), marketSymbol);
-        }
+		}
 
-        /// <summary>
-        /// Gets the address to deposit to and applicable details.
-        /// </summary>
-        /// <param name="currency">Currency to get address for.</param>
-        /// <param name="forceRegenerate">Regenerate the address</param>
-        /// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
-        public virtual async Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false)
-        {
-            if (forceRegenerate)
-            {
-                // force regenetate, do not cache
-                return await OnGetDepositAddressAsync(currency, forceRegenerate);
-            }
-            else
-            {
-                return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositAddressAsync(currency, forceRegenerate), nameof(GetDepositAddressAsync), nameof(currency), currency);
-            }
-        }
+		/// <summary>
+		/// Gets the address to deposit to and applicable details.
+		/// </summary>
+		/// <param name="currency">Currency to get address for.</param>
+		/// <param name="forceRegenerate">Regenerate the address</param>
+		/// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
+		public virtual async Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false)
+		{
+			if (forceRegenerate)
+			{
+				// force regenetate, do not cache
+				return await OnGetDepositAddressAsync(currency, forceRegenerate);
+			}
+			else
+			{
+				return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetDepositAddressAsync(currency, forceRegenerate), nameof(GetDepositAddressAsync), nameof(currency), currency);
+			}
+		}
 
-        /// <summary>
-        /// Gets the deposit history for a symbol
-        /// </summary>
-        /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public virtual async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency)
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetDepositHistoryAsync(currency), nameof(GetDepositHistoryAsync), nameof(currency), currency);
-        }
+		/// <summary>
+		/// Gets the deposit history for a symbol
+		/// </summary>
+		/// <returns>Collection of ExchangeCoinTransfers</returns>
+		public virtual async Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency)
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetDepositHistoryAsync(currency), nameof(GetDepositHistoryAsync), nameof(currency), currency);
+		}
 
-        /// <summary>
-        /// Get candles (open, high, low, close)
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get candles for</param>
-        /// <param name="periodSeconds">Period in seconds to get candles for. Use 60 for minute, 3600 for hour, 3600*24 for day, 3600*24*30 for month.</param>
-        /// <param name="startDate">Optional start date to get candles for</param>
-        /// <param name="endDate">Optional end date to get candles for</param>
-        /// <param name="limit">Max results, can be used instead of startDate and endDate if desired</param>
-        /// <returns>Candles</returns>
-        public virtual async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetCandlesAsync(marketSymbol, periodSeconds, startDate, endDate, limit), nameof(GetCandlesAsync),
-                nameof(marketSymbol), marketSymbol, nameof(periodSeconds), periodSeconds, nameof(startDate), startDate, nameof(endDate), endDate, nameof(limit), limit);
-        }
+		/// <summary>
+		/// Get candles (open, high, low, close)
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get candles for</param>
+		/// <param name="periodSeconds">Period in seconds to get candles for. Use 60 for minute, 3600 for hour, 3600*24 for day, 3600*24*30 for month.</param>
+		/// <param name="startDate">Optional start date to get candles for</param>
+		/// <param name="endDate">Optional end date to get candles for</param>
+		/// <param name="limit">Max results, can be used instead of startDate and endDate if desired</param>
+		/// <returns>Candles</returns>
+		public virtual async Task<IEnumerable<MarketCandle>> GetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetCandlesAsync(marketSymbol, periodSeconds, startDate, endDate, limit), nameof(GetCandlesAsync),
+				nameof(marketSymbol), marketSymbol, nameof(periodSeconds), periodSeconds, nameof(startDate), startDate, nameof(endDate), endDate, nameof(limit), limit);
+		}
 
-        /// <summary>
-        /// Get total amounts, symbol / amount dictionary
-        /// </summary>
-        /// <returns>Dictionary of symbols and amounts</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetAmountsAsync()
-        {
-			var amounts = await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetAmountsAsync()), nameof(GetAmountsAsync));
+		/// <summary>
+		/// Get total amounts, symbol / amount dictionary
+		/// </summary>
+		/// <returns>Dictionary of symbols and amounts</returns>
+		public virtual async Task<Dictionary<string, decimal>> GetAmountsAsync()
+		{
+			var amounts = await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetAmountsAsync()), nameof(GetAmountsAsync));
 			var globalAmounts = await ExchangeCurrenciesDictionaryToGlobalCurrenciesDictionaryAsync(amounts);
 
 			return globalAmounts;
 		}
 
-        /// <summary>
-        /// Get fees
-        /// </summary>
-        /// <returns>The customer trading fees</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetFeesAync()
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetFeesAsync(), nameof(GetFeesAync));
-        }
+		/// <summary>
+		/// Get fees
+		/// </summary>
+		/// <returns>The customer trading fees</returns>
+		public virtual async Task<Dictionary<string, decimal>> GetFeesAync()
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetFeesAsync(), nameof(GetFeesAync));
+		}
 
-        /// <summary>
-        /// Get amounts available to trade, symbol / amount dictionary
-        /// </summary>
-        /// <returns>Symbol / amount dictionary</returns>
-        public virtual async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
-        {
-			var exchangeBalances = await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetAmountsAvailableToTradeAsync(), nameof(GetAmountsAvailableToTradeAsync));
+		/// <summary>
+		/// Get amounts available to trade, symbol / amount dictionary
+		/// </summary>
+		/// <returns>Symbol / amount dictionary</returns>
+		public virtual async Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync()
+		{
+			var exchangeBalances = await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetAmountsAvailableToTradeAsync(), nameof(GetAmountsAvailableToTradeAsync));
 			var globalBalances = await ExchangeCurrenciesDictionaryToGlobalCurrenciesDictionaryAsync(exchangeBalances);
 
 			return globalBalances;
@@ -810,7 +839,7 @@ namespace ExchangeSharp
 		/// <returns>Symbol / amount dictionary</returns>
 		public virtual async Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances = false)
 		{
-			var exchangeBalances = await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetMarginAmountsAvailableToTradeAsync(includeZeroBalances),
+			var exchangeBalances = await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetMarginAmountsAvailableToTradeAsync(includeZeroBalances),
 				nameof(GetMarginAmountsAvailableToTradeAsync), nameof(includeZeroBalances), includeZeroBalances);
 			var globalBalances = await ExchangeCurrenciesDictionaryToGlobalCurrenciesDictionaryAsync(exchangeBalances);
 
@@ -823,122 +852,120 @@ namespace ExchangeSharp
 		/// <param name="order">The order request</param>
 		/// <returns>Result</returns>
 		public virtual async Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order)
-        {
-            // *NOTE* do not wrap in CacheMethodCall
-            await new SynchronizationContextRemover();
-            order.MarketSymbol = NormalizeMarketSymbol(order.MarketSymbol);
-            return await OnPlaceOrderAsync(order);
-        }
+		{
+			// *NOTE* do not wrap in CacheMethodCall
+			await new SynchronizationContextRemover();
+			order.MarketSymbol = NormalizeMarketSymbol(order.MarketSymbol);
+			return await OnPlaceOrderAsync(order);
+		}
 
-        /// <summary>
-        /// Place bulk orders
-        /// </summary>
-        /// <param name="orders">Order requests</param>f
-        /// <returns>Order results, each result matches up with each order in index</returns>
-        public virtual async Task<ExchangeOrderResult[]> PlaceOrdersAsync(params ExchangeOrderRequest[] orders)
-        {
-            // *NOTE* do not wrap in CacheMethodCall
-            await new SynchronizationContextRemover();
-            foreach (ExchangeOrderRequest request in orders)
-            {
-                request.MarketSymbol = NormalizeMarketSymbol(request.MarketSymbol);
-            }
-            return await OnPlaceOrdersAsync(orders);
-        }
+		/// <summary>
+		/// Place bulk orders
+		/// </summary>
+		/// <param name="orders">Order requests</param>f
+		/// <returns>Order results, each result matches up with each order in index</returns>
+		public virtual async Task<ExchangeOrderResult[]> PlaceOrdersAsync(params ExchangeOrderRequest[] orders)
+		{
+			// *NOTE* do not wrap in CacheMethodCall
+			await new SynchronizationContextRemover();
+			foreach (ExchangeOrderRequest request in orders)
+			{
+				request.MarketSymbol = NormalizeMarketSymbol(request.MarketSymbol);
+			}
+			return await OnPlaceOrdersAsync(orders);
+		}
 
-        /// <summary>
-        /// Get order details
-        /// </summary>
-        /// <param name="orderId">Order id to get details for</param>
-        /// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
-        /// <returns>Order details</returns>
-        public virtual async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string? marketSymbol = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOrderDetailsAsync(orderId, marketSymbol), nameof(GetOrderDetailsAsync), nameof(orderId), orderId, nameof(marketSymbol), marketSymbol);
-        }
+		/// <summary>
+		/// Get order details
+		/// </summary>
+		/// <param name="orderId">Order id to get details for</param>
+		/// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
+		/// <returns>Order details</returns>
+		public virtual async Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string? marketSymbol = null)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetOrderDetailsAsync(orderId, marketSymbol), nameof(GetOrderDetailsAsync), nameof(orderId), orderId, nameof(marketSymbol), marketSymbol);
+		}
 
-        /// <summary>
-        /// Get the details of all open orders
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get open orders for or null for all</param>
-        /// <returns>All open order details</returns>
-        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string? marketSymbol = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenOrderDetailsAsync(marketSymbol), nameof(GetOpenOrderDetailsAsync), nameof(marketSymbol), marketSymbol);
-        }
+		/// <summary>
+		/// Get the details of all open orders
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get open orders for or null for all</param>
+		/// <returns>All open order details</returns>
+		public virtual async Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string? marketSymbol = null)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetOpenOrderDetailsAsync(marketSymbol), nameof(GetOpenOrderDetailsAsync), nameof(marketSymbol), marketSymbol);
+		}
 
-        /// <summary>
-        /// Get the details of all completed orders
-        /// </summary>
-        /// <param name="marketSymbol">Symbol to get completed orders for or null for all</param>
-        /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
-        /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => (await OnGetCompletedOrderDetailsAsync(marketSymbol, afterDate)).ToArray(), nameof(GetCompletedOrderDetailsAsync),
-                nameof(marketSymbol), marketSymbol, nameof(afterDate), afterDate);
-        }
+		/// <summary>
+		/// Get the details of all completed orders
+		/// </summary>
+		/// <param name="marketSymbol">Symbol to get completed orders for or null for all</param>
+		/// <param name="afterDate">Only returns orders on or after the specified date/time</param>
+		/// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
+		public virtual async Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetCompletedOrderDetailsAsync(marketSymbol, afterDate)).ToArray(), nameof(GetCompletedOrderDetailsAsync),
+				nameof(marketSymbol), marketSymbol, nameof(afterDate), afterDate);
+		}
 
-        /// <summary>
-        /// Cancel an order, an exception is thrown if error
-        /// </summary>
-        /// <param name="orderId">Order id of the order to cancel</param>
-        /// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
-        public virtual async Task CancelOrderAsync(string orderId, string? marketSymbol = null)
-        {
-            // *NOTE* do not wrap in CacheMethodCall
-            await new SynchronizationContextRemover();
-            await OnCancelOrderAsync(orderId, NormalizeMarketSymbol(marketSymbol));
-        }
+		/// <summary>
+		/// Cancel an order, an exception is thrown if error
+		/// </summary>
+		/// <param name="orderId">Order id of the order to cancel</param>
+		/// <param name="marketSymbol">Symbol of order (most exchanges do not require this)</param>
+		public virtual async Task CancelOrderAsync(string orderId, string? marketSymbol = null)
+		{
+			// *NOTE* do not wrap in CacheMethodCall
+			await new SynchronizationContextRemover();
+			await OnCancelOrderAsync(orderId, NormalizeMarketSymbol(marketSymbol));
+		}
 
-        /// <summary>
-        /// Asynchronous withdraws request.
-        /// </summary>
-        /// <param name="withdrawalRequest">The withdrawal request.</param>
-        public virtual async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
-        {
-            // *NOTE* do not wrap in CacheMethodCall
-            await new SynchronizationContextRemover();
-            withdrawalRequest.Currency = NormalizeMarketSymbol(withdrawalRequest.Currency);
-            return await OnWithdrawAsync(withdrawalRequest);
-        }
+		/// <summary>
+		/// Asynchronous withdraws request.
+		/// </summary>
+		/// <param name="withdrawalRequest">The withdrawal request.</param>
+		public virtual async Task<ExchangeWithdrawalResponse> WithdrawAsync(ExchangeWithdrawalRequest withdrawalRequest)
+		{
+			// *NOTE* do not wrap in CacheMethodCall
+			await new SynchronizationContextRemover();
+			withdrawalRequest.Currency = NormalizeMarketSymbol(withdrawalRequest.Currency);
+			return await OnWithdrawAsync(withdrawalRequest);
+		}
 
-        /// <summary>
-        /// Gets the withdraw history for a symbol
-        /// </summary>
-        /// <returns>Collection of ExchangeCoinTransfers</returns>
-        public virtual async Task<IEnumerable<ExchangeTransaction>> GetWithdrawHistoryAsync(string currency)
-        {
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetWithdrawHistoryAsync(currency), nameof(GetWithdrawHistoryAsync), nameof(currency), currency);
-        }
+		/// <summary>
+		/// Gets the withdraw history for a symbol
+		/// </summary>
+		/// <returns>Collection of ExchangeCoinTransfers</returns>
+		public virtual async Task<IEnumerable<ExchangeTransaction>> GetWithdrawHistoryAsync(string currency)
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetWithdrawHistoryAsync(currency), nameof(GetWithdrawHistoryAsync), nameof(currency), currency);
+		}
 
-        /// <summary>
-        /// Get open margin position
-        /// </summary>
-        /// <param name="marketSymbol">Symbol</param>
-        /// <returns>Open margin position result</returns>
-        public virtual async Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol)
-        {
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            return await Cache.CacheMethod(MethodCachePolicy, async () => await OnGetOpenPositionAsync(marketSymbol), nameof(GetOpenPositionAsync), nameof(marketSymbol), marketSymbol);
-        }
+		/// <summary>
+		/// Get open margin position
+		/// </summary>
+		/// <param name="marketSymbol">Symbol</param>
+		/// <returns>Open margin position result</returns>
+		public virtual async Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol)
+		{
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			return await Cache.CacheMethod(MethodCachePolicy, async() => await OnGetOpenPositionAsync(marketSymbol), nameof(GetOpenPositionAsync), nameof(marketSymbol), marketSymbol);
+		}
 
-        /// <summary>
-        /// Close a margin position
-        /// </summary>
-        /// <param name="marketSymbol">Symbol</param>
-        /// <returns>Close margin position result</returns>
-        public virtual async Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol)
-        {
-            // *NOTE* do not wrap in CacheMethodCall
-            await new SynchronizationContextRemover();
-            return await OnCloseMarginPositionAsync(NormalizeMarketSymbol(marketSymbol));
-        }
-
-
+		/// <summary>
+		/// Close a margin position
+		/// </summary>
+		/// <param name="marketSymbol">Symbol</param>
+		/// <returns>Close margin position result</returns>
+		public virtual async Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol)
+		{
+			// *NOTE* do not wrap in CacheMethodCall
+			await new SynchronizationContextRemover();
+			return await OnCloseMarginPositionAsync(NormalizeMarketSymbol(marketSymbol));
+		}
 
 		#endregion REST API
 
@@ -951,69 +978,69 @@ namespace ExchangeSharp
 		/// <param name="symbols"></param>
 		/// <returns>Web socket, call Dispose to close</returns>
 		public virtual Task<IWebSocket> GetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] symbols)
-        {
-            callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetTickersWebSocketAsync(callback, symbols);
-        }
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetTickersWebSocketAsync(callback, symbols);
+		}
 
-        /// <summary>
-        /// Get information about trades via web socket
-        /// </summary>
-        /// <param name="callback">Callback (symbol and trade)</param>
-        /// <param name="marketSymbols">Market Symbols</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual Task<IWebSocket> GetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
-        {
-            callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetTradesWebSocketAsync(callback, marketSymbols);
-        }
+		/// <summary>
+		/// Get information about trades via web socket
+		/// </summary>
+		/// <param name="callback">Callback (symbol and trade)</param>
+		/// <param name="marketSymbols">Market Symbols</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetTradesWebSocketAsync(callback, marketSymbols);
+		}
 
-        /// <summary>
-        /// Get delta order book bids and asks via web socket. Only the deltas are returned for each callback. To manage a full order book, use ExchangeAPIExtensions.GetOrderBookWebSocket.
-        /// </summary>
-        /// <param name="callback">Callback of symbol, order book</param>
-        /// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
-        /// <param name="marketSymbols">Market symbols or null/empty for all of them (if supported)</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual Task<IWebSocket> GetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
-        {
-            callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetDeltaOrderBookWebSocketAsync(callback, maxCount, marketSymbols);
-        }
+		/// <summary>
+		/// Get delta order book bids and asks via web socket. Only the deltas are returned for each callback. To manage a full order book, use ExchangeAPIExtensions.GetOrderBookWebSocket.
+		/// </summary>
+		/// <param name="callback">Callback of symbol, order book</param>
+		/// <param name="maxCount">Max count of bids and asks - not all exchanges will honor this parameter</param>
+		/// <param name="marketSymbols">Market symbols or null/empty for all of them (if supported)</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetDeltaOrderBookWebSocketAsync(callback, maxCount, marketSymbols);
+		}
 
-        /// <summary>
-        /// Get the details of all changed orders via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual Task<IWebSocket> GetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback)
-        {
-            callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetOrderDetailsWebSocketAsync(callback);
-        }
+		/// <summary>
+		/// Get the details of all changed orders via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetOrderDetailsWebSocketAsync(callback);
+		}
 
-        /// <summary>
-        /// Get the details of all completed orders via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual Task<IWebSocket> GetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback)
-        {
-            callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-            return OnGetCompletedOrderDetailsWebSocketAsync(callback);
-        }
+		/// <summary>
+		/// Get the details of all completed orders via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetCompletedOrderDetailsWebSocketAsync(callback);
+		}
 
-        /// <summary>
-        /// Get user detail over web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <param name="listenKey">Listen key</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        public virtual Task<IWebSocket> GetUserDataWebSocketAsync(Action<object> callback, string listenKey)
-        {
-	        callback.ThrowIfNull(nameof(callback), "Callback must not be null");
-	        return OnUserDataWebSocketAsync(callback, listenKey);
-        }
+		/// <summary>
+		/// Get user detail over web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <param name="listenKey">Listen key</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetUserDataWebSocketAsync(Action<object> callback, string listenKey)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnUserDataWebSocketAsync(callback, listenKey);
+		}
 		#endregion Web Socket API
 	}
 }

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -131,6 +131,10 @@ namespace ExchangeSharp
 			throw new NotImplementedException();
 		protected virtual Task<IEnumerable<string>> OnGetMarketSymbolsAsync() =>
 			throw new NotImplementedException();
+		protected virtual Task<IEnumerable<string>> OnGetMarketSymbolsAsync(bool isWebSocket = false)
+		{
+			return OnGetMarketSymbolsAsync();
+		}
 		protected internal virtual Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync() =>
 			throw new NotImplementedException();
 		protected virtual Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol) =>
@@ -638,7 +642,16 @@ namespace ExchangeSharp
 		/// <returns>Array of symbols</returns>
 		public virtual async Task<IEnumerable<string>> GetMarketSymbolsAsync()
 		{
-			return await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetMarketSymbolsAsync()).ToArray(), nameof(GetMarketSymbolsAsync));
+			return await GetMarketSymbolsAsync(false);
+		}
+
+		/// <summary>
+		/// Get exchange symbols
+		/// </summary>
+		/// <returns>Array of symbols</returns>
+		public virtual async Task<IEnumerable<string>> GetMarketSymbolsAsync(bool isWebSocket = false)
+		{
+			return await Cache.CacheMethod(MethodCachePolicy, async() => (await OnGetMarketSymbolsAsync(isWebSocket)).ToArray(), nameof(GetMarketSymbolsAsync));
 		}
 
 		/// <summary>

--- a/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -17,121 +17,121 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
-    /// <summary>
-    /// Interface for common exchange end points
-    /// </summary>
-    public interface IExchangeAPI : IDisposable, IBaseAPI, IOrderBookProvider
-    {
-        #region Utility Methods
+	/// <summary>
+	/// Interface for common exchange end points
+	/// </summary>
+	public interface IExchangeAPI : IDisposable, IBaseAPI, IOrderBookProvider
+	{
+		#region Utility Methods
 
-        /// <summary>
-        /// Normalize a symbol for use on this exchange.
-        /// </summary>
-        /// <param name="marketSymbol">Symbol</param>
-        /// <returns>Normalized symbol</returns>
-        string NormalizeMarketSymbol(string marketSymbol);
+		/// <summary>
+		/// Normalize a symbol for use on this exchange.
+		/// </summary>
+		/// <param name="marketSymbol">Symbol</param>
+		/// <returns>Normalized symbol</returns>
+		string NormalizeMarketSymbol(string marketSymbol);
 
 		/// <summary>
 		/// Convert an exchange symbol into a global symbol, which will be the same for all exchanges.
 		/// Global symbols are always uppercase and separate the currency pair with a hyphen (-).
 		/// Global symbols list the base currency first (i.e. BTC) and quote/conversion currency
 		/// second (i.e. USD). Global symbols are of the form BASE-QUOTE. BASE-QUOTE is read as
-		/// 1 BASE is worth y QUOTE. 
+		/// 1 BASE is worth y QUOTE.
 		///
 		/// Examples:
 		///		On 1/25/2020,
 		///			- BTC-USD: $8,371; 1 BTC (base) is worth $8,371 USD (quote)
 		///			- ETH-BTC: 0.01934; 1 ETH is worth 0.01934 BTC
 		///			- EUR-USD: 1.2; 1 EUR worth 1.2 USD
-		/// 
+		///
 		/// A value greater than 1 means one unit of base currency is more valuable than one unit of
 		/// quote currency.
-		/// 
+		///
 		/// </summary>
 		/// <param name="marketSymbol">Exchange symbol</param>
 		/// <returns>Global symbol</returns>
 		Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol);
 
-        /// <summary>
-        /// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
-        /// </summary>
-        /// <param name="marketSymbol">Global symbol</param>
-        /// <returns>Exchange symbol</returns>
-        Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol);
+		/// <summary>
+		/// Convert a global symbol into an exchange symbol, which will potentially be different from other exchanges.
+		/// </summary>
+		/// <param name="marketSymbol">Global symbol</param>
+		/// <returns>Exchange symbol</returns>
+		Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol);
 
-        /// <summary>
-        /// Convert seconds to a period string, or throw exception if seconds invalid. Example: 60 seconds becomes 1m.
-        /// </summary>
-        /// <param name="seconds">Seconds</param>
-        /// <returns>Period string</returns>
-        string PeriodSecondsToString(int seconds);
+		/// <summary>
+		/// Convert seconds to a period string, or throw exception if seconds invalid. Example: 60 seconds becomes 1m.
+		/// </summary>
+		/// <param name="seconds">Seconds</param>
+		/// <returns>Period string</returns>
+		string PeriodSecondsToString(int seconds);
 
-        #endregion Utility Methods
+		#endregion Utility Methods
 
-        #region REST
+		#region REST
 
-        /// <summary>
-        /// Gets currencies and related data such as IsEnabled and TxFee (if available)
-        /// </summary>
-        /// <returns>Collection of Currencies</returns>
-        Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync();
+		/// <summary>
+		/// Gets currencies and related data such as IsEnabled and TxFee (if available)
+		/// </summary>
+		/// <returns>Collection of Currencies</returns>
+		Task<IReadOnlyDictionary<string, ExchangeCurrency>> GetCurrenciesAsync();
 
-        /// <summary>
-        /// Gets the address to deposit to and applicable details.
-        /// </summary>
-        /// <param name="currency">Currency to get address for.</param>
-        /// <param name="forceRegenerate">True to regenerate the address</param>
-        /// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
-        Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false);
+		/// <summary>
+		/// Gets the address to deposit to and applicable details.
+		/// </summary>
+		/// <param name="currency">Currency to get address for.</param>
+		/// <param name="forceRegenerate">True to regenerate the address</param>
+		/// <returns>Deposit address details (including tag if applicable, such as XRP)</returns>
+		Task<ExchangeDepositDetails> GetDepositAddressAsync(string currency, bool forceRegenerate = false);
 
-        /// <summary>
-        /// Gets the deposit history for a currency
-        /// </summary>
-        /// <param name="currency">The currency to check. May be null.</param>
-        /// <returns>Collection of ExchangeCoinTransfers</returns>
-        Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency);
+		/// <summary>
+		/// Gets the deposit history for a currency
+		/// </summary>
+		/// <param name="currency">The currency to check. May be null.</param>
+		/// <returns>Collection of ExchangeCoinTransfers</returns>
+		Task<IEnumerable<ExchangeTransaction>> GetDepositHistoryAsync(string currency);
 
-        /// <summary>
-        /// Get symbols for the exchange markets
-        /// </summary>
-        /// <returns>Symbols</returns>
-        Task<IEnumerable<string>> GetMarketSymbolsAsync();
+		/// <summary>
+		/// Get symbols for the exchange markets
+		/// </summary>
+		/// <returns>Symbols</returns>
+		Task<IEnumerable<string>> GetMarketSymbolsAsync();
 
-        /// <summary>
-        /// Get exchange market symbols including available metadata such as min trade size and whether the market is active
-        /// </summary>
-        /// <returns>Collection of ExchangeMarkets</returns>
-        Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync();
+		/// <summary>
+		/// Get exchange market symbols including available metadata such as min trade size and whether the market is active
+		/// </summary>
+		/// <returns>Collection of ExchangeMarkets</returns>
+		Task<IEnumerable<ExchangeMarket>> GetMarketSymbolsMetadataAsync();
 
-        /// <summary>
-        /// Get latest ticker
-        /// </summary>
-        /// <param name="marketSymbol">Symbol</param>
-        /// <returns>Latest ticker</returns>
-        Task<ExchangeTicker> GetTickerAsync(string marketSymbol);
+		/// <summary>
+		/// Get latest ticker
+		/// </summary>
+		/// <param name="marketSymbol">Symbol</param>
+		/// <returns>Latest ticker</returns>
+		Task<ExchangeTicker> GetTickerAsync(string marketSymbol);
 
-        /// <summary>
-        /// Get all tickers, not all exchanges support this
-        /// </summary>
-        /// <returns>Key value pair of symbol and tickers array</returns>
-        Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync();
+		/// <summary>
+		/// Get all tickers, not all exchanges support this
+		/// </summary>
+		/// <returns>Key value pair of symbol and tickers array</returns>
+		Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> GetTickersAsync();
 
-        /// <summary>
-        /// Get historical trades for the exchange
-        /// </summary>
-        /// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
-        /// <param name="marketSymbol">Symbol to get historical data for</param>
-        /// <param name="startDate">Optional start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        /// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
-        Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null);
+		/// <summary>
+		/// Get historical trades for the exchange
+		/// </summary>
+		/// <param name="callback">Callback for each set of trades. Return false to stop getting trades immediately.</param>
+		/// <param name="marketSymbol">Symbol to get historical data for</param>
+		/// <param name="startDate">Optional start date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
+		/// <param name="endDate">Optional UTC end date time to start getting the historical data at, null for the most recent data. Not all exchanges support this.</param>
+		Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null);
 		//Task GetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null);
 
-        /// <summary>
-        /// Get the latest trades
-        /// </summary>
-        /// <param name="marketSymbol">Market Symbol</param>
-        /// <returns>Trades</returns>
-        Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol, int? limit = null);
+		/// <summary>
+		/// Get the latest trades
+		/// </summary>
+		/// <param name="marketSymbol">Market Symbol</param>
+		/// <returns>Trades</returns>
+		Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol, int? limit = null);
 		//Task<IEnumerable<ExchangeTrade>> GetRecentTradesAsync(string marketSymbol);
 
 		/// <summary>
@@ -145,123 +145,123 @@ namespace ExchangeSharp
 		/// <returns>Candles</returns>
 		Task<IEnumerable<MarketCandle>> GetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null);
 
-        /// <summary>
-        /// Get total amounts, symbol / amount dictionary
-        /// </summary>
-        /// <returns>Dictionary of symbols and amounts</returns>
-        Task<Dictionary<string, decimal>> GetAmountsAsync();
+		/// <summary>
+		/// Get total amounts, symbol / amount dictionary
+		/// </summary>
+		/// <returns>Dictionary of symbols and amounts</returns>
+		Task<Dictionary<string, decimal>> GetAmountsAsync();
 
-        /// <summary>
-        /// Get amounts available to trade, symbol / amount dictionary
-        /// </summary>
-        /// <returns>Dictionary of symbols and amounts available to trade</returns>
-        Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync();
+		/// <summary>
+		/// Get amounts available to trade, symbol / amount dictionary
+		/// </summary>
+		/// <returns>Dictionary of symbols and amounts available to trade</returns>
+		Task<Dictionary<string, decimal>> GetAmountsAvailableToTradeAsync();
 
-        /// <summary>
-        /// Place an order
-        /// </summary>
-        /// <param name="order">Order request</param>
-        /// <returns>Order result and message string if any</returns>
-        Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order);
+		/// <summary>
+		/// Place an order
+		/// </summary>
+		/// <param name="order">Order request</param>
+		/// <returns>Order result and message string if any</returns>
+		Task<ExchangeOrderResult> PlaceOrderAsync(ExchangeOrderRequest order);
 
-        /// <summary>
-        /// Place bulk orders
-        /// </summary>
-        /// <param name="orders">Order requests</param>
-        /// <returns>Order results, each result matches up with each order in index</returns>
-        Task<ExchangeOrderResult[]> PlaceOrdersAsync(params ExchangeOrderRequest[] orders);
+		/// <summary>
+		/// Place bulk orders
+		/// </summary>
+		/// <param name="orders">Order requests</param>
+		/// <returns>Order results, each result matches up with each order in index</returns>
+		Task<ExchangeOrderResult[]> PlaceOrdersAsync(params ExchangeOrderRequest[] orders);
 
-        /// <summary>
-        /// Get details of an order
-        /// </summary>
-        /// <param name="orderId">order id</param>
-        /// <param name="marketSymbol">Market Symbol</param>
-        /// <returns>Order details</returns>
-        Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string? marketSymbol = null);
+		/// <summary>
+		/// Get details of an order
+		/// </summary>
+		/// <param name="orderId">order id</param>
+		/// <param name="marketSymbol">Market Symbol</param>
+		/// <returns>Order details</returns>
+		Task<ExchangeOrderResult> GetOrderDetailsAsync(string orderId, string? marketSymbol = null);
 
-        /// <summary>
-        /// Get the details of all open orders
-        /// </summary>
-        /// <param name="marketSymbol">Market symbol to get open orders for or null for all</param>
-        /// <returns>All open order details for the specified symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string? marketSymbol = null);
+		/// <summary>
+		/// Get the details of all open orders
+		/// </summary>
+		/// <param name="marketSymbol">Market symbol to get open orders for or null for all</param>
+		/// <returns>All open order details for the specified symbol</returns>
+		Task<IEnumerable<ExchangeOrderResult>> GetOpenOrderDetailsAsync(string? marketSymbol = null);
 
-        /// <summary>
-        /// Get the details of all completed orders
-        /// </summary>
-        /// <param name="marketSymbol">Market symbol to get completed orders for or null for all</param>
-        /// <param name="afterDate">Only returns orders on or after the specified date/time</param>
-        /// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
-        Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null);
+		/// <summary>
+		/// Get the details of all completed orders
+		/// </summary>
+		/// <param name="marketSymbol">Market symbol to get completed orders for or null for all</param>
+		/// <param name="afterDate">Only returns orders on or after the specified date/time</param>
+		/// <returns>All completed order details for the specified symbol, or all if null symbol</returns>
+		Task<IEnumerable<ExchangeOrderResult>> GetCompletedOrderDetailsAsync(string? marketSymbol = null, DateTime? afterDate = null);
 
-        /// <summary>
-        /// Cancel an order, an exception is thrown if failure
-        /// </summary>
-        /// <param name="orderId">Order id of the order to cancel</param>
-        /// <param name="marketSymbol">Market symbol of the order to cancel (not required for most exchanges)</param>
-        Task CancelOrderAsync(string orderId, string? marketSymbol = null);
+		/// <summary>
+		/// Cancel an order, an exception is thrown if failure
+		/// </summary>
+		/// <param name="orderId">Order id of the order to cancel</param>
+		/// <param name="marketSymbol">Market symbol of the order to cancel (not required for most exchanges)</param>
+		Task CancelOrderAsync(string orderId, string? marketSymbol = null);
 
-        /// <summary>
-        /// Get margin amounts available to trade, symbol / amount dictionary
-        /// </summary>
-        /// <param name="includeZeroBalances">Include currencies with zero balance in return value</param>
-        /// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
-        Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances = false);
+		/// <summary>
+		/// Get margin amounts available to trade, symbol / amount dictionary
+		/// </summary>
+		/// <param name="includeZeroBalances">Include currencies with zero balance in return value</param>
+		/// <returns>Dictionary of symbols and amounts available to trade in margin account</returns>
+		Task<Dictionary<string, decimal>> GetMarginAmountsAvailableToTradeAsync(bool includeZeroBalances = false);
 
-        /// <summary>
-        /// Get open margin position
-        /// </summary>
-        /// <param name="marketSymbol">Market Symbol</param>
-        /// <returns>Open margin position result</returns>
-        Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol);
+		/// <summary>
+		/// Get open margin position
+		/// </summary>
+		/// <param name="marketSymbol">Market Symbol</param>
+		/// <returns>Open margin position result</returns>
+		Task<ExchangeMarginPositionResult> GetOpenPositionAsync(string marketSymbol);
 
-        /// <summary>
-        /// Close a margin position
-        /// </summary>
-        /// <param name="marketSymbol">Market Symbol</param>
-        /// <returns>Close margin position result</returns>
-        Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol);
-         
-        /// <summary>
-        /// Get fees
-        /// </summary>
-        /// <returns>The customer trading fees</returns>
-        Task<Dictionary<string, decimal>> GetFeesAync();
+		/// <summary>
+		/// Close a margin position
+		/// </summary>
+		/// <param name="marketSymbol">Market Symbol</param>
+		/// <returns>Close margin position result</returns>
+		Task<ExchangeCloseMarginPositionResult> CloseMarginPositionAsync(string marketSymbol);
 
-        #endregion REST
+		/// <summary>
+		/// Get fees
+		/// </summary>
+		/// <returns>The customer trading fees</returns>
+		Task<Dictionary<string, decimal>> GetFeesAync();
 
-        #region Web Socket
+		#endregion REST
 
-        /// <summary>
-        /// Get all tickers via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <param name="symbols">Symbols. If no symbols are specified, this will get the tickers for all symbols. NOTE: Some exchanges don't allow you to specify which symbols to return.</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        Task<IWebSocket> GetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] symbols);
+		#region Web Socket
 
-        /// <summary>
-        /// Get information about trades via web socket
-        /// </summary>
-        /// <param name="callback">Callback (symbol and trade)</param>
-        /// <param name="marketSymbols">Market symbols</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        Task<IWebSocket> GetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols);
+		/// <summary>
+		/// Get all tickers via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <param name="symbols">Symbols. If no symbols are specified, this will get the tickers for all symbols. NOTE: Some exchanges don't allow you to specify which symbols to return.</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		Task<IWebSocket> GetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] symbols);
 
-        /// <summary>
-        /// Get the details of all changed orders via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        Task<IWebSocket> GetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback);
+		/// <summary>
+		/// Get information about trades via web socket
+		/// </summary>
+		/// <param name="callback">Callback (symbol and trade)</param>
+		/// <param name="marketSymbols">Market symbols</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		Task<IWebSocket> GetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols);
 
-        /// <summary>
-        /// Get the details of all completed orders via web socket
-        /// </summary>
-        /// <param name="callback">Callback</param>
-        /// <returns>Web socket, call Dispose to close</returns>
-        Task<IWebSocket> GetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback);
+		/// <summary>
+		/// Get the details of all changed orders via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		Task<IWebSocket> GetOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback);
 
-        #endregion Web Socket
-    }
+		/// <summary>
+		/// Get the details of all completed orders via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		Task<IWebSocket> GetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback);
+
+		#endregion Web Socket
+	}
 }

--- a/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -98,6 +98,12 @@ namespace ExchangeSharp
 		Task<IEnumerable<string>> GetMarketSymbolsAsync();
 
 		/// <summary>
+		/// Get WebSocket symbols for the exchange markets
+		/// </summary>
+		/// <returns>Symbols</returns>
+		Task<IEnumerable<string>> GetMarketSymbolsAsync(bool isWebSocket = false);
+
+		/// <summary>
 		/// Get exchange market symbols including available metadata such as min trade size and whether the market is active
 		/// </summary>
 		/// <returns>Collection of ExchangeMarkets</returns>

--- a/src/ExchangeSharpConsole/Options/BaseOption.cs
+++ b/src/ExchangeSharpConsole/Options/BaseOption.cs
@@ -26,7 +26,7 @@ namespace ExchangeSharpConsole.Options
 				return;
 			}
 
-			using (var proc = Process.GetCurrentProcess())
+			using(var proc = Process.GetCurrentProcess())
 			{
 				Console.Error.WriteLine($"Connect debugger to PID: {proc.Id}.");
 				Console.Error.WriteLine("Waiting...");
@@ -166,17 +166,15 @@ namespace ExchangeSharpConsole.Options
 			}
 		}
 
-
 		/// <summary>
 		/// Makes the app keep running after main thread has exited
 		/// </summary>
 		/// <param name="callback">A callback for when the user press CTRL-C or Q</param>
-		protected static IDisposable KeepSessionAlive(Action callback = null)
-			=> new ConsoleSessionKeeper(callback);
+		protected static IDisposable KeepSessionAlive(Action callback = null) => new ConsoleSessionKeeper(callback);
 
-		protected static async Task<string[]> ValidateMarketSymbolsAsync(IExchangeAPI api, string[] marketSymbols)
+		protected static async Task<string[]> ValidateMarketSymbolsAsync(IExchangeAPI api, string[] marketSymbols, bool isWebSocket = false)
 		{
-			var apiSymbols = (await api.GetMarketSymbolsAsync()).ToArray();
+			var apiSymbols = (await api.GetMarketSymbolsAsync(isWebSocket)).ToArray();
 
 			if (marketSymbols is null || marketSymbols.Length == 0)
 			{
@@ -209,8 +207,8 @@ namespace ExchangeSharpConsole.Options
 				var validSymbols = string.Join(",", apiSymbols.OrderBy(s => s));
 
 				throw new ArgumentException(
-					$"Symbol {marketSymbol} does not exist in API {api.Name}.\n" +
-					$"Valid symbols: {validSymbols}"
+					$"Symbol {marketSymbol} does not exist in API {api.Name}.\n"
+					+ $"Valid symbols: {validSymbols}"
 				);
 			}
 		}
@@ -230,10 +228,10 @@ namespace ExchangeSharpConsole.Options
 
 			for (var i = 0; i < length; i++)
 			{
-				var (_, ask) = orderBook.Asks.ElementAtOrDefault(i);
-				var (_, bid) = orderBook.Bids.ElementAtOrDefault(i);
-				Console.WriteLine($"{bid.Price,10} ({bid.Amount,9:N2}) | " +
-				                  $"{ask.Price,10} ({ask.Amount,9:N})");
+				var(_, ask) = orderBook.Asks.ElementAtOrDefault(i);
+				var(_, bid) = orderBook.Bids.ElementAtOrDefault(i);
+				Console.WriteLine($"{bid.Price,10} ({bid.Amount,9:N2}) | "
+					+ $"{ask.Price,10} ({ask.Amount,9:N})");
 			}
 		}
 	}

--- a/src/ExchangeSharpConsole/Options/WebSocketsOrderbookOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsOrderbookOption.cs
@@ -9,19 +9,19 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("ws-orderbook", HelpText =
-		"Connects to the given exchange websocket and keeps printing the first bid and ask prices and amounts for the given market symbols." +
-		"If market symbol is not set then uses all.")]
+		"Connects to the given exchange websocket and keeps printing the first bid and ask prices and amounts for the given market symbols."
+		+ "If market symbol is not set then uses all.")]
 	public class WebSocketsOrderbookOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol
 	{
 		public override async Task RunCommand()
 		{
 			async Task<IWebSocket> GetWebSocket(IExchangeAPI api)
 			{
-				var symbols = await ValidateMarketSymbolsAsync(api, MarketSymbols.ToArray());
+				var symbols = await ValidateMarketSymbolsAsync(api, MarketSymbols.ToArray(), true);
 
 				return await api.GetFullOrderBookWebSocketAsync(
 					OrderBookCallback,
-					symbols: symbols
+					symbols : symbols
 				);
 			}
 
@@ -30,13 +30,13 @@ namespace ExchangeSharpConsole.Options
 
 		private static void OrderBookCallback(ExchangeOrderBook msg)
 		{
-			var (_, bid) = msg.Bids.FirstOrDefault();
-			var (_, ask) = msg.Asks.FirstOrDefault();
+			var(_, bid) = msg.Bids.FirstOrDefault();
+			var(_, ask) = msg.Asks.FirstOrDefault();
 
 			Console.WriteLine(
-				$"[{msg.MarketSymbol,-8}:{msg.SequenceId,10}] " +
-				$"{bid.Price,10} ({bid.Amount,9:N2}) | " +
-				$"{ask.Price,10} ({ask.Amount,9:N})"
+				$"[{msg.MarketSymbol,-8}:{msg.SequenceId,10}] "
+				+ $"{bid.Price,10} ({bid.Amount,9:N2}) | "
+				+ $"{ask.Price,10} ({ask.Amount,9:N})"
 			);
 		}
 


### PR DESCRIPTION
@jjxtra 
There is some code formatting changes in this diff to move these files to tabs for indention. That's mainly in the first commit.

Biggest change here is adding `isWebSocket` overload parameter to the `GetMarketSymbolsAsync(bool isWebSocket = false);` and `OnGetMarketSymbolsAsync(bool isWebSocket = false)` methods. This was needed because Kraken's WebSocket symbols are different from the REST API symbols :roll_eyes:. `ETHDAI` vs. `ETH/DAI`

You had added some support for Gemini `ws-orderbook`, but it wasn't updating. Similar to the `ws-ticker` issue we exchanged emails about. That's fix now.