### PR TITLE
Add ExchangeKrakenAPI.OnGetCandlesWebSocketAsync implementation

### DIFF
--- a/src/ExchangeSharp/API/Common/APIRequestMaker.cs
+++ b/src/ExchangeSharp/API/Common/APIRequestMaker.cs
@@ -216,7 +216,7 @@ namespace ExchangeSharp
                 using (StreamReader responseStreamReader = new StreamReader(responseStream))
                     responseString = responseStreamReader.ReadToEnd();
 
-                if (response.StatusCode != HttpStatusCode.OK)
+                if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Created)
                 {
 	                // 404 maybe return empty responseString
 	                if (string.IsNullOrWhiteSpace(responseString))

--- a/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -252,7 +252,25 @@ namespace ExchangeSharp
 		#region OrderBooks
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 25)
 		{
-			JToken token = await MakeJsonRequestAsync<JToken>("/markets/" + marketSymbol + "/orderbook" + marketSymbol + "&depth=" + maxCount);
+			// Bittrex API allowed values are [1, 25, 500], default is 25.
+			if (maxCount > 100)
+			{
+				maxCount = 500;
+			}
+			else if (maxCount > 25 && maxCount <= 100) // ExchangeSharp default.
+			{
+				maxCount = 25;
+			}
+			else if (maxCount > 1 && maxCount <= 25)
+			{
+				maxCount = 25;
+			}
+			else
+			{
+				maxCount = 1;
+			}
+
+			JToken token = await MakeJsonRequestAsync<JToken>("/markets/" + marketSymbol + "/orderbook" + "?depth=" + maxCount);
 			return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, "ask", "bid", "rate", "quantity", maxCount: maxCount);
 		}
 
@@ -370,7 +388,7 @@ namespace ExchangeSharp
 			if (order.OrderType == ExchangeSharp.OrderType.Limit)
 			{
 				orderParams.Add("limit", orderPrice);
-				//orderParams.Add("timeInForce", "GOOD_TIL_CANCELLED");
+				orderParams.Add("timeInForce", "GOOD_TIL_CANCELLED");
 			}
 
 			foreach (KeyValuePair<string, object> kv in order.ExtraParameters)

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -843,6 +843,51 @@ namespace ExchangeSharp
 			await MakeJsonRequestAsync<JToken>("/0/private/CancelOrder", null, payload);
 		}
 
+		protected override async Task<IWebSocket> OnGetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols)
+		{
+			if (marketSymbols == null || marketSymbols.Length == 0)
+			{
+				marketSymbols = (await GetMarketSymbolsAsync(true)).ToArray();
+			}
+			//kraken has multiple OHLC channels named ohlc-1|5|15|30|60|240|1440|10080|21600 with interval specified in minutes
+			int interval = periodSeconds / 60;
+
+			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
+			{
+				/*
+				https://docs.kraken.com/websockets/#message-ohlc
+				[0]channelID integer Channel ID of subscription -deprecated, use channelName and pair
+				[1]Array array
+				-time    decimal Begin time of interval, in seconds since epoch
+				-etime   decimal End time of interval, in seconds since epoch
+				-open    decimal Open price of interval
+				-high    decimal High price within interval
+				-low decimal Low price within interval
+				-close   decimal Close price of interval
+				-vwap    decimal Volume weighted average price within interval
+				-volume  decimal Accumulated volume within interval
+				-count   integer Number of trades within interval
+				[2]channelName string Channel Name of subscription
+				[3]pair    string Asset pair
+				*/
+				if (JToken.Parse(msg.ToStringFromUTF8()) is JArray token && token[2].ToStringInvariant() == ($"ohlc-{interval}"))
+				{
+					string marketSymbol = token[3].ToStringInvariant();
+					var candle = this.ParseCandle(token[1], marketSymbol, interval * 60, 2, 3, 4, 5, 0, TimestampType.UnixSeconds, 7, null, 6);
+					await callbackAsync(candle);
+				}
+			}, connectCallback: async (_socket) =>
+			{
+				List<string> marketSymbolList = await GetMarketSymbolList(marketSymbols);
+				await _socket.SendMessageAsync(new
+				{
+					@event = "subscribe",
+					pair = marketSymbolList,
+					subscription = new { name = "ohlc", interval = interval }
+				});
+			});
+		}
+
 		protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols)
 		{
 			if (marketSymbols == null || marketSymbols.Length == 0)
@@ -850,23 +895,23 @@ namespace ExchangeSharp
 				marketSymbols = (await GetMarketSymbolsAsync(true)).ToArray();
 			}
 			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
-		   {
-			   if (JToken.Parse(msg.ToStringFromUTF8()) is JArray token)
-			   {
-				   var exchangeTicker = await ConvertToExchangeTickerAsync(token[3].ToString(), token[1]);
-				   var kv = new KeyValuePair<string, ExchangeTicker>(exchangeTicker.MarketSymbol, exchangeTicker);
-				   tickers(new List<KeyValuePair<string, ExchangeTicker>> { kv });
-			   }
-		   }, connectCallback: async (_socket) =>
-		   {
-			   List<string> marketSymbolList = await GetMarketSymbolList(marketSymbols);
-			   await _socket.SendMessageAsync(new
-			   {
-				   @event = "subscribe",
-				   pair = marketSymbolList,
-				   subscription = new { name = "ticker" }
-			   });
-		   });
+			{
+				if (JToken.Parse(msg.ToStringFromUTF8()) is JArray token)
+				{
+					var exchangeTicker = await ConvertToExchangeTickerAsync(token[3].ToString(), token[1]);
+					var kv = new KeyValuePair<string, ExchangeTicker>(exchangeTicker.MarketSymbol, exchangeTicker);
+					tickers(new List<KeyValuePair<string, ExchangeTicker>> { kv });
+				}
+			}, connectCallback: async (_socket) =>
+			{
+				List<string> marketSymbolList = await GetMarketSymbolList(marketSymbols);
+				await _socket.SendMessageAsync(new
+				{
+					@event = "subscribe",
+					pair = marketSymbolList,
+					subscription = new { name = "ticker" }
+				});
+			});
 		}
 
 		protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -749,13 +749,17 @@ namespace ExchangeSharp
 
 		protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
 		{
+			IEnumerable<ExchangeMarket> markets = await OnGetMarketSymbolsMetadataAsync();
+			ExchangeMarket market = markets.Where(m => m.MarketSymbol == order.MarketSymbol).First<ExchangeMarket>();
+
 			object nonce = await GenerateNonceAsync();
 			Dictionary<string, object> payload = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
 			{ { "pair", order.MarketSymbol }, { "type", (order.IsBuy ? "buy" : "sell") }, { "ordertype", order.OrderType.ToString().ToLowerInvariant() }, { "volume", order.RoundAmount().ToStringInvariant() }, { "trading_agreement", "agree" }, { "nonce", nonce }
 			};
 			if (order.OrderType != OrderType.Market)
 			{
-				payload.Add("price", order.Price.ToStringInvariant());
+				int precision = BitConverter.GetBytes(Decimal.GetBits((decimal)market.PriceStepSize)[3])[2];
+				payload.Add("price", Math.Round(order.Price, precision).ToStringInvariant());
 			}
 			order.ExtraParameters.CopyTo(payload);
 

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -873,6 +873,8 @@ namespace ExchangeSharp
 				if (JToken.Parse(msg.ToStringFromUTF8()) is JArray token && token[2].ToStringInvariant() == ($"ohlc-{interval}"))
 				{
 					string marketSymbol = token[3].ToStringInvariant();
+					//Kraken updates the candle open time to the current time, but we want it as open-time i.e. close-time - interval
+					token[1][0] = token[1][1].ConvertInvariant<long>() - interval * 60;
 					var candle = this.ParseCandle(token[1], marketSymbol, interval * 60, 2, 3, 4, 5, 0, TimestampType.UnixSeconds, 7, null, 6);
 					await callbackAsync(candle);
 				}

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -178,7 +178,7 @@ namespace ExchangeSharp
 			throw new NotImplementedException();
 		protected virtual Task<ExchangeCloseMarginPositionResult> OnCloseMarginPositionAsync(string marketSymbol) =>
 			throw new NotImplementedException();
-		protected virtual Task<IWebSocket> OnGetCandlesWebSocketAsync(Func<IReadOnlyCollection<MarketCandle>, Task> callbackAsync, params string[] marketSymbols) =>
+		protected virtual Task<IWebSocket> OnGetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols) =>
 			throw new NotImplementedException();
 		protected virtual Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols) =>
 			throw new NotImplementedException();
@@ -1005,10 +1005,10 @@ namespace ExchangeSharp
 		/// <param name="callbackAsync">Callback</param>
 		/// <param name="marketSymbols">Market Symbols</param>
 		/// <returns>Web socket, call Dispose to close</returns>
-		public virtual Task<IWebSocket> GetCandlesWebSocketAsync(Func<IReadOnlyCollection<MarketCandle>, Task> callbackAsync, params string[] marketSymbols)
+		public virtual Task<IWebSocket> GetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols)
 		{
 			callbackAsync.ThrowIfNull(nameof(callbackAsync), "Callback must not be null");
-			return OnGetCandlesWebSocketAsync(callbackAsync, marketSymbols);
+			return OnGetCandlesWebSocketAsync(callbackAsync, periodSeconds, marketSymbols);
 		}
 
 		/// <summary>

--- a/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -241,9 +241,10 @@ namespace ExchangeSharp
 		/// Gets Candles (OHLC) websocket
 		/// </summary>
 		/// <param name="callbackAsync">Callback</param>
+		/// <param name="periodSeconds">Candle interval in seconds</param>
 		/// <param name="marketSymbols">Market Symbols</param>
 		/// <returns>Web socket, call Dispose to close</returns>
-		Task<IWebSocket> GetCandlesWebSocketAsync(Func<IReadOnlyCollection<MarketCandle>, Task> callbackAsync, params string[] marketSymbols);
+		Task<IWebSocket> GetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols);
 
 		/// <summary>
 		/// Get all tickers via web socket

--- a/src/ExchangeSharp/Traders/MovingAverageCalculator.cs
+++ b/src/ExchangeSharp/Traders/MovingAverageCalculator.cs
@@ -30,6 +30,9 @@ namespace ExchangeSharp
         protected T _previousMovingAverage;
         protected T _previousExponentialMovingAverage;
 
+        public int WindowSize => _windowSize;
+
+        public T WeightingMultiplier => _weightingMultiplier;
         /// <summary>
         /// Current moving average
         /// </summary>
@@ -57,6 +60,17 @@ namespace ExchangeSharp
         public override string ToString()
         {
             return string.Format("{0}:{1}, {2}:{3}", MovingAverage, Slope, ExponentialMovingAverage, ExponentialSlope);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether enough values have been provided to fill the
+        /// specified window size.  Values returned from NextValue may still be used prior
+        /// to IsMature returning true, however such values are not subject to the intended
+        /// smoothing effect of the moving average's window size.
+        /// </summary>
+        public bool IsMature
+        {
+            get { return _valuesIn == _windowSize; }
         }
     }
 
@@ -124,17 +138,6 @@ namespace ExchangeSharp
                 ExponentialSlope = 0.0;
                 _previousExponentialMovingAverage = ExponentialMovingAverage;
             }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether enough values have been provided to fill the
-        /// specified window size.  Values returned from NextValue may still be used prior
-        /// to IsMature returning true, however such values are not subject to the intended
-        /// smoothing effect of the moving average's window size.
-        /// </summary>
-        public bool IsMature
-        {
-            get { return _valuesIn == _windowSize; }
         }
 
         /// <summary>

--- a/src/ExchangeSharpConsole/Options/CandlesOption.cs
+++ b/src/ExchangeSharpConsole/Options/CandlesOption.cs
@@ -7,7 +7,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("candles", HelpText = "Prints all candle data from a 12 days period for the given exchange.")]
-	public class CandlesOption : BaseOption, IOptionPerExchange, IOptionPerMarketSymbol
+	public class CandlesOption : BaseOption, IOptionPerExchange, IOptionPerMarketSymbol, IOptionWithPeriod
 	{
 		public override async Task RunCommand()
 		{
@@ -15,7 +15,7 @@ namespace ExchangeSharpConsole.Options
 
 			var candles = await api.GetCandlesAsync(
 				MarketSymbol,
-				1800,
+				Period,
 				//TODO: Add interfaces for start and end date
 				CryptoUtility.UtcNow.AddDays(-12),
 				CryptoUtility.UtcNow
@@ -32,5 +32,7 @@ namespace ExchangeSharpConsole.Options
 		public string ExchangeName { get; set; }
 
 		public string MarketSymbol { get; set; }
+
+		public int Period { get; set; }
 	}
 }

--- a/src/ExchangeSharpConsole/Options/Interfaces/IOptionWithPeriod.cs
+++ b/src/ExchangeSharpConsole/Options/Interfaces/IOptionWithPeriod.cs
@@ -1,0 +1,11 @@
+using CommandLine;
+
+namespace ExchangeSharpConsole.Options.Interfaces
+{
+	public interface IOptionWithPeriod
+	{
+		[Option('p', "period", Default = 1800,
+			HelpText = "Period in seconds.")]
+		int Period { get; set; }
+	}
+}

--- a/src/ExchangeSharpConsole/Options/WebSocketsCandesOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsCandesOption.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using ExchangeSharp;
+using ExchangeSharpConsole.Options.Interfaces;
+
+namespace ExchangeSharpConsole.Options
+{
+	[Verb("ws-candles", HelpText =
+		"Connects to the given exchange websocket and keeps printing the candles from that exchange." +
+		"If market symbol is not set then uses all.")]
+	public class WebSocketsCandlesOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol, IOptionWithPeriod
+	{
+		public override async Task RunCommand()
+		{
+			async Task<IWebSocket> GetWebSocket(IExchangeAPI api)
+			{
+				var symbols = await ValidateMarketSymbolsAsync(api, MarketSymbols.ToArray(), true);
+
+				return await api.GetCandlesWebSocketAsync(candle =>
+				{
+					Console.WriteLine($"Market {candle.Name,8}: {candle}");
+					return Task.CompletedTask;
+				},
+				Period,
+				symbols
+				);
+			}
+
+			await RunWebSocket(ExchangeName, GetWebSocket);
+		}
+
+		public string ExchangeName { get; set; }
+
+		public IEnumerable<string> MarketSymbols { get; set; }
+
+		public int Period { get; set; }
+	}
+}

--- a/src/ExchangeSharpConsole/Program.cs
+++ b/src/ExchangeSharpConsole/Program.cs
@@ -35,7 +35,8 @@ namespace ExchangeSharpConsole
 			typeof(TradeHistoryOption),
 			typeof(WebSocketsOrderbookOption),
 			typeof(WebSocketsTickersOption),
-			typeof(WebSocketsTradesOption)
+			typeof(WebSocketsTradesOption),
+			typeof(WebSocketsCandlesOption)
 		};
 
 		public Program()


### PR DESCRIPTION
1. The kraken API (https://docs.kraken.com/websockets/#message-ohlc) actually only sends one candle at a time, not an array of candles, so I changed the interface accordingly
2. The API also requires the candle interval parameter which is part of the channel name, so this was also added to the interface
3. Provided an implementation for Kraken exchange. There is one quirk* mentioned below
4. Added ws-candles to ExchangeSharpConsole. Also added a `IOptionWithPeriod` so the candle interval can be specified on commandline - and applied this to the REST-based CandlesOption with the same default value of 1800


I'm not sure if we have formal tests but I tested from the console app and all looked good except for:

*Note that Kraken sends updates to the current candle when there are new trades, and when it does the open-time is the current time, i.e. the open time changes over the life-time of the candle but the close-time does not. Current implementation passes open-time to `ParseCandle` extension method as `MarketCandle.TimeStamp` is specified as the open time of the OHLC candle. So you'll see candle updates with new candle timestamp come through. 
I do not know if this would be consider correct/desired functionality by the community, or if the open-time should be set as `close-time - period` so it is constant? It would be a trivial change to `var candle = this.ParseCandle(token[1], marketSymbol, interval * 60, 2, 3, 4, 5, 0, TimestampType.UnixSeconds, 7, null, 6);` you are welcome to make.

