### PR TITLE
Feature/kraken private websocket support

### DIFF
--- a/src/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/src/ExchangeSharp/API/Common/BaseAPI.cs
@@ -575,6 +575,7 @@ namespace ExchangeSharp
 		/// <param name="url">The sub url for the web socket, or null for none</param>
 		/// <param name="messageCallback">Callback for messages</param>
 		/// <param name="connectCallback">Connect callback</param>
+		/// <param name="textMessageCallback">Text Message callback</param>
 		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
 		public Task<IWebSocket> ConnectPrivateWebSocketAsync
 		(

--- a/src/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/src/ExchangeSharp/API/Common/BaseAPI.cs
@@ -31,687 +31,745 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    /// <summary>
-    /// Type of nonce styles
-    /// </summary>
-    public enum NonceStyle
-    {
-        /// <summary>
-        /// No nonce style
-        /// </summary>
-        None = 0,
+	/// <summary>
+	/// Type of nonce styles
+	/// </summary>
+	public enum NonceStyle
+	{
+		/// <summary>
+		/// No nonce style
+		/// </summary>
+		None = 0,
 
-        /// <summary>
-        /// Ticks (int64)
-        /// </summary>
-        Ticks,
+		/// <summary>
+		/// Ticks (int64)
+		/// </summary>
+		Ticks,
 
-        /// <summary>
-        /// Ticks (string)
-        /// </summary>
-        TicksString,
+		/// <summary>
+		/// Ticks (string)
+		/// </summary>
+		TicksString,
 
-        /// <summary>
-        /// Start with ticks, then increment by one
-        /// </summary>
-        TicksThenIncrement,
+		/// <summary>
+		/// Start with ticks, then increment by one
+		/// </summary>
+		TicksThenIncrement,
 
-        /// <summary>
-        /// Milliseconds (int64)
-        /// </summary>
-        UnixMilliseconds,
+		/// <summary>
+		/// Milliseconds (int64)
+		/// </summary>
+		UnixMilliseconds,
 
-        /// <summary>
-        /// Milliseconds (string)
-        /// </summary>
-        UnixMillisecondsString,
+		/// <summary>
+		/// Milliseconds (string)
+		/// </summary>
+		UnixMillisecondsString,
 
-        /// <summary>
-        /// Start with Unix milliseconds then increment by one
-        /// </summary>
-        UnixMillisecondsThenIncrement,
+		/// <summary>
+		/// Start with Unix milliseconds then increment by one
+		/// </summary>
+		UnixMillisecondsThenIncrement,
 
-        /// <summary>
-        /// Seconds (double)
-        /// </summary>
-        UnixSeconds,
+		/// <summary>
+		/// Seconds (double)
+		/// </summary>
+		UnixSeconds,
 
-        /// <summary>
-        /// Seconds (string)
-        /// </summary>
-        UnixSecondsString,
+		/// <summary>
+		/// Seconds (string)
+		/// </summary>
+		UnixSecondsString,
 
-        /// <summary>
-        /// Persist nonce to counter and file for the API key, once it hits int.MaxValue, it is useless
-        /// </summary>
-        Int32File,
+		/// <summary>
+		/// Persist nonce to counter and file for the API key, once it hits int.MaxValue, it is useless
+		/// </summary>
+		Int32File,
 
-        /// <summary>
-        /// Persist nonce to counter and file for the API key, once it hits long.MaxValue, it is useless
-        /// </summary>
-        Int64File,
+		/// <summary>
+		/// Persist nonce to counter and file for the API key, once it hits long.MaxValue, it is useless
+		/// </summary>
+		Int64File,
 
-        /// <summary>
-        /// No nonce, use expires instead which passes an expires param to the api using the nonce value - duplicate nonce are allowed
-        /// Specify a negative NonceOffset for when you want the call to expire
-        /// </summary>
-        ExpiresUnixSeconds,
+		/// <summary>
+		/// No nonce, use expires instead which passes an expires param to the api using the nonce value - duplicate nonce are allowed
+		/// Specify a negative NonceOffset for when you want the call to expire
+		/// </summary>
+		ExpiresUnixSeconds,
 
-        /// <summary>
-        /// No nonce, use expires instead which passes an expires param to the api using the nonce value - duplicate nonce are allowed
-        /// Specify a negative NonceOffset for when you want the call to expire
-        /// </summary>
-        ExpiresUnixMilliseconds,
+		/// <summary>
+		/// No nonce, use expires instead which passes an expires param to the api using the nonce value - duplicate nonce are allowed
+		/// Specify a negative NonceOffset for when you want the call to expire
+		/// </summary>
+		ExpiresUnixMilliseconds,
 
-        /// <summary>
-        /// An iso-8601 date
-        /// </summary>
-        Iso8601
-    }
+		/// <summary>
+		/// An iso-8601 date
+		/// </summary>
+		Iso8601
+	}
 
-    /// <summary>
-    /// Anything wit ha name
-    /// </summary>
-    public interface INamed
-    {
-        /// <summary>
-        /// The name of the service, exchange, etc.
-        /// </summary>
-        string Name { get; }
-    }
+	/// <summary>
+	/// Anything wit ha name
+	/// </summary>
+	public interface INamed
+	{
+		/// <summary>
+		/// The name of the service, exchange, etc.
+		/// </summary>
+		string Name { get; }
+	}
 
-    /// <summary>
-    /// API base class functionality
-    /// </summary>
-    public abstract class BaseAPI : IAPIRequestHandler, INamed
-    {
-        /// <summary>
-        /// User agent for requests
-        /// </summary>
-        public const string RequestUserAgent = "ExchangeSharp (https://github.com/jjxtra/ExchangeSharp)";
+	/// <summary>
+	/// API base class functionality
+	/// </summary>
+	public abstract class BaseAPI : IAPIRequestHandler, INamed
+	{
+		/// <summary>
+		/// User agent for requests
+		/// </summary>
+		public const string RequestUserAgent = "ExchangeSharp (https://github.com/jjxtra/ExchangeSharp)";
 
-        private IAPIRequestMaker requestMaker;
-        /// <summary>
-        /// API request maker
-        /// </summary>
-        public IAPIRequestMaker RequestMaker
-        {
-            get { return requestMaker; }
-            set { requestMaker = value ?? new APIRequestMaker(this); }
+		private IAPIRequestMaker requestMaker;
+		/// <summary>
+		/// API request maker
+		/// </summary>
+		public IAPIRequestMaker RequestMaker
+		{
+			get { return requestMaker; }
+			set { requestMaker = value ?? new APIRequestMaker(this); }
 
-        }
-        /// <summary>
-        /// Base URL for the API
-        /// </summary>
-        public abstract string BaseUrl { get; set; }
+		}
+		/// <summary>
+		/// Base URL for the API
+		/// </summary>
+		public abstract string BaseUrl { get; set; }
 
-        /// <summary>
-        /// Base URL for the API for web sockets
-        /// </summary>
-        public virtual string BaseUrlWebSocket { get; set; } = string.Empty;
+		/// <summary>
+		/// Base URL for the API for web sockets
+		/// </summary>
+		public virtual string BaseUrlWebSocket { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Gets the name of the API
-        /// </summary>
-        public virtual string Name { get; private set; } = string.Empty;
+		/// <summary>
+		/// Base URL for the private API for web sockets
+		/// </summary>
+		public virtual string BaseUrlPrivateWebSocket { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Public API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
-        /// </summary>
-        public System.Security.SecureString? PublicApiKey { get; set; }
+		/// <summary>
+		/// Gets the name of the API
+		/// </summary>
+		public virtual string Name { get; private set; } = string.Empty;
 
-        /// <summary>
-        /// Private API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
-        /// </summary>
-        public System.Security.SecureString? PrivateApiKey { get; set; }
+		/// <summary>
+		/// Public API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
+		/// </summary>
+		public System.Security.SecureString? PublicApiKey { get; set; }
 
-        /// <summary>
-        /// Pass phrase API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
-        /// Most services do not require this, but Coinbase is an example of one that does
-        /// </summary>
-        public System.Security.SecureString? Passphrase { get; set; }
+		/// <summary>
+		/// Private API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
+		/// </summary>
+		public System.Security.SecureString? PrivateApiKey { get; set; }
 
-        /// <summary>
-        /// Rate limiter - set this to a new limit if you are seeing your ip get blocked by the API
-        /// </summary>
-        public RateGate RateLimit { get; set; } = new RateGate(5, TimeSpan.FromSeconds(15.0d));
+		/// <summary>
+		/// Pass phrase API key - only needs to be set if you are using private authenticated end points. Please use CryptoUtility.SaveUnprotectedStringsToFile to store your API keys, never store them in plain text!
+		/// Most services do not require this, but Coinbase is an example of one that does
+		/// </summary>
+		public System.Security.SecureString? Passphrase { get; set; }
 
-        /// <summary>
-        /// Default request method
-        /// </summary>
-        public string RequestMethod { get; set; } = "GET";
+		/// <summary>
+		/// Rate limiter - set this to a new limit if you are seeing your ip get blocked by the API
+		/// </summary>
+		public RateGate RateLimit { get; set; } = new RateGate(5, TimeSpan.FromSeconds(15.0d));
 
-        /// <summary>
-        /// Content type for requests
-        /// </summary>
-        public string RequestContentType { get; set; } = "text/plain";
+		/// <summary>
+		/// Default request method
+		/// </summary>
+		public string RequestMethod { get; set; } = "GET";
 
-        /// <summary>
-        /// Timeout for requests
-        /// </summary>
-        public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30.0);
+		/// <summary>
+		/// Content type for requests
+		/// </summary>
+		public string RequestContentType { get; set; } = "text/plain";
 
-        /// <summary>
-        /// Request window - most services do not use this, but Binance API is an example of one that does
-        /// </summary>
-        public TimeSpan RequestWindow { get; set; } = TimeSpan.Zero;
+		/// <summary>
+		/// Timeout for requests
+		/// </summary>
+		public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(30.0);
 
-        /// <summary>
-        /// Type of nonce
-        /// </summary>
-        public NonceStyle NonceStyle { get; protected set; } = NonceStyle.Ticks;
+		/// <summary>
+		/// Request window - most services do not use this, but Binance API is an example of one that does
+		/// </summary>
+		public TimeSpan RequestWindow { get; set; } = TimeSpan.Zero;
 
-        /// <summary>
-        /// Offset for nonce calculation, some exchanges like Binance have a problem with requests being in the future, so you can offset the current DateTime with this
-        /// </summary>
-        public TimeSpan NonceOffset { get; set; }
+		/// <summary>
+		/// Type of nonce
+		/// </summary>
+		public NonceStyle NonceStyle { get; protected set; } = NonceStyle.Ticks;
 
-        /// <summary>
-        /// The nonce end point for pulling down a server timestamp - override OnGetNonceOffset if you need custom handling
-        /// </summary>
-        public string? NonceEndPoint { get; protected set; }
+		/// <summary>
+		/// Offset for nonce calculation, some exchanges like Binance have a problem with requests being in the future, so you can offset the current DateTime with this
+		/// </summary>
+		public TimeSpan NonceOffset { get; set; }
 
-        /// <summary>
-        /// The field in the json returned by the nonce end point to parse out - override OnGetNonceOffset if you need custom handling
-        /// </summary>
-        public string? NonceEndPointField { get; protected set; }
+		/// <summary>
+		/// The nonce end point for pulling down a server timestamp - override OnGetNonceOffset if you need custom handling
+		/// </summary>
+		public string? NonceEndPoint { get; protected set; }
 
-        /// <summary>
-        /// The type of value in the nonce end point field - override OnGetNonceOffset if you need custom handling.
-        /// Supported values are Iso8601 and UnixMilliseconds.
-        /// </summary>
-        public NonceStyle NonceEndPointStyle { get; protected set; }
+		/// <summary>
+		/// The field in the json returned by the nonce end point to parse out - override OnGetNonceOffset if you need custom handling
+		/// </summary>
+		public string? NonceEndPointField { get; protected set; }
 
-        /// <summary>
-        /// Cache policy - defaults to no cache, don't change unless you have specific needs
-        /// </summary>
-        public System.Net.Cache.RequestCachePolicy RequestCachePolicy { get; set; } = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore);
+		/// <summary>
+		/// The type of value in the nonce end point field - override OnGetNonceOffset if you need custom handling.
+		/// Supported values are Iso8601 and UnixMilliseconds.
+		/// </summary>
+		public NonceStyle NonceEndPointStyle { get; protected set; }
 
-        /// <summary>
-        /// Method cache policy (method name, time to cache)
-        /// Can be cleared for no caching, or you can put in custom cache times using nameof(method) and timespan.
-        /// </summary>
-        public Dictionary<string, TimeSpan> MethodCachePolicy { get; } = new Dictionary<string, TimeSpan>();
+		/// <summary>
+		/// Cache policy - defaults to no cache, don't change unless you have specific needs
+		/// </summary>
+		public System.Net.Cache.RequestCachePolicy RequestCachePolicy { get; set; } = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore);
 
-        private ICache cache = new MemoryCache();
-        /// <summary>
-        /// Get or set the current cache. Defaults to MemoryCache.
-        /// </summary>
-        public ICache Cache
-        {
-            get { return cache; }
-            set
-            {
-                value.ThrowIfNull(nameof(Cache));
-                cache = value;
-            }
-        }
+		/// <summary>
+		/// Method cache policy (method name, time to cache)
+		/// Can be cleared for no caching, or you can put in custom cache times using nameof(method) and timespan.
+		/// </summary>
+		public Dictionary<string, TimeSpan> MethodCachePolicy { get; } = new Dictionary<string, TimeSpan>();
 
-        private decimal lastNonce;
+		private ICache cache = new MemoryCache();
+		/// <summary>
+		/// Get or set the current cache. Defaults to MemoryCache.
+		/// </summary>
+		public ICache Cache
+		{
+			get { return cache; }
+			set
+			{
+				value.ThrowIfNull(nameof(Cache));
+				cache = value;
+			}
+		}
 
-        private readonly string[] resultKeys = new string[] { "result", "data", "return", "Result", "Data", "Return" };
+		private decimal lastNonce;
 
-        /// <summary>
-        /// Static constructor
-        /// </summary>
-        static BaseAPI()
-        {
+		private readonly string[] resultKeys = new string[] { "result", "data", "return", "Result", "Data", "Return" };
+
+		/// <summary>
+		/// Static constructor
+		/// </summary>
+		static BaseAPI()
+		{
 
 #pragma warning disable CS0618
 
-            try
-            {
+			try
+			{
 
 #if HAS_WINDOWS_FORMS // NET47
 
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.SystemDefault | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
 #else
 
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
 #endif
 
-            }
-            catch
-            {
+			}
+			catch
+			{
 
-            }
+			}
 
 #pragma warning restore CS0618
 
-        }
+		}
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        public BaseAPI()
-        {
-            requestMaker = new APIRequestMaker(this);
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public BaseAPI()
+		{
+			requestMaker = new APIRequestMaker(this);
 
-            string className = GetType().Name;
-            object[] nameAttributes = GetType().GetCustomAttributes(typeof(ApiNameAttribute), true);
-            if (nameAttributes == null || nameAttributes.Length == 0)
-            {
-                Name = Regex.Replace(className, "^Exchange|API$", string.Empty, RegexOptions.CultureInvariant);
-            }
-            else
-            {
-                Name = (nameAttributes[0] as ApiNameAttribute)?.Name ?? string.Empty;
-            }
-        }
+			string className = GetType().Name;
+			object[] nameAttributes = GetType().GetCustomAttributes(typeof(ApiNameAttribute), true);
+			if (nameAttributes == null || nameAttributes.Length == 0)
+			{
+				Name = Regex.Replace(className, "^Exchange|API$", string.Empty, RegexOptions.CultureInvariant);
+			}
+			else
+			{
+				Name = (nameAttributes[0] as ApiNameAttribute)?.Name ?? string.Empty;
+			}
+		}
 
-        /// <summary>
-        /// Generate a nonce
-        /// </summary>
-        /// <returns>Nonce</returns>
-        public async Task<object> GenerateNonceAsync()
-        {
-            await new SynchronizationContextRemover();
+		/// <summary>
+		/// Generate a nonce
+		/// </summary>
+		/// <returns>Nonce</returns>
+		public async Task<object> GenerateNonceAsync()
+		{
+			await new SynchronizationContextRemover();
 
-            if (NonceOffset.Ticks == 0)
-            {
-                await OnGetNonceOffset();
-            }
+			if (NonceOffset.Ticks == 0)
+			{
+				await OnGetNonceOffset();
+			}
 
-            object nonce;
+			object nonce;
 
-            while (true)
-            {
-                lock (this)
-                {
-                    // some API (Binance) have a problem with requests being after server time, subtract of offset can help
-                    DateTime now = CryptoUtility.UtcNow - NonceOffset;
-                    switch (NonceStyle)
-                    {
-                        case NonceStyle.Ticks:
-                            nonce = now.Ticks;
-                            break;
+			while (true)
+			{
+				lock (this)
+				{
+					// some API (Binance) have a problem with requests being after server time, subtract of offset can help
+					DateTime now = CryptoUtility.UtcNow - NonceOffset;
+					switch (NonceStyle)
+					{
+						case NonceStyle.Ticks:
+							nonce = now.Ticks;
+							break;
 
-                        case NonceStyle.TicksString:
-                        case NonceStyle.Iso8601:
-                            nonce = now.Ticks.ToStringInvariant();
-                            break;
+						case NonceStyle.TicksString:
+						case NonceStyle.Iso8601:
+							nonce = now.Ticks.ToStringInvariant();
+							break;
 
-                        case NonceStyle.TicksThenIncrement:
-                            if (lastNonce == 0m)
-                            {
-                                nonce = now.Ticks;
-                            }
-                            else
-                            {
-                                nonce = (long)(lastNonce + 1m);
-                            }
-                            break;
+						case NonceStyle.TicksThenIncrement:
+							if (lastNonce == 0m)
+							{
+								nonce = now.Ticks;
+							}
+							else
+							{
+								nonce = (long)(lastNonce + 1m);
+							}
+							break;
 
-                        case NonceStyle.UnixMilliseconds:
-                            nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
-                            break;
+						case NonceStyle.UnixMilliseconds:
+							nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
+							break;
 
-                        case NonceStyle.UnixMillisecondsString:
-                            nonce = ((long)now.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
-                            break;
+						case NonceStyle.UnixMillisecondsString:
+							nonce = ((long)now.UnixTimestampFromDateTimeMilliseconds()).ToStringInvariant();
+							break;
 
-                        case NonceStyle.UnixMillisecondsThenIncrement:
-                            if (lastNonce == 0m)
-                            {
-                                nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
-                            }
-                            else
-                            {
-                                nonce = (long)(lastNonce + 1m);
-                            }
-                            break;
+						case NonceStyle.UnixMillisecondsThenIncrement:
+							if (lastNonce == 0m)
+							{
+								nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
+							}
+							else
+							{
+								nonce = (long)(lastNonce + 1m);
+							}
+							break;
 
-                        case NonceStyle.UnixSeconds:
-                            nonce = now.UnixTimestampFromDateTimeSeconds();
-                            break;
+						case NonceStyle.UnixSeconds:
+							nonce = now.UnixTimestampFromDateTimeSeconds();
+							break;
 
-                        case NonceStyle.UnixSecondsString:
-                            nonce = now.UnixTimestampFromDateTimeSeconds().ToStringInvariant();
-                            break;
+						case NonceStyle.UnixSecondsString:
+							nonce = now.UnixTimestampFromDateTimeSeconds().ToStringInvariant();
+							break;
 
-                        case NonceStyle.Int32File:
-                        case NonceStyle.Int64File:
-                            {
-                                // why an API would use a persistent incrementing counter for nonce is beyond me, ticks is so much better with a sliding window...
-                                // making it required to increment by 1 is also a pain - especially when restarting a process or rebooting.
-                                string tempFile = Path.Combine(Path.GetTempPath(), (PublicApiKey?.ToUnsecureString() ?? "unknown_pub_key") + ".nonce");
-                                if (!File.Exists(tempFile))
-                                {
-                                    File.WriteAllText(tempFile, "0");
-                                }
-                                unchecked
-                                {
-                                    long longNonce = File.ReadAllText(tempFile).ConvertInvariant<long>() + 1;
-                                    long maxValue = (NonceStyle == NonceStyle.Int32File ? int.MaxValue : long.MaxValue);
-                                    if (longNonce < 1 || longNonce > maxValue)
-                                    {
-                                        throw new APIException($"Nonce {longNonce.ToStringInvariant()} is out of bounds, valid ranges are 1 to {maxValue.ToStringInvariant()}, " +
-                                            $"please regenerate new API keys. Please contact {Name} API support and ask them to change to a sensible nonce algorithm.");
-                                    }
-                                    File.WriteAllText(tempFile, longNonce.ToStringInvariant());
-                                    nonce = longNonce;
-                                }
-                                break;
-                            }
+						case NonceStyle.Int32File:
+						case NonceStyle.Int64File:
+							{
+								// why an API would use a persistent incrementing counter for nonce is beyond me, ticks is so much better with a sliding window...
+								// making it required to increment by 1 is also a pain - especially when restarting a process or rebooting.
+								string tempFile = Path.Combine(Path.GetTempPath(), (PublicApiKey?.ToUnsecureString() ?? "unknown_pub_key") + ".nonce");
+								if (!File.Exists(tempFile))
+								{
+									File.WriteAllText(tempFile, "0");
+								}
+								unchecked
+								{
+									long longNonce = File.ReadAllText(tempFile).ConvertInvariant<long>() + 1;
+									long maxValue = (NonceStyle == NonceStyle.Int32File ? int.MaxValue : long.MaxValue);
+									if (longNonce < 1 || longNonce > maxValue)
+									{
+										throw new APIException($"Nonce {longNonce.ToStringInvariant()} is out of bounds, valid ranges are 1 to {maxValue.ToStringInvariant()}, " +
+											$"please regenerate new API keys. Please contact {Name} API support and ask them to change to a sensible nonce algorithm.");
+									}
+									File.WriteAllText(tempFile, longNonce.ToStringInvariant());
+									nonce = longNonce;
+								}
+								break;
+							}
 
-                        case NonceStyle.ExpiresUnixMilliseconds:
-                            nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
-                            break;
+						case NonceStyle.ExpiresUnixMilliseconds:
+							nonce = (long)now.UnixTimestampFromDateTimeMilliseconds();
+							break;
 
-                        case NonceStyle.ExpiresUnixSeconds:
-                            nonce = (long)now.UnixTimestampFromDateTimeSeconds();
-                            break;
+						case NonceStyle.ExpiresUnixSeconds:
+							nonce = (long)now.UnixTimestampFromDateTimeSeconds();
+							break;
 
-                        default:
-                            throw new InvalidOperationException("Invalid nonce style: " + NonceStyle);
-                    }
+						default:
+							throw new InvalidOperationException("Invalid nonce style: " + NonceStyle);
+					}
 
-                    // check for duplicate nonce
-                    decimal convertedNonce = nonce.ConvertInvariant<decimal>();
-                    if (lastNonce != convertedNonce || NonceStyle == NonceStyle.ExpiresUnixSeconds || NonceStyle == NonceStyle.ExpiresUnixMilliseconds)
-                    {
-                        lastNonce = convertedNonce;
-                        break;
-                    }
-                }
+					// check for duplicate nonce
+					decimal convertedNonce = nonce.ConvertInvariant<decimal>();
+					if (lastNonce != convertedNonce || NonceStyle == NonceStyle.ExpiresUnixSeconds || NonceStyle == NonceStyle.ExpiresUnixMilliseconds)
+					{
+						lastNonce = convertedNonce;
+						break;
+					}
+				}
 
-                // wait 1 millisecond for a new nonce
-                await Task.Delay(1);
-            }
+				// wait 1 millisecond for a new nonce
+				await Task.Delay(1);
+			}
 
-            return nonce;
-        }
+			return nonce;
+		}
 
-        /// <summary>
-        /// Load API keys from an encrypted file - keys will stay encrypted in memory
-        /// </summary>
-        /// <param name="encryptedFile">Encrypted file to load keys from</param>
-        public void LoadAPIKeys(string encryptedFile)
-        {
-	        if (string.IsNullOrWhiteSpace(encryptedFile))
-		        throw new ArgumentNullException(nameof(encryptedFile));
-	        if (!File.Exists(encryptedFile))
-		        throw new ArgumentException("Invalid key file.", nameof(encryptedFile));
+		/// <summary>
+		/// Load API keys from an encrypted file - keys will stay encrypted in memory
+		/// </summary>
+		/// <param name="encryptedFile">Encrypted file to load keys from</param>
+		public void LoadAPIKeys(string encryptedFile)
+		{
+			if (string.IsNullOrWhiteSpace(encryptedFile))
+				throw new ArgumentNullException(nameof(encryptedFile));
+			if (!File.Exists(encryptedFile))
+				throw new ArgumentException("Invalid key file.", nameof(encryptedFile));
 
-	        var strings = CryptoUtility.LoadProtectedStringsFromFile(encryptedFile);
+			var strings = CryptoUtility.LoadProtectedStringsFromFile(encryptedFile);
 
-	        if (strings.Length < 2)
-	        {
-		        throw new InvalidOperationException(
-			        "Encrypted keys file should have at least a public and private key, and an optional pass phrase"
-		        );
-	        }
+			if (strings.Length < 2)
+			{
+				throw new InvalidOperationException(
+					"Encrypted keys file should have at least a public and private key, and an optional pass phrase"
+				);
+			}
 
-	        PublicApiKey = strings[0];
-	        PrivateApiKey = strings[1];
-	        if (strings.Length > 2)
-	        {
-		        Passphrase = strings[2];
-	        }
-        }
+			PublicApiKey = strings[0];
+			PrivateApiKey = strings[1];
+			if (strings.Length > 2)
+			{
+				Passphrase = strings[2];
+			}
+		}
 
-        /// <summary>
-        /// Load API keys from unsecure strings
-        /// </summary>
-        /// <param name="publicApiKey">Public Api Key</param>
-        /// <param name="privateApiKey">Private Api Key</param>
-        /// <param name="passPhrase">Pass phrase, null for none</param>
-        public void LoadAPIKeysUnsecure(string publicApiKey, string privateApiKey, string? passPhrase = null)
-        {
-            PublicApiKey = publicApiKey.ToSecureString();
-            PrivateApiKey = privateApiKey.ToSecureString();
-            Passphrase = passPhrase?.ToSecureString();
-        }
+		/// <summary>
+		/// Load API keys from unsecure strings
+		/// </summary>
+		/// <param name="publicApiKey">Public Api Key</param>
+		/// <param name="privateApiKey">Private Api Key</param>
+		/// <param name="passPhrase">Pass phrase, null for none</param>
+		public void LoadAPIKeysUnsecure(string publicApiKey, string privateApiKey, string? passPhrase = null)
+		{
+			PublicApiKey = publicApiKey.ToSecureString();
+			PrivateApiKey = privateApiKey.ToSecureString();
+			Passphrase = passPhrase?.ToSecureString();
+		}
 
-        /// <summary>
-        /// Make a request to a path on the API
-        /// </summary>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// The encoding of payload is API dependant but is typically json.
-        /// <param name="method">Request method or null for default</param>
-        /// <returns>Raw response</returns>
-        public Task<string> MakeRequestAsync(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? method = null) => requestMaker.MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: method);
+		/// <summary>
+		/// Make a request to a path on the API
+		/// </summary>
+		/// <param name="url">Path and query</param>
+		/// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+		/// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+		/// The encoding of payload is API dependant but is typically json.
+		/// <param name="method">Request method or null for default</param>
+		/// <returns>Raw response</returns>
+		public Task<string> MakeRequestAsync(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? method = null) => requestMaker.MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: method);
 
-        /// <summary>
-        /// Make a JSON request to an API end point
-        /// </summary>
-        /// <typeparam name="T">Type of object to parse JSON as</typeparam>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// <param name="requestMethod">Request method or null for default</param>
-        /// <returns>Result decoded from JSON response</returns>
-        public async Task<T> MakeJsonRequestAsync<T>(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? requestMethod = null)
-        {
-            await new SynchronizationContextRemover();
+		/// <summary>
+		/// Make a JSON request to an API end point
+		/// </summary>
+		/// <typeparam name="T">Type of object to parse JSON as</typeparam>
+		/// <param name="url">Path and query</param>
+		/// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+		/// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+		/// <param name="requestMethod">Request method or null for default</param>
+		/// <returns>Result decoded from JSON response</returns>
+		public async Task<T> MakeJsonRequestAsync<T>(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? requestMethod = null)
+		{
+			await new SynchronizationContextRemover();
 
-            string stringResult = await MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
-            T jsonResult = JsonConvert.DeserializeObject<T>(stringResult);
-            if (jsonResult is JToken token)
-            {
-                return (T)(object)CheckJsonResponse(token);
-            }
-            return jsonResult;
-        }
+			string stringResult = await MakeRequestAsync(url, baseUrl: baseUrl, payload: payload, method: requestMethod);
+			T jsonResult = JsonConvert.DeserializeObject<T>(stringResult);
+			if (jsonResult is JToken token)
+			{
+				return (T)(object)CheckJsonResponse(token);
+			}
+			return jsonResult;
+		}
 
-        /// <summary>
-        /// Connect a web socket to a path on the API and start listening, not all exchanges support this
-        /// </summary>
-        /// <param name="url">The sub url for the web socket, or null for none</param>
-        /// <param name="messageCallback">Callback for messages</param>
-        /// <param name="connectCallback">Connect callback</param>
-        /// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
-        public Task<IWebSocket> ConnectWebSocketAsync
-        (
-            string url,
-            Func<IWebSocket, byte[], Task> messageCallback,
-            WebSocketConnectionDelegate? connectCallback = null,
-            WebSocketConnectionDelegate? disconnectCallback = null
-        )
-        {
-            if (messageCallback == null)
-            {
-                throw new ArgumentNullException(nameof(messageCallback));
-            }
+		/// <summary>
+		/// Connect a web socket to a path on the API and start listening, not all exchanges support this
+		/// </summary>
+		/// <param name="url">The full url for the web socket, or null for none</param>
+		/// <param name="messageCallback">Callback for messages</param>
+		/// <param name="connectCallback">Connect callback</param>
+		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
+		public Task<IWebSocket> ConnectWebSocketAsync
+		(
+			string url,
+			Func<IWebSocket, byte[], Task> messageCallback,
+			WebSocketConnectionDelegate? connectCallback = null,
+			WebSocketConnectionDelegate? disconnectCallback = null
+		)
+		{
+			if (messageCallback == null)
+			{
+				throw new ArgumentNullException(nameof(messageCallback));
+			}
 
-            string fullUrl = BaseUrlWebSocket + (url ?? string.Empty);
-            ExchangeSharp.ClientWebSocket wrapper = new ExchangeSharp.ClientWebSocket
-            {
-                Uri = new Uri(fullUrl),
-                OnBinaryMessage = messageCallback
-            };
-            if (connectCallback != null)
-            {
-                wrapper.Connected += connectCallback;
-            }
-            if (disconnectCallback != null)
-            {
-                wrapper.Disconnected += disconnectCallback;
-            }
-            wrapper.Start();
-            return Task.FromResult<IWebSocket>(wrapper);
-        }
+			ExchangeSharp.ClientWebSocket wrapper = new ExchangeSharp.ClientWebSocket
+			{
+				Uri = new Uri(url),
+				OnBinaryMessage = messageCallback
+			};
 
-        /// <summary>
-        /// Whether the API can make authenticated (private) API requests
-        /// </summary>
-        /// <param name="payload">Payload to potentially send</param>
-        /// <returns>True if an authenticated request can be made with the payload, false otherwise</returns>
-        protected virtual bool CanMakeAuthenticatedRequest(IReadOnlyDictionary<string, object>? payload)
-        {
-            return (PrivateApiKey != null && PublicApiKey != null && payload != null && payload.ContainsKey("nonce"));
-        }
+			if (connectCallback != null)
+			{
+				wrapper.Connected += connectCallback;
+			}
 
-        /// <summary>
-        /// Additional handling for request. This simply returns a completed task and can be used for derived classes
-        /// that do not have an await in their ProcessRequestAsync overload.
-        /// </summary>
-        /// <param name="request">Request</param>
-        /// <param name="payload">Payload</param>
-        protected virtual Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object>? payload)
-        {
-            return Task.CompletedTask;
-        }
+			if (disconnectCallback != null)
+			{
+				wrapper.Disconnected += disconnectCallback;
+			}
 
-        /// <summary>
-        /// Additional handling for response
-        /// </summary>
-        /// <param name="response">Response</param>
-        protected virtual void ProcessResponse(IHttpWebResponse response)
-        {
+			wrapper.Start();
 
-        }
+			return Task.FromResult<IWebSocket>(wrapper);
+		}
 
-        /// <summary>
-        /// Process a request url
-        /// </summary>
-        /// <param name="url">Url</param>
-        /// <param name="payload">Payload</param>
-        /// <param name="method">Method</param>
-        /// <returns>Updated url</returns>
-        protected virtual Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object>? payload, string? method)
-        {
-            return url.Uri;
-        }
+		/// <summary>
+		/// Connect a private web socket to a path on the API and start listening, not all exchanges support this
+		/// </summary>
+		/// <param name="url">The sub url for the web socket, or null for none</param>
+		/// <param name="messageCallback">Callback for messages</param>
+		/// <param name="connectCallback">Connect callback</param>
+		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
+		public Task<IWebSocket> ConnectPublicWebSocketAsync
+		(
+			string url,
+			Func<IWebSocket, byte[], Task> messageCallback,
+			WebSocketConnectionDelegate? connectCallback = null,
+			WebSocketConnectionDelegate? disconnectCallback = null
+		)
+		{
+			if (messageCallback == null)
+			{
+				throw new ArgumentNullException(nameof(messageCallback));
+			}
 
-        /// <summary>
-        /// Throw an exception if token represents an error condition.
-        /// For most API this method does not need to be overriden if:
-        /// - API passes an 'error', 'errorCode' or 'error_code' child element if the call fails
-        /// - API passes a 'status' element of 'error' if the call fails
-        /// - API passes a 'success' element of 'false' if the call fails
-        /// This call also looks for 'result', 'data', 'return' child elements and returns those if
-        /// found, otherwise the result parameter is returned.
-        /// For all other cases, override CheckJsonResponse for the exchange or add more logic here.
-        /// </summary>
-        /// <param name="result">Result</param>
-        protected virtual JToken CheckJsonResponse(JToken result)
-        {
-            if (result == null)
-            {
-                throw new APIException("No result from server");
-            }
-            else if (!(result is JArray) && result.Type == JTokenType.Object)
-            {
-                if
-                (
-                    (!string.IsNullOrWhiteSpace(result["error"].ToStringInvariant())) ||
-                    (!string.IsNullOrWhiteSpace(result["errorCode"].ToStringInvariant())) ||
-                    (!string.IsNullOrWhiteSpace(result["error_code"].ToStringInvariant())) ||
-                    (result["status"].ToStringInvariant() == "error") ||
-                    (result["Status"].ToStringInvariant() == "error") ||
-                    (result["success"] != null && !result["success"].ConvertInvariant<bool>()) ||
-                    (result["Success"] != null && !result["Success"].ConvertInvariant<bool>()) ||
-                    (!string.IsNullOrWhiteSpace(result["ok"].ToStringInvariant()) && result["ok"].ToStringInvariant().ToLowerInvariant() != "ok")
-                )
-                {
-                    throw new APIException(result.ToStringInvariant());
-                }
+			string fullUrl = BaseUrlWebSocket + (url ?? string.Empty);
 
-                // find result object from result keywords
-                foreach (string key in resultKeys)
-                {
-                    JToken possibleResult = result[key];
-                    if (possibleResult != null && (possibleResult.Type == JTokenType.Object || possibleResult.Type == JTokenType.Array))
-                    {
-                        result = possibleResult;
-                        break;
-                    }
-                }
-            }
-            return result;
-        }
+			return ConnectWebSocketAsync(fullUrl, messageCallback, connectCallback, disconnectCallback);
+		}
 
-        /// <summary>
-        /// Get a dictionary with a nonce key and value of the required nonce type. Derived classes should call this base class method first.
-        /// </summary>
-        /// <param name="key">Key</param>
-        /// <returns>Dictionary with nonce</returns>
-        protected virtual async Task<Dictionary<string, object>> GetNoncePayloadAsync()
-        {
-            Dictionary<string, object> noncePayload = new Dictionary<string, object>
-            {
-                ["nonce"] = await GenerateNonceAsync()
-            };
-            if (RequestWindow.Ticks > 0)
-            {
-                noncePayload["recvWindow"] = (long)RequestWindow.TotalMilliseconds;
-            }
-            return noncePayload;
-        }
+		/// <summary>
+		/// Connect a private web socket to a path on the API and start listening, not all exchanges support this
+		/// </summary>
+		/// <param name="url">The sub url for the web socket, or null for none</param>
+		/// <param name="messageCallback">Callback for messages</param>
+		/// <param name="connectCallback">Connect callback</param>
+		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
+		public Task<IWebSocket> ConnectPrivateWebSocketAsync
+		(
+			string url,
+			Func<IWebSocket, byte[], Task> messageCallback,
+			WebSocketConnectionDelegate? connectCallback = null,
+			WebSocketConnectionDelegate? disconnectCallback = null
+		)
+		{
+			if (messageCallback == null)
+			{
+				throw new ArgumentNullException(nameof(messageCallback));
+			}
 
-        /// <summary>
-        /// Derived classes can override to get a nonce offset from the API itself
-        /// </summary>
-        protected virtual async Task OnGetNonceOffset()
-        {
-            if (String.IsNullOrWhiteSpace(NonceEndPoint))
-            {
-                return;
-            }
+			string fullUrl = BaseUrlPrivateWebSocket == string.Empty ? BaseUrlWebSocket : BaseUrlPrivateWebSocket + (url ?? string.Empty);
 
-            try
-            {
-                JToken token = await MakeJsonRequestAsync<JToken>(NonceEndPoint!);
-                JToken value = token[NonceEndPointField];
-                DateTime serverDate = NonceEndPointStyle switch
-                {
-                    NonceStyle.Iso8601 => value.ToDateTimeInvariant(),
-                    NonceStyle.UnixMilliseconds => value.ConvertInvariant<long>().UnixTimeStampToDateTimeMilliseconds(),
-                    _ => throw new ArgumentException("Invalid nonce end point style '" + NonceEndPointStyle + "' for exchange '" + Name + "'"),
-                };
-                NonceOffset = (CryptoUtility.UtcNow - serverDate);
-            }
-            catch
-            {
-                // if this fails we don't want to crash, just run without a nonce
-                Logger.Warn("Failed to get nonce offset for exchange {0}", Name);
-            }
-        }
+			return ConnectWebSocketAsync(fullUrl, messageCallback, connectCallback, disconnectCallback);
+		}
 
-        async Task IAPIRequestHandler.ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object>? payload)
-        {
-            await ProcessRequestAsync(request, payload);
-        }
+		/// <summary>
+		/// Whether the API can make authenticated (private) API requests
+		/// </summary>
+		/// <param name="payload">Payload to potentially send</param>
+		/// <returns>True if an authenticated request can be made with the payload, false otherwise</returns>
+		protected virtual bool CanMakeAuthenticatedRequest(IReadOnlyDictionary<string, object>? payload)
+		{
+			return (PrivateApiKey != null && PublicApiKey != null && payload != null && payload.ContainsKey("nonce"));
+		}
 
-        void IAPIRequestHandler.ProcessResponse(IHttpWebResponse response)
-        {
-            ProcessResponse(response);
-        }
+		/// <summary>
+		/// Additional handling for request. This simply returns a completed task and can be used for derived classes
+		/// that do not have an await in their ProcessRequestAsync overload.
+		/// </summary>
+		/// <param name="request">Request</param>
+		/// <param name="payload">Payload</param>
+		protected virtual Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object>? payload)
+		{
+			return Task.CompletedTask;
+		}
 
-        Uri IAPIRequestHandler.ProcessRequestUrl(UriBuilder url, Dictionary<string, object>? payload, string? method)
-        {
-            return ProcessRequestUrl(url, payload, method);
-        }
-    }
+		/// <summary>
+		/// Additional handling for response
+		/// </summary>
+		/// <param name="response">Response</param>
+		protected virtual void ProcessResponse(IHttpWebResponse response)
+		{
 
-    /// <summary>
-    /// Normally a BaseAPI class attempts to get the Name from the class name.
-    /// If there is a problem, apply this attribute to a BaseAPI subclass to populate the Name property with the attribute name.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    public class ApiNameAttribute : Attribute
-    {
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="name">Name</param>
-        public ApiNameAttribute(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentException($"'{nameof(name)}' must not be null or empty");
-            }
-            Name = name;
-        }
+		}
 
-        /// <summary>
-        /// Name
-        /// </summary>
-        public string Name { get; private set; }
-    }
+		/// <summary>
+		/// Process a request url
+		/// </summary>
+		/// <param name="url">Url</param>
+		/// <param name="payload">Payload</param>
+		/// <param name="method">Method</param>
+		/// <returns>Updated url</returns>
+		protected virtual Uri ProcessRequestUrl(UriBuilder url, Dictionary<string, object>? payload, string? method)
+		{
+			return url.Uri;
+		}
+
+		/// <summary>
+		/// Throw an exception if token represents an error condition.
+		/// For most API this method does not need to be overriden if:
+		/// - API passes an 'error', 'errorCode' or 'error_code' child element if the call fails
+		/// - API passes a 'status' element of 'error' if the call fails
+		/// - API passes a 'success' element of 'false' if the call fails
+		/// This call also looks for 'result', 'data', 'return' child elements and returns those if
+		/// found, otherwise the result parameter is returned.
+		/// For all other cases, override CheckJsonResponse for the exchange or add more logic here.
+		/// </summary>
+		/// <param name="result">Result</param>
+		protected virtual JToken CheckJsonResponse(JToken result)
+		{
+			if (result == null)
+			{
+				throw new APIException("No result from server");
+			}
+			else if (!(result is JArray) && result.Type == JTokenType.Object)
+			{
+				if
+				(
+					(!string.IsNullOrWhiteSpace(result["error"].ToStringInvariant())) ||
+					(!string.IsNullOrWhiteSpace(result["errorCode"].ToStringInvariant())) ||
+					(!string.IsNullOrWhiteSpace(result["error_code"].ToStringInvariant())) ||
+					(result["status"].ToStringInvariant() == "error") ||
+					(result["Status"].ToStringInvariant() == "error") ||
+					(result["success"] != null && !result["success"].ConvertInvariant<bool>()) ||
+					(result["Success"] != null && !result["Success"].ConvertInvariant<bool>()) ||
+					(!string.IsNullOrWhiteSpace(result["ok"].ToStringInvariant()) && result["ok"].ToStringInvariant().ToLowerInvariant() != "ok")
+				)
+				{
+					throw new APIException(result.ToStringInvariant());
+				}
+
+				// find result object from result keywords
+				foreach (string key in resultKeys)
+				{
+					JToken possibleResult = result[key];
+					if (possibleResult != null && (possibleResult.Type == JTokenType.Object || possibleResult.Type == JTokenType.Array))
+					{
+						result = possibleResult;
+						break;
+					}
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Get a dictionary with a nonce key and value of the required nonce type. Derived classes should call this base class method first.
+		/// </summary>
+		/// <param name="key">Key</param>
+		/// <returns>Dictionary with nonce</returns>
+		protected virtual async Task<Dictionary<string, object>> GetNoncePayloadAsync()
+		{
+			Dictionary<string, object> noncePayload = new Dictionary<string, object>
+			{
+				["nonce"] = await GenerateNonceAsync()
+			};
+			if (RequestWindow.Ticks > 0)
+			{
+				noncePayload["recvWindow"] = (long)RequestWindow.TotalMilliseconds;
+			}
+			return noncePayload;
+		}
+
+		/// <summary>
+		/// Derived classes can override to get a nonce offset from the API itself
+		/// </summary>
+		protected virtual async Task OnGetNonceOffset()
+		{
+			if (String.IsNullOrWhiteSpace(NonceEndPoint))
+			{
+				return;
+			}
+
+			try
+			{
+				JToken token = await MakeJsonRequestAsync<JToken>(NonceEndPoint!);
+				JToken value = token[NonceEndPointField];
+				DateTime serverDate = NonceEndPointStyle switch
+				{
+					NonceStyle.Iso8601 => value.ToDateTimeInvariant(),
+					NonceStyle.UnixMilliseconds => value.ConvertInvariant<long>().UnixTimeStampToDateTimeMilliseconds(),
+					_ => throw new ArgumentException("Invalid nonce end point style '" + NonceEndPointStyle + "' for exchange '" + Name + "'"),
+				};
+				NonceOffset = (CryptoUtility.UtcNow - serverDate);
+			}
+			catch
+			{
+				// if this fails we don't want to crash, just run without a nonce
+				Logger.Warn("Failed to get nonce offset for exchange {0}", Name);
+			}
+		}
+
+		async Task IAPIRequestHandler.ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object>? payload)
+		{
+			await ProcessRequestAsync(request, payload);
+		}
+
+		void IAPIRequestHandler.ProcessResponse(IHttpWebResponse response)
+		{
+			ProcessResponse(response);
+		}
+
+		Uri IAPIRequestHandler.ProcessRequestUrl(UriBuilder url, Dictionary<string, object>? payload, string? method)
+		{
+			return ProcessRequestUrl(url, payload, method);
+		}
+	}
+
+	/// <summary>
+	/// Normally a BaseAPI class attempts to get the Name from the class name.
+	/// If there is a problem, apply this attribute to a BaseAPI subclass to populate the Name property with the attribute name.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class)]
+	public class ApiNameAttribute : Attribute
+	{
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="name">Name</param>
+		public ApiNameAttribute(string name)
+		{
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				throw new ArgumentException($"'{nameof(name)}' must not be null or empty");
+			}
+			Name = name;
+		}
+
+		/// <summary>
+		/// Name
+		/// </summary>
+		public string Name { get; private set; }
+	}
 }

--- a/src/ExchangeSharp/API/Exchanges/BL3P/ExchangeBL3PAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BL3P/ExchangeBL3PAPI.cs
@@ -139,7 +139,7 @@ namespace ExchangeSharp
 
 			return new MultiWebsocketWrapper(
 				await Task.WhenAll(
-					marketSymbols.Select(ms => ConnectWebSocketAsync($"{ms}/orderbook", MessageCallback))
+					marketSymbols.Select(ms => ConnectPublicWebSocketAsync($"{ms}/orderbook", MessageCallback))
 				)
 			);
 		}
@@ -164,7 +164,7 @@ namespace ExchangeSharp
 
 			return new MultiWebsocketWrapper(
 				await Task.WhenAll(
-					marketSymbols.Select(ms => ConnectWebSocketAsync($"{ms}/trades", MessageCallback))
+					marketSymbols.Select(ms => ConnectPublicWebSocketAsync($"{ms}/trades", MessageCallback))
 				)
 			);
 		}

--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
@@ -234,7 +234,7 @@ namespace ExchangeSharp.BinanceGroup
 
 		protected override Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] symbols)
 		{
-			return ConnectWebSocketAsync("/stream?streams=!ticker@arr", async (_socket, msg) =>
+			return ConnectPublicWebSocketAsync("/stream?streams=!ticker@arr", async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				List<KeyValuePair<string, ExchangeTicker>> tickerList = new List<KeyValuePair<string, ExchangeTicker>>();
@@ -274,7 +274,7 @@ namespace ExchangeSharp.BinanceGroup
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
 			string url = await GetWebSocketStreamUrlForSymbolsAsync("@aggTrade", marketSymbols);
-			return await ConnectWebSocketAsync(url, messageCallback: async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(url, messageCallback: async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				string name = token["stream"].ToStringInvariant();
@@ -297,7 +297,7 @@ namespace ExchangeSharp.BinanceGroup
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
 			string combined = string.Join("/", marketSymbols.Select(s => this.NormalizeMarketSymbol(s).ToLowerInvariant() + "@depth@100ms"));
-			return await ConnectWebSocketAsync($"/stream?streams={combined}", (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync($"/stream?streams={combined}", (_socket, msg) =>
 			{
 				string json = msg.ToStringFromUTF8();
 				var update = JsonConvert.DeserializeObject<MultiDepthStream>(json);
@@ -1130,7 +1130,7 @@ namespace ExchangeSharp.BinanceGroup
 
 		protected override async Task<IWebSocket> OnUserDataWebSocketAsync(Action<object> callback, string listenKey)
 		{
-			return await ConnectWebSocketAsync($"/ws/{listenKey}", (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync($"/ws/{listenKey}", (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				var eventType = token["e"].ToStringInvariant();

--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceDEXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceDEXAPI.cs
@@ -103,7 +103,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(string.Empty, messageCallback: async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, messageCallback: async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["stream"].ToStringLowerInvariant() == "trades")

--- a/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -235,7 +235,7 @@ namespace ExchangeSharp
 "data":[{"timestamp":"2018-07-06T08:31:53.333Z","symbol":"XBTUSD","side":"Buy","size":10000,"price":6520,"tickDirection":"PlusTick","trdMatchID":"a296312f-c9a4-e066-2f9e-7f4cf2751f0a","grossValue":153370000,"homeNotional":1.5337,"foreignNotional":10000}]}
              */
 
-            return ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+            return ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
             {
                 var str = msg.ToStringFromUTF8();
                 JToken token = JToken.Parse(str);
@@ -282,7 +282,7 @@ namespace ExchangeSharp
             {
                 marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
             }
-            return await ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
             {
                 var str = msg.ToStringFromUTF8();
                 JToken token = JToken.Parse(str);
@@ -355,7 +355,7 @@ namespace ExchangeSharp
             });
         }
 
-        public async Task<IWebSocket> GetPositionWebSocketAsync(Action<ExchangePosition> callback)
+		protected override async Task<IWebSocket> OnGetPositionsWebSocketAsync(Action<ExchangePosition> callback)
         {
             /*
 "{\"info\":\"Welcome to the BitMEX Realtime API.\",\"version\":\"2020-04-08T01:10:16.000Z\",\"timestamp\":\"2020-04-11T11:43:31.856Z\",\"docs\":\"https://testnet.bitmex.com/app/wsAPI\",\"limit\":{\"remaining\":39}}"
@@ -364,7 +364,7 @@ namespace ExchangeSharp
 "{\"table\":\"position\",\"action\":\"partial\",\"keys\":[\"account\",\"symbol\"],\"types\":{\"account\":\"long\",\"symbol\":\"symbol\",\"currency\":\"symbol\",\"underlying\":\"symbol\",\"quoteCurrency\":\"symbol\",\"commission\":\"float\",\"initMarginReq\":\"float\",\"maintMarginReq\":\"float\",\"riskLimit\":\"long\",\"leverage\":\"float\",\"crossMargin\":\"boolean\",\"deleveragePercentile\":\"float\",\"rebalancedPnl\":\"long\",\"prevRealisedPnl\":\"long\",\"prevUnrealisedPnl\":\"long\",\"prevClosePrice\":\"float\",\"openingTimestamp\":\"timestamp\",\"openingQty\":\"long\",\"openingCost\":\"long\",\"openingComm\":\"long\",\"openOrderBuyQty\":\"long\",\"openOrderBuyCost\":\"long\",\"openOrderBuyPremium\":\"long\",\"openOrderSellQty\":\"long\",\"openOrderSellCost\":\"long\",\"openOrderSellPremium\":\"long\",\"execBuyQty\":\"long\",\"execBuyCost\":\"long\",\"execSellQty\":\"long\",\"execSellCost\":\"long\",\"execQty\":\"long\",\"execCost\":\"long\",\"execComm\":\"long\",\"currentTimestamp\":\"timestamp\",\"currentQty\":\"long\",\"currentCost\":\"long\",\"currentComm\":\"long\",\"realisedCost\":\"long\",\"unrealisedCost\":\"long\",\"grossOpenCost\":\"long\",\"grossOpenPremium\":\"long\",\"grossExecCost\":\"long\",\"isOpen\":\"boolean\",\"markPrice\":\"float\",\"markValue\":\"long\",\"riskValue\":\"long\",\"homeNotional\":\"float\",\"foreignNotional\":\"float\",\"posState\":\"symbol\",\"posCost\":\"long\",\"posCost2\":\"long\",\"posCross\":\"long\",\"posInit\":\"long\",\"posComm\":\"long\",\"posLoss\":\"long\",\"posMargin\":\"long\",\"posMaint\":\"long\",\"posAllowance\":\"long\",\"taxableMargin\":\"long\",\"initMargin\":\"long\",\"maintMargin\":\"long\",\"sessionMargin\":\"long\",\"targetExcessMargin\":\"long\",\"varMargin\":\"long\",\"realisedGrossPnl\":\"long\",\"realisedTax\":\"long\",\"realisedPnl\":\"long\",\"unrealisedGrossPnl\":\"long\",\"longBankrupt\":\"long\",\"shortBankrupt\":\"long\",\"taxBase\":\"long\",\"indicativeTaxRate\":\"float\",\"indicativeTax\":\"long\",\"unrealisedTax\":\"long\",\"unrealisedPnl\":\"long\",\"unrealisedPnlPcnt\":\"float\",\"unrealisedRoePcnt\":\"float\",\"simpleQty\":\"float\",\"simpleCost\":\"float\",\"simpleValue\":\"float\",\"simplePnl\":\"float\",\"simplePnlPcnt\":\"float\",\"avgCostPrice\":\"float\",\"avgEntryPrice\":\"float\",\"breakEvenPrice\":\"float\",\"marginCallPrice\":\"float\",\"liquidationPrice\":\"float\",\"bankruptPrice\":\"float\",\"timestamp\":\"timestamp\",\"lastPrice\":\"float\",\"lastValue\":\"long\"},\"foreignKeys\":{\"symbol\":\"instrument\"},\"attributes\":{\"account\":\"sorted\",\"symbol\":\"grouped\",\"underlying\":\"grouped\"},\"filter\":{\"account\":12345678},\"data\":[{\"account\":12345678,\"symbol\":\"XBTUSD\",\"currency\":\"XBt\",\"underlying\":\"XBT\",\"quoteCurrency\":\"USD\",\"commission\":0.00075,\"initMarginReq\":0.01,\"maintMarginReq\":0.005,\"riskLimit\":20000000000,\"leverage\":100,\"crossMargin\":true,\"deleveragePercentile\":null,\"rebalancedPnl\":1234,\"prevRealisedPnl\":678,\"prevUnrealisedPnl\":0,\"prevClosePrice\":6905.23,\"openingTimestamp\":\"2020-04-11T11:00:00.000Z\",\"openingQty\":0,\"openingCost\":9876,\"openingComm\":6543,\"openOrderBuyQty\":0,\"openOrderBuyCost\":0,\"openOrderBuyPremium\":0,\"openOrderSellQty\":0,\"openOrderSellCost\":0,\"openOrderSellPremium\":0,\"execBuyQty\":0,\"execBuyCost\":0,\"execSellQty\":0,\"execSellCost\":0,\"execQty\":0,\"execCost\":0,\"execComm\":0,\"currentTimestamp\":\"2020-04-11T11:00:00.330Z\",\"currentQty\":0,\"currentCost\":8765,\"currentComm\":564542,\"realisedCost\":9876,\"unrealisedCost\":0,\"grossOpenCost\":0,\"grossOpenPremium\":0,\"grossExecCost\":0,\"isOpen\":false,\"markPrice\":null,\"markValue\":0,\"riskValue\":0,\"homeNotional\":0,\"foreignNotional\":0,\"posState\":\"\",\"posCost\":0,\"posCost2\":0,\"posCross\":0,\"posInit\":0,\"posComm\":0,\"posLoss\":0,\"posMargin\":0,\"posMaint\":0,\"posAllowance\":0,\"taxableMargin\":0,\"initMargin\":0,\"maintMargin\":0,\"sessionMargin\":0,\"targetExcessMargin\":0,\"varMargin\":0,\"realisedGrossPnl\":-7654,\"realisedTax\":0,\"realisedPnl\":-7654,\"unrealisedGrossPnl\":0,\"longBankrupt\":0,\"shortBankrupt\":0,\"taxBase\":0,\"indicativeTaxRate\":null,\"indicativeTax\":0,\"unrealisedTax\":0,\"unrealisedPnl\":0,\"unrealisedPnlPcnt\":0,\"unrealisedRoePcnt\":0,\"simpleQty\":null,\"simpleCost\":null,\"simpleValue\":null,\"simplePnl\":null,\"simplePnlPcnt\":null,\"avgCostPrice\":null,\"avgEntryPrice\":null,\"breakEvenPrice\":null,\"marginCallPrice\":null,\"liquidationPrice\":null,\"bankruptPrice\":null,\"timestamp\":\"2020-04-11T11:00:00.330Z\",\"lastPrice\":null,\"lastValue\":0}]}"
             */
 
-            return await ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
             {
                 var str = msg.ToStringFromUTF8();
                 JToken token = JToken.Parse(str);

--- a/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -23,72 +23,72 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    public sealed partial class ExchangeBitMEXAPI : ExchangeAPI
-    {
-        public override string BaseUrl { get; set; } = "https://www.bitmex.com/api/v1";
-        public override string BaseUrlWebSocket { get; set; } = "wss://www.bitmex.com/realtime";
-        //public override string BaseUrl { get; set; } = "https://testnet.bitmex.com/api/v1";
-        //public override string BaseUrlWebSocket { get; set; } = "wss://testnet.bitmex.com/realtime";
+	public sealed partial class ExchangeBitMEXAPI : ExchangeAPI
+	{
+		public override string BaseUrl { get; set; } = "https://www.bitmex.com/api/v1";
+		public override string BaseUrlWebSocket { get; set; } = "wss://www.bitmex.com/realtime";
+		//public override string BaseUrl { get; set; } = "https://testnet.bitmex.com/api/v1";
+		//public override string BaseUrlWebSocket { get; set; } = "wss://testnet.bitmex.com/realtime";
 
-        private SortedDictionary<long, decimal> dict_long_decimal = new SortedDictionary<long, decimal>();
-        private SortedDictionary<decimal, long> dict_decimal_long = new SortedDictionary<decimal, long>();
+		private SortedDictionary<long, decimal> dict_long_decimal = new SortedDictionary<long, decimal>();
+		private SortedDictionary<decimal, long> dict_decimal_long = new SortedDictionary<decimal, long>();
 
 		private ExchangeBitMEXAPI()
-        {
-            RequestWindow = TimeSpan.Zero;
-            NonceStyle = NonceStyle.ExpiresUnixSeconds;
+		{
+			RequestWindow = TimeSpan.Zero;
+			NonceStyle = NonceStyle.ExpiresUnixSeconds;
 
-            // make the nonce go 60 seconds into the future (the offset is subtracted)
-            // this will give us an api-expires 60 seconds into the future
-            NonceOffset = TimeSpan.FromSeconds(-60.0);
+			// make the nonce go 60 seconds into the future (the offset is subtracted)
+			// this will give us an api-expires 60 seconds into the future
+			NonceOffset = TimeSpan.FromSeconds(-60.0);
 
-            MarketSymbolSeparator = string.Empty;
-            RequestContentType = "application/json";
-            WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
+			MarketSymbolSeparator = string.Empty;
+			RequestContentType = "application/json";
+			WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
 
-            RateLimit = new RateGate(300, TimeSpan.FromMinutes(5));
-        }
+			RateLimit = new RateGate(300, TimeSpan.FromMinutes(5));
+		}
 
-        public override Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
-        {
-            throw new NotImplementedException();
-        }
+		public override Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
+		{
+			throw new NotImplementedException();
+		}
 
-        public override Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
-        {
-            throw new NotImplementedException();
-        }
+		public override Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
+		{
+			throw new NotImplementedException();
+		}
 
-        protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
-        {
-            if (CanMakeAuthenticatedRequest(payload))
-            {
-                // convert nonce to long, trim off milliseconds
-                var nonce = payload["nonce"].ConvertInvariant<long>();
-                payload.Remove("nonce");
-                var msg = CryptoUtility.GetJsonForPayload(payload);
-                var sign = $"{request.Method}{request.RequestUri.AbsolutePath}{request.RequestUri.Query}{nonce}{msg}";
-                string signature = CryptoUtility.SHA256Sign(sign, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
+		protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
+		{
+			if (CanMakeAuthenticatedRequest(payload))
+			{
+				// convert nonce to long, trim off milliseconds
+				var nonce = payload["nonce"].ConvertInvariant<long>();
+				payload.Remove("nonce");
+				var msg = CryptoUtility.GetJsonForPayload(payload);
+				var sign = $"{request.Method}{request.RequestUri.AbsolutePath}{request.RequestUri.Query}{nonce}{msg}";
+				string signature = CryptoUtility.SHA256Sign(sign, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
 
-                request.AddHeader("api-expires", nonce.ToStringInvariant());
-                request.AddHeader("api-key", PublicApiKey.ToUnsecureString());
-                request.AddHeader("api-signature", signature);
+				request.AddHeader("api-expires", nonce.ToStringInvariant());
+				request.AddHeader("api-key", PublicApiKey.ToUnsecureString());
+				request.AddHeader("api-signature", signature);
 
-                await CryptoUtility.WritePayloadJsonToRequestAsync(request, payload);
-            }
-        }
+				await CryptoUtility.WritePayloadJsonToRequestAsync(request, payload);
+			}
+		}
 
-        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
-        {
-            var m = await GetMarketSymbolsMetadataAsync();
-            return m.Select(x => x.MarketSymbol);
-        }
+		protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
+		{
+			var m = await GetMarketSymbolsMetadataAsync();
+			return m.Select(x => x.MarketSymbol);
+		}
 
 
-        protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
-        {
-            /*
-             {{
+		protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
+		{
+			/*
+			 {{
   "symbol": ".XRPXBT",
   "rootSymbol": "XRP",
   "state": "Unlisted",
@@ -191,54 +191,54 @@ namespace ExchangeSharp
   "settledPrice": null,
   "timestamp": "2018-07-05T13:27:15Z"
 }}
-             */
+			 */
 
-            List<ExchangeMarket> markets = new List<ExchangeMarket>();
-            JToken allSymbols = await MakeJsonRequestAsync<JToken>("/instrument?count=500&reverse=false");
+			List<ExchangeMarket> markets = new List<ExchangeMarket>();
+			JToken allSymbols = await MakeJsonRequestAsync<JToken>("/instrument?count=500&reverse=false");
 			foreach (JToken marketSymbolToken in allSymbols)
-            {
-                var market = new ExchangeMarket
-                {
-                    MarketSymbol = marketSymbolToken["symbol"].ToStringUpperInvariant(),
-                    IsActive = marketSymbolToken["state"].ToStringInvariant().EqualsWithOption("Open"),
-                    QuoteCurrency = marketSymbolToken["quoteCurrency"].ToStringUpperInvariant(),
-                    BaseCurrency = marketSymbolToken["underlying"].ToStringUpperInvariant(),
-                };
+			{
+				var market = new ExchangeMarket
+				{
+					MarketSymbol = marketSymbolToken["symbol"].ToStringUpperInvariant(),
+					IsActive = marketSymbolToken["state"].ToStringInvariant().EqualsWithOption("Open"),
+					QuoteCurrency = marketSymbolToken["quoteCurrency"].ToStringUpperInvariant(),
+					BaseCurrency = marketSymbolToken["underlying"].ToStringUpperInvariant(),
+				};
 
-                try
-                {
-                    market.PriceStepSize = marketSymbolToken["tickSize"].ConvertInvariant<decimal>();
-                    market.MaxPrice = marketSymbolToken["maxPrice"].ConvertInvariant<decimal>();
-                    //market.MinPrice = symbol["minPrice"].ConvertInvariant<decimal>();
+				try
+				{
+					market.PriceStepSize = marketSymbolToken["tickSize"].ConvertInvariant<decimal>();
+					market.MaxPrice = marketSymbolToken["maxPrice"].ConvertInvariant<decimal>();
+					//market.MinPrice = symbol["minPrice"].ConvertInvariant<decimal>();
 
-                    market.MaxTradeSize = marketSymbolToken["maxOrderQty"].ConvertInvariant<decimal>();
-                    //market.MinTradeSize = symbol["minQty"].ConvertInvariant<decimal>();
-                    //market.QuantityStepSize = symbol["stepSize"].ConvertInvariant<decimal>();
-                }
-                catch
-                {
+					market.MaxTradeSize = marketSymbolToken["maxOrderQty"].ConvertInvariant<decimal>();
+					//market.MinTradeSize = symbol["minQty"].ConvertInvariant<decimal>();
+					//market.QuantityStepSize = symbol["stepSize"].ConvertInvariant<decimal>();
+				}
+				catch
+				{
 
-                }
-                markets.Add(market);
-            }
-            return markets;
-        }
+				}
+				markets.Add(market);
+			}
+			return markets;
+		}
 
-        protected override Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
-        {
-            /*
+		protected override Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
+		{
+			/*
 {"table":"trade","action":"partial","keys":[],
 "types":{"timestamp":"timestamp","symbol":"symbol","side":"symbol","size":"long","price":"float","tickDirection":"symbol","trdMatchID":"guid","grossValue":"long","homeNotional":"float","foreignNotional":"float"},
 "foreignKeys":{"symbol":"instrument","side":"side"},
 "attributes":{"timestamp":"sorted","symbol":"grouped"},
 "filter":{"symbol":"XBTUSD"},
 "data":[{"timestamp":"2018-07-06T08:31:53.333Z","symbol":"XBTUSD","side":"Buy","size":10000,"price":6520,"tickDirection":"PlusTick","trdMatchID":"a296312f-c9a4-e066-2f9e-7f4cf2751f0a","grossValue":153370000,"homeNotional":1.5337,"foreignNotional":10000}]}
-             */
+			 */
 
-            return ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
-            {
-                var str = msg.ToStringFromUTF8();
-                JToken token = JToken.Parse(str);
+			return ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
+			{
+				var str = msg.ToStringFromUTF8();
+				JToken token = JToken.Parse(str);
 
 				if (token["error"] != null)
 				{
@@ -246,577 +246,577 @@ namespace ExchangeSharp
 					return;
 				}
 				else if (token["table"] == null)
-                {
+				{
 					return;
-                }
+				}
 
-                var action = token["action"].ToStringInvariant();
-                JArray data = token["data"] as JArray;
-                foreach (var t in data)
-                {
-                    var marketSymbol = t["symbol"].ToStringInvariant();
-                    await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, t.ParseTrade("size", "price", "side", "timestamp", TimestampType.Iso8601, "trdMatchID")));
-                }
-            }, async (_socket) =>
-            {
-                if (marketSymbols == null || marketSymbols.Length == 0)
-                {
+				var action = token["action"].ToStringInvariant();
+				JArray data = token["data"] as JArray;
+				foreach (var t in data)
+				{
+					var marketSymbol = t["symbol"].ToStringInvariant();
+					await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, t.ParseTrade("size", "price", "side", "timestamp", TimestampType.Iso8601, "trdMatchID")));
+				}
+			}, async (_socket) =>
+			{
+				if (marketSymbols == null || marketSymbols.Length == 0)
+				{
 					await _socket.SendMessageAsync(new { op = "subscribe", args = "trade" });
 				}
 				else
 				{
 					await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "trade:" + this.NormalizeMarketSymbol(s)).ToArray() });
 				}
-            });
-        }
+			});
+		}
 
-        protected override async Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
-        {
-            /*
+		protected override async Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
+		{
+			/*
 {"info":"Welcome to the BitMEX Realtime API.","version":"2018-06-29T18:05:14.000Z","timestamp":"2018-07-05T14:22:26.267Z","docs":"https://www.bitmex.com/app/wsAPI","limit":{"remaining":39}}
 {"success":true,"subscribe":"orderBookL2:XBTUSD","request":{"op":"subscribe","args":["orderBookL2:XBTUSD"]}}
 {"table":"orderBookL2","action":"update","data":[{"symbol":"XBTUSD","id":8799343000,"side":"Buy","size":350544}]}
-             */
+			 */
 
-            if (marketSymbols == null || marketSymbols.Length == 0)
-            {
-                marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
-            }
-            return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
-            {
-                var str = msg.ToStringFromUTF8();
-                JToken token = JToken.Parse(str);
+			if (marketSymbols == null || marketSymbols.Length == 0)
+			{
+				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
+			}
+			return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
+			{
+				var str = msg.ToStringFromUTF8();
+				JToken token = JToken.Parse(str);
 
-                if (token["table"] == null)
-                {
-                    return Task.CompletedTask;
-                }
+				if (token["table"] == null)
+				{
+					return Task.CompletedTask;
+				}
 
-                var action = token["action"].ToStringInvariant();
-                JArray data = token["data"] as JArray;
+				var action = token["action"].ToStringInvariant();
+				JArray data = token["data"] as JArray;
 
-                ExchangeOrderBook book = new ExchangeOrderBook();
-                var price = 0m;
-                var size = 0m;
-                foreach (var d in data)
-                {
-                    var marketSymbol = d["symbol"].ToStringInvariant();
-                    var id = d["id"].ConvertInvariant<long>();
-                    if (d["price"] == null)
-                    {
-                        if (!dict_long_decimal.TryGetValue(id, out price))
-                        {
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        price = d["price"].ConvertInvariant<decimal>();
-                        dict_long_decimal[id] = price;
-                        dict_decimal_long[price] = id;
-                    }
+				ExchangeOrderBook book = new ExchangeOrderBook();
+				var price = 0m;
+				var size = 0m;
+				foreach (var d in data)
+				{
+					var marketSymbol = d["symbol"].ToStringInvariant();
+					var id = d["id"].ConvertInvariant<long>();
+					if (d["price"] == null)
+					{
+						if (!dict_long_decimal.TryGetValue(id, out price))
+						{
+							continue;
+						}
+					}
+					else
+					{
+						price = d["price"].ConvertInvariant<decimal>();
+						dict_long_decimal[id] = price;
+						dict_decimal_long[price] = id;
+					}
 
-                    var side = d["side"].ToStringInvariant();
+					var side = d["side"].ToStringInvariant();
 
-                    if (d["size"] == null)
-                    {
-                        size = 0m;
-                    }
-                    else
-                    {
-                        size = d["size"].ConvertInvariant<decimal>();
-                    }
+					if (d["size"] == null)
+					{
+						size = 0m;
+					}
+					else
+					{
+						size = d["size"].ConvertInvariant<decimal>();
+					}
 
-                    var depth = new ExchangeOrderPrice { Price = price, Amount = size };
+					var depth = new ExchangeOrderPrice { Price = price, Amount = size };
 
-                    if (side.EqualsWithOption("Buy"))
-                    {
-                        book.Bids[depth.Price] = depth;
-                    }
-                    else
-                    {
-                        book.Asks[depth.Price] = depth;
-                    }
-                    book.MarketSymbol = marketSymbol;
-                }
+					if (side.EqualsWithOption("Buy"))
+					{
+						book.Bids[depth.Price] = depth;
+					}
+					else
+					{
+						book.Asks[depth.Price] = depth;
+					}
+					book.MarketSymbol = marketSymbol;
+				}
 
-                if (!string.IsNullOrEmpty(book.MarketSymbol))
-                {
-                    callback(book);
-                }
-                return Task.CompletedTask;
-            }, async (_socket) =>
-            {
-                if (marketSymbols.Length == 0)
-                {
-                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
-                }
-                await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "orderBookL2:" + this.NormalizeMarketSymbol(s)).ToArray() });
-            });
-        }
+				if (!string.IsNullOrEmpty(book.MarketSymbol))
+				{
+					callback(book);
+				}
+				return Task.CompletedTask;
+			}, async (_socket) =>
+			{
+				if (marketSymbols.Length == 0)
+				{
+					marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
+				}
+				await _socket.SendMessageAsync(new { op = "subscribe", args = marketSymbols.Select(s => "orderBookL2:" + this.NormalizeMarketSymbol(s)).ToArray() });
+			});
+		}
 
 		protected override async Task<IWebSocket> OnGetPositionsWebSocketAsync(Action<ExchangePosition> callback)
-        {
-            /*
+		{
+			/*
 "{\"info\":\"Welcome to the BitMEX Realtime API.\",\"version\":\"2020-04-08T01:10:16.000Z\",\"timestamp\":\"2020-04-11T11:43:31.856Z\",\"docs\":\"https://testnet.bitmex.com/app/wsAPI\",\"limit\":{\"remaining\":39}}"
 "{\"success\":true,\"request\":{\"op\":\"authKeyExpires\",\"args\":[\"Foo123\",1586605471,\"Bar456\"]}}"
 "{\"success\":true,\"subscribe\":\"position\",\"request\":{\"op\":\"subscribe\",\"args\":\"position\"}}"
 "{\"table\":\"position\",\"action\":\"partial\",\"keys\":[\"account\",\"symbol\"],\"types\":{\"account\":\"long\",\"symbol\":\"symbol\",\"currency\":\"symbol\",\"underlying\":\"symbol\",\"quoteCurrency\":\"symbol\",\"commission\":\"float\",\"initMarginReq\":\"float\",\"maintMarginReq\":\"float\",\"riskLimit\":\"long\",\"leverage\":\"float\",\"crossMargin\":\"boolean\",\"deleveragePercentile\":\"float\",\"rebalancedPnl\":\"long\",\"prevRealisedPnl\":\"long\",\"prevUnrealisedPnl\":\"long\",\"prevClosePrice\":\"float\",\"openingTimestamp\":\"timestamp\",\"openingQty\":\"long\",\"openingCost\":\"long\",\"openingComm\":\"long\",\"openOrderBuyQty\":\"long\",\"openOrderBuyCost\":\"long\",\"openOrderBuyPremium\":\"long\",\"openOrderSellQty\":\"long\",\"openOrderSellCost\":\"long\",\"openOrderSellPremium\":\"long\",\"execBuyQty\":\"long\",\"execBuyCost\":\"long\",\"execSellQty\":\"long\",\"execSellCost\":\"long\",\"execQty\":\"long\",\"execCost\":\"long\",\"execComm\":\"long\",\"currentTimestamp\":\"timestamp\",\"currentQty\":\"long\",\"currentCost\":\"long\",\"currentComm\":\"long\",\"realisedCost\":\"long\",\"unrealisedCost\":\"long\",\"grossOpenCost\":\"long\",\"grossOpenPremium\":\"long\",\"grossExecCost\":\"long\",\"isOpen\":\"boolean\",\"markPrice\":\"float\",\"markValue\":\"long\",\"riskValue\":\"long\",\"homeNotional\":\"float\",\"foreignNotional\":\"float\",\"posState\":\"symbol\",\"posCost\":\"long\",\"posCost2\":\"long\",\"posCross\":\"long\",\"posInit\":\"long\",\"posComm\":\"long\",\"posLoss\":\"long\",\"posMargin\":\"long\",\"posMaint\":\"long\",\"posAllowance\":\"long\",\"taxableMargin\":\"long\",\"initMargin\":\"long\",\"maintMargin\":\"long\",\"sessionMargin\":\"long\",\"targetExcessMargin\":\"long\",\"varMargin\":\"long\",\"realisedGrossPnl\":\"long\",\"realisedTax\":\"long\",\"realisedPnl\":\"long\",\"unrealisedGrossPnl\":\"long\",\"longBankrupt\":\"long\",\"shortBankrupt\":\"long\",\"taxBase\":\"long\",\"indicativeTaxRate\":\"float\",\"indicativeTax\":\"long\",\"unrealisedTax\":\"long\",\"unrealisedPnl\":\"long\",\"unrealisedPnlPcnt\":\"float\",\"unrealisedRoePcnt\":\"float\",\"simpleQty\":\"float\",\"simpleCost\":\"float\",\"simpleValue\":\"float\",\"simplePnl\":\"float\",\"simplePnlPcnt\":\"float\",\"avgCostPrice\":\"float\",\"avgEntryPrice\":\"float\",\"breakEvenPrice\":\"float\",\"marginCallPrice\":\"float\",\"liquidationPrice\":\"float\",\"bankruptPrice\":\"float\",\"timestamp\":\"timestamp\",\"lastPrice\":\"float\",\"lastValue\":\"long\"},\"foreignKeys\":{\"symbol\":\"instrument\"},\"attributes\":{\"account\":\"sorted\",\"symbol\":\"grouped\",\"underlying\":\"grouped\"},\"filter\":{\"account\":12345678},\"data\":[{\"account\":12345678,\"symbol\":\"XBTUSD\",\"currency\":\"XBt\",\"underlying\":\"XBT\",\"quoteCurrency\":\"USD\",\"commission\":0.00075,\"initMarginReq\":0.01,\"maintMarginReq\":0.005,\"riskLimit\":20000000000,\"leverage\":100,\"crossMargin\":true,\"deleveragePercentile\":null,\"rebalancedPnl\":1234,\"prevRealisedPnl\":678,\"prevUnrealisedPnl\":0,\"prevClosePrice\":6905.23,\"openingTimestamp\":\"2020-04-11T11:00:00.000Z\",\"openingQty\":0,\"openingCost\":9876,\"openingComm\":6543,\"openOrderBuyQty\":0,\"openOrderBuyCost\":0,\"openOrderBuyPremium\":0,\"openOrderSellQty\":0,\"openOrderSellCost\":0,\"openOrderSellPremium\":0,\"execBuyQty\":0,\"execBuyCost\":0,\"execSellQty\":0,\"execSellCost\":0,\"execQty\":0,\"execCost\":0,\"execComm\":0,\"currentTimestamp\":\"2020-04-11T11:00:00.330Z\",\"currentQty\":0,\"currentCost\":8765,\"currentComm\":564542,\"realisedCost\":9876,\"unrealisedCost\":0,\"grossOpenCost\":0,\"grossOpenPremium\":0,\"grossExecCost\":0,\"isOpen\":false,\"markPrice\":null,\"markValue\":0,\"riskValue\":0,\"homeNotional\":0,\"foreignNotional\":0,\"posState\":\"\",\"posCost\":0,\"posCost2\":0,\"posCross\":0,\"posInit\":0,\"posComm\":0,\"posLoss\":0,\"posMargin\":0,\"posMaint\":0,\"posAllowance\":0,\"taxableMargin\":0,\"initMargin\":0,\"maintMargin\":0,\"sessionMargin\":0,\"targetExcessMargin\":0,\"varMargin\":0,\"realisedGrossPnl\":-7654,\"realisedTax\":0,\"realisedPnl\":-7654,\"unrealisedGrossPnl\":0,\"longBankrupt\":0,\"shortBankrupt\":0,\"taxBase\":0,\"indicativeTaxRate\":null,\"indicativeTax\":0,\"unrealisedTax\":0,\"unrealisedPnl\":0,\"unrealisedPnlPcnt\":0,\"unrealisedRoePcnt\":0,\"simpleQty\":null,\"simpleCost\":null,\"simpleValue\":null,\"simplePnl\":null,\"simplePnlPcnt\":null,\"avgCostPrice\":null,\"avgEntryPrice\":null,\"breakEvenPrice\":null,\"marginCallPrice\":null,\"liquidationPrice\":null,\"bankruptPrice\":null,\"timestamp\":\"2020-04-11T11:00:00.330Z\",\"lastPrice\":null,\"lastValue\":0}]}"
-            */
+			*/
 
-            return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
-            {
-                var str = msg.ToStringFromUTF8();
-                JToken token = JToken.Parse(str);
+			return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
+			{
+				var str = msg.ToStringFromUTF8();
+				JToken token = JToken.Parse(str);
 				if (token["error"] != null)
 				{
 					Logger.Info(token["error"].ToStringInvariant());
-                    return Task.CompletedTask;
+					return Task.CompletedTask;
 				}
 				else if (token["table"] == null)
-                {
-                    return Task.CompletedTask;
-                }
+				{
+					return Task.CompletedTask;
+				}
 
-                JArray data = token["data"] as JArray;
-                foreach (var d in data)
-                {
-                    var position = ParsePosition(d);
-                    callback(position);
-                }
-                return Task.CompletedTask;
+				JArray data = token["data"] as JArray;
+				foreach (var d in data)
+				{
+					var position = ParsePosition(d);
+					callback(position);
+				}
+				return Task.CompletedTask;
 
-            }, async (_socket) =>
-            {
+			}, async (_socket) =>
+			{
 				long nonce = (await GenerateNonceAsync()).ConvertInvariant<long>();
-                var authPayload = $"GET/realtime{nonce}";
-                string signature = CryptoUtility.SHA256Sign(authPayload, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
+				var authPayload = $"GET/realtime{nonce}";
+				string signature = CryptoUtility.SHA256Sign(authPayload, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
 
-                var authArgs = new object[]{PublicApiKey.ToUnsecureString(), nonce, signature};
-                await _socket.SendMessageAsync(new { op = "authKeyExpires", args = authArgs });
-                await _socket.SendMessageAsync(new { op = "subscribe", args = "position" });
-            });
-        }
-        
+				var authArgs = new object[]{PublicApiKey.ToUnsecureString(), nonce, signature};
+				await _socket.SendMessageAsync(new { op = "authKeyExpires", args = authArgs });
+				await _socket.SendMessageAsync(new { op = "subscribe", args = "position" });
+			});
+		}
+		
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            /*
-             [
+		protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			/*
+			 [
 {"timestamp":"2017-01-01T00:00:00.000Z","symbol":"XBTUSD","open":968.29,"high":968.29,"low":968.29,"close":968.29,"trades":0,"volume":0,"vwap":null,"lastSize":null,"turnover":0,"homeNotional":0,"foreignNotional":0},
 {"timestamp":"2017-01-01T00:01:00.000Z","symbol":"XBTUSD","open":968.29,"high":968.76,"low":968.49,"close":968.7,"trades":17,"volume":12993,"vwap":968.72,"lastSize":2000,"turnover":1341256747,"homeNotional":13.412567469999997,"foreignNotional":12993},
-             */
+			 */
 
-            List<MarketCandle> candles = new List<MarketCandle>();
-            string periodString = PeriodSecondsToString(periodSeconds);
-            string url = $"/trade/bucketed?binSize={periodString}&partial=false&symbol={marketSymbol}&reverse=true" + marketSymbol;
-            if (startDate != null)
-            {
-                url += "&startTime=" + startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
-            }
-            if (endDate != null)
-            {
-                url += "&endTime=" + endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
-            }
-            if (limit != null)
-            {
-                url += "&count=" + (limit.Value.ToStringInvariant());
-            }
+			List<MarketCandle> candles = new List<MarketCandle>();
+			string periodString = PeriodSecondsToString(periodSeconds);
+			string url = $"/trade/bucketed?binSize={periodString}&partial=false&symbol={marketSymbol}&reverse=true" + marketSymbol;
+			if (startDate != null)
+			{
+				url += "&startTime=" + startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+			}
+			if (endDate != null)
+			{
+				url += "&endTime=" + endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss");
+			}
+			if (limit != null)
+			{
+				url += "&count=" + (limit.Value.ToStringInvariant());
+			}
 
-            var obj = await MakeJsonRequestAsync<JToken>(url);
-            foreach (var t in obj)
-            {
-                candles.Add(this.ParseCandle(t, marketSymbol, periodSeconds, "open", "high", "low", "close", "timestamp", TimestampType.Iso8601, "volume", "turnover", "vwap"));
-            }
-            candles.Reverse();
+			var obj = await MakeJsonRequestAsync<JToken>(url);
+			foreach (var t in obj)
+			{
+				candles.Add(this.ParseCandle(t, marketSymbol, periodSeconds, "open", "high", "low", "close", "timestamp", TimestampType.Iso8601, "volume", "turnover", "vwap"));
+			}
+			candles.Reverse();
 
-            return candles;
-        }
+			return candles;
+		}
 
-        public async Task<IEnumerable<ExchangeTrade>> GetHistoricalTradesAsync(
-            string marketSymbol = null,
-            DateTime? startDate = null,
-            DateTime? endDate = null,
-            int? startingIndex = null,
-            int? limit = 1000)
-        {
-            List<ExchangeTrade> trades = new List<ExchangeTrade>();
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            string url = "/trade?";
-            url += "&columns=[\"symbol\", \"size\", \"price\", \"side\", \"timestamp\", \"trdMatchID\"]";
-            if (!string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                url += "&symbol=" + NormalizeMarketSymbol(marketSymbol);
-            }
-            if (startDate != null)
-            {
-                url += "&startTime=" + startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "Z";
-            }
-            if (endDate != null)
-            {
-                url += "&endTime=" + endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "Z";
-            }
-            if (limit != null)
-            {
-                url += "&count=" + (limit.Value.ToStringInvariant());
-            }
-            if (startingIndex != null)
-            {
-                url += "&start=" + (startingIndex.Value.ToStringInvariant());
-            }
+		public async Task<IEnumerable<ExchangeTrade>> GetHistoricalTradesAsync(
+			string marketSymbol = null,
+			DateTime? startDate = null,
+			DateTime? endDate = null,
+			int? startingIndex = null,
+			int? limit = 1000)
+		{
+			List<ExchangeTrade> trades = new List<ExchangeTrade>();
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			string url = "/trade?";
+			url += "&columns=[\"symbol\", \"size\", \"price\", \"side\", \"timestamp\", \"trdMatchID\"]";
+			if (!string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				url += "&symbol=" + NormalizeMarketSymbol(marketSymbol);
+			}
+			if (startDate != null)
+			{
+				url += "&startTime=" + startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "Z";
+			}
+			if (endDate != null)
+			{
+				url += "&endTime=" + endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "Z";
+			}
+			if (limit != null)
+			{
+				url += "&count=" + (limit.Value.ToStringInvariant());
+			}
+			if (startingIndex != null)
+			{
+				url += "&start=" + (startingIndex.Value.ToStringInvariant());
+			}
 
-            var obj = await MakeJsonRequestAsync<JToken>(url);
-            foreach (var t in obj)
-            {
-                trades.Add(t.ParseTrade("size", "price", "side", "timestamp", TimestampType.Iso8601, "trdMatchID"));
-            }
+			var obj = await MakeJsonRequestAsync<JToken>(url);
+			foreach (var t in obj)
+			{
+				trades.Add(t.ParseTrade("size", "price", "side", "timestamp", TimestampType.Iso8601, "trdMatchID"));
+			}
 
-            return trades;
-        }
+			return trades;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
-        {
-            /*
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+		{
+			/*
 {[
   {
-    "account": 93592,
-    "currency": "XBt",
-    "riskLimit": 1000000000000,
-    "prevState": "",
-    "state": "",
-    "action": "",
-    "amount": 141755795,
-    "pendingCredit": 0,
-    "pendingDebit": 0,
-    "confirmedDebit": 0,
-    "prevRealisedPnl": 0,
-    "prevUnrealisedPnl": 0,
-    "grossComm": 0,
-    "grossOpenCost": 0,
-    "grossOpenPremium": 0,
-    "grossExecCost": 0,
-    "grossMarkValue": 0,
-    "riskValue": 0,
-    "taxableMargin": 0,
-    "initMargin": 0,
-    "maintMargin": 0,
-    "sessionMargin": 0,
-    "targetExcessMargin": 0,
-    "varMargin": 0,
-    "realisedPnl": 0,
-    "unrealisedPnl": 0,
-    "indicativeTax": 0,
-    "unrealisedProfit": 0,
-    "syntheticMargin": 0,
-    "walletBalance": 141755795,
-    "marginBalance": 141755795,
-    "marginBalancePcnt": 1,
-    "marginLeverage": 0,
-    "marginUsedPcnt": 0,
-    "excessMargin": 141755795,
-    "excessMarginPcnt": 1,
-    "availableMargin": 141755795,
-    "withdrawableMargin": 141755795,
-    "timestamp": "2018-07-08T07:40:24.395Z",
-    "grossLastValue": 0,
-    "commission": null
+	"account": 93592,
+	"currency": "XBt",
+	"riskLimit": 1000000000000,
+	"prevState": "",
+	"state": "",
+	"action": "",
+	"amount": 141755795,
+	"pendingCredit": 0,
+	"pendingDebit": 0,
+	"confirmedDebit": 0,
+	"prevRealisedPnl": 0,
+	"prevUnrealisedPnl": 0,
+	"grossComm": 0,
+	"grossOpenCost": 0,
+	"grossOpenPremium": 0,
+	"grossExecCost": 0,
+	"grossMarkValue": 0,
+	"riskValue": 0,
+	"taxableMargin": 0,
+	"initMargin": 0,
+	"maintMargin": 0,
+	"sessionMargin": 0,
+	"targetExcessMargin": 0,
+	"varMargin": 0,
+	"realisedPnl": 0,
+	"unrealisedPnl": 0,
+	"indicativeTax": 0,
+	"unrealisedProfit": 0,
+	"syntheticMargin": 0,
+	"walletBalance": 141755795,
+	"marginBalance": 141755795,
+	"marginBalancePcnt": 1,
+	"marginLeverage": 0,
+	"marginUsedPcnt": 0,
+	"excessMargin": 141755795,
+	"excessMarginPcnt": 1,
+	"availableMargin": 141755795,
+	"withdrawableMargin": 141755795,
+	"timestamp": "2018-07-08T07:40:24.395Z",
+	"grossLastValue": 0,
+	"commission": null
   }
 ]}
-             */
+			 */
 
 
-            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
-            var payload = await GetNoncePayloadAsync();
-            JToken token = await MakeJsonRequestAsync<JToken>($"/user/margin?currency=all", BaseUrl, payload);
-            foreach (var item in token)
-            {
-                var balance = item["marginBalance"].ConvertInvariant<decimal>();
-                var currency = item["currency"].ToStringInvariant();
+			Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+			var payload = await GetNoncePayloadAsync();
+			JToken token = await MakeJsonRequestAsync<JToken>($"/user/margin?currency=all", BaseUrl, payload);
+			foreach (var item in token)
+			{
+				var balance = item["marginBalance"].ConvertInvariant<decimal>();
+				var currency = item["currency"].ToStringInvariant();
 
-                if (amounts.ContainsKey(currency))
-                {
-                    amounts[currency] += balance;
-                }
-                else
-                {
-                    amounts[currency] = balance;
-                }
-            }
-            return amounts;
-        }
+				if (amounts.ContainsKey(currency))
+				{
+					amounts[currency] += balance;
+				}
+				else
+				{
+					amounts[currency] = balance;
+				}
+			}
+			return amounts;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
-        {
-            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
-            var payload = await GetNoncePayloadAsync();
-            JToken token = await MakeJsonRequestAsync<JToken>($"/user/margin?currency=all", BaseUrl, payload);
-            foreach (var item in token)
-            {
-                var balance = item["availableMargin"].ConvertInvariant<decimal>();
-                var currency = item["currency"].ToStringInvariant();
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+		{
+			Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+			var payload = await GetNoncePayloadAsync();
+			JToken token = await MakeJsonRequestAsync<JToken>($"/user/margin?currency=all", BaseUrl, payload);
+			foreach (var item in token)
+			{
+				var balance = item["availableMargin"].ConvertInvariant<decimal>();
+				var currency = item["currency"].ToStringInvariant();
 
-                if (amounts.ContainsKey(currency))
-                {
-                    amounts[currency] += balance;
-                }
-                else
-                {
-                    amounts[currency] = balance;
-                }
-            }
-            return amounts;
-        }
+				if (amounts.ContainsKey(currency))
+				{
+					amounts[currency] += balance;
+				}
+				else
+				{
+					amounts[currency] = balance;
+				}
+			}
+			return amounts;
+		}
 
-        public async Task<IEnumerable<ExchangePosition>> GetCurrentPositionsAsync()
-        {
-            var payload = await GetNoncePayloadAsync();
-            string url = "/position?";
-            url += "&columns=[\"symbol\", \"currentQty\", \"avgEntryPrice\", \"liquidationPrice\", \"leverage\", \"lastPrice\", \"currentTimestamp\"]";
-            JToken token = await MakeJsonRequestAsync<JToken>(url, BaseUrl, payload);
-            List<ExchangePosition> positions = new List<ExchangePosition>();
-            foreach (var item in token)
-            {
-                positions.Add(ParsePosition(item));
-            }
-            return positions;
-        }
+		public async Task<IEnumerable<ExchangePosition>> GetCurrentPositionsAsync()
+		{
+			var payload = await GetNoncePayloadAsync();
+			string url = "/position?";
+			url += "&columns=[\"symbol\", \"currentQty\", \"avgEntryPrice\", \"liquidationPrice\", \"leverage\", \"lastPrice\", \"currentTimestamp\"]";
+			JToken token = await MakeJsonRequestAsync<JToken>(url, BaseUrl, payload);
+			List<ExchangePosition> positions = new List<ExchangePosition>();
+			foreach (var item in token)
+			{
+				positions.Add(ParsePosition(item));
+			}
+			return positions;
+		}
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
-        {
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            //string query = "/order";
-            string query = "/order?filter={\"open\": true}";
-            if (!string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                query += "&symbol=" + NormalizeMarketSymbol(marketSymbol);
-            }
-            JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "GET");
-            foreach (JToken order in token)
-            {
-                orders.Add(ParseOrder(order));
-            }
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
+		{
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			//string query = "/order";
+			string query = "/order?filter={\"open\": true}";
+			if (!string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				query += "&symbol=" + NormalizeMarketSymbol(marketSymbol);
+			}
+			JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "GET");
+			foreach (JToken order in token)
+			{
+				orders.Add(ParseOrder(order));
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
-        {
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            string query = $"/order?filter={{\"orderID\": \"{orderId}\"}}";
-            JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "GET");
-            foreach (JToken order in token)
-            {
-                orders.Add(ParseOrder(order));
-            }
+		protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
+		{
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			string query = $"/order?filter={{\"orderID\": \"{orderId}\"}}";
+			JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "GET");
+			foreach (JToken order in token)
+			{
+				orders.Add(ParseOrder(order));
+			}
 
-            return orders[0];
-        }
+			return orders[0];
+		}
 
-        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
-        {
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["orderID"] = orderId;
-            JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrl, payload, "DELETE");
-        }
-    
-        public async Task CancelAllOrdersAsync(string marketSymbol = null)
-        {
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            string query = "/order/all";
-            if (!string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                payload["symbol"] = NormalizeMarketSymbol(marketSymbol);
-            }
-            JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "DELETE");
-        }
+		protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
+		{
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			payload["orderID"] = orderId;
+			JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrl, payload, "DELETE");
+		}
+	
+		public async Task CancelAllOrdersAsync(string marketSymbol = null)
+		{
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			string query = "/order/all";
+			if (!string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				payload["symbol"] = NormalizeMarketSymbol(marketSymbol);
+			}
+			JToken token = await MakeJsonRequestAsync<JToken>(query, BaseUrl, payload, "DELETE");
+		}
 
-        public async Task DeadmanAsync(int timeoutMS)
-        {
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            payload["timeout"] = timeoutMS;
-            JToken token = await MakeJsonRequestAsync<JToken>("/order/cancelAllAfter", BaseUrl, payload, "POST");
-        }
-        
-        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
-        {
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            AddOrderToPayload(order, payload);
-            JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrl, payload, "POST");
-            return ParseOrder(token);
-        }
+		public async Task DeadmanAsync(int timeoutMS)
+		{
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			payload["timeout"] = timeoutMS;
+			JToken token = await MakeJsonRequestAsync<JToken>("/order/cancelAllAfter", BaseUrl, payload, "POST");
+		}
+		
+		protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+		{
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			AddOrderToPayload(order, payload);
+			JToken token = await MakeJsonRequestAsync<JToken>("/order", BaseUrl, payload, "POST");
+			return ParseOrder(token);
+		}
 
-        private async Task<ExchangeOrderResult[]> PlaceOrdersAsync(string requestMethod, params ExchangeOrderRequest[] orders)
-        {
-            List<ExchangeOrderResult> results = new List<ExchangeOrderResult>();
-            Dictionary<string, object> payload = await GetNoncePayloadAsync();
-            List<Dictionary<string, object>> orderRequests = new List<Dictionary<string, object>>();
-            foreach (ExchangeOrderRequest order in orders)
-            {
-                Dictionary<string, object> subPayload = new Dictionary<string, object>();
-                AddOrderToPayload(order, subPayload);
-                orderRequests.Add(subPayload);
-            }
-            payload["orders"] = orderRequests;
-            JToken token = await MakeJsonRequestAsync<JToken>("/order/bulk", BaseUrl, payload, requestMethod);
-            foreach (JToken orderResultToken in token)
-            {
-                results.Add(ParseOrder(orderResultToken));
-            }
-            return results.ToArray();
-        }
+		private async Task<ExchangeOrderResult[]> PlaceOrdersAsync(string requestMethod, params ExchangeOrderRequest[] orders)
+		{
+			List<ExchangeOrderResult> results = new List<ExchangeOrderResult>();
+			Dictionary<string, object> payload = await GetNoncePayloadAsync();
+			List<Dictionary<string, object>> orderRequests = new List<Dictionary<string, object>>();
+			foreach (ExchangeOrderRequest order in orders)
+			{
+				Dictionary<string, object> subPayload = new Dictionary<string, object>();
+				AddOrderToPayload(order, subPayload);
+				orderRequests.Add(subPayload);
+			}
+			payload["orders"] = orderRequests;
+			JToken token = await MakeJsonRequestAsync<JToken>("/order/bulk", BaseUrl, payload, requestMethod);
+			foreach (JToken orderResultToken in token)
+			{
+				results.Add(ParseOrder(orderResultToken));
+			}
+			return results.ToArray();
+		}
 
-        protected override async Task<ExchangeOrderResult[]> OnPlaceOrdersAsync(params ExchangeOrderRequest[] orders)
-        {
-            return await PlaceOrdersAsync("POST", orders);
-        }
+		protected override async Task<ExchangeOrderResult[]> OnPlaceOrdersAsync(params ExchangeOrderRequest[] orders)
+		{
+			return await PlaceOrdersAsync("POST", orders);
+		}
 
-        public async Task<ExchangeOrderResult[]> AmendOrdersAsync(params ExchangeOrderRequest[] orders)
-        {
-            return await PlaceOrdersAsync("PUT", orders);
-        }
+		public async Task<ExchangeOrderResult[]> AmendOrdersAsync(params ExchangeOrderRequest[] orders)
+		{
+			return await PlaceOrdersAsync("PUT", orders);
+		}
 
-        private void AddOrderToPayload(ExchangeOrderRequest order, Dictionary<string, object> payload)
-        {
-            payload["symbol"] = order.MarketSymbol;
-            payload["ordType"] = order.OrderType.ToStringInvariant();
-            payload["side"] = order.IsBuy ? "Buy" : "Sell";
-            payload["orderQty"] = order.Amount;
+		private void AddOrderToPayload(ExchangeOrderRequest order, Dictionary<string, object> payload)
+		{
+			payload["symbol"] = order.MarketSymbol;
+			payload["ordType"] = order.OrderType.ToStringInvariant();
+			payload["side"] = order.IsBuy ? "Buy" : "Sell";
+			payload["orderQty"] = order.Amount;
 
-            if(order.OrderId != null)
-                payload["orderID"] = order.OrderId;
+			if(order.OrderId != null)
+				payload["orderID"] = order.OrderId;
 
-            if(order.ClientOrderId != null)
-                payload["clOrdID"] = order.ClientOrderId;
+			if(order.ClientOrderId != null)
+				payload["clOrdID"] = order.ClientOrderId;
 
-            if(order.OrderType!=OrderType.Market)
-                payload["price"] = order.Price;
+			if(order.OrderType!=OrderType.Market)
+				payload["price"] = order.Price;
 
-            if (order.ExtraParameters.TryGetValue("execInst", out var execInst))
-            {
-                payload["execInst"] = execInst;
-            }
-        }
+			if (order.ExtraParameters.TryGetValue("execInst", out var execInst))
+			{
+				payload["execInst"] = execInst;
+			}
+		}
 
-        private ExchangePosition ParsePosition(JToken token)
-        {
-            ExchangePosition result = new ExchangePosition
-            {
-                MarketSymbol = token["symbol"].ToStringUpperInvariant(),
-                Amount = token["currentQty"].ConvertInvariant<decimal>(),
-                AveragePrice = token["avgEntryPrice"].ConvertInvariant<decimal>(),
-                LiquidationPrice = token["liquidationPrice"].ConvertInvariant<decimal>(),
-                Leverage = token["leverage"].ConvertInvariant<decimal>(),
-                LastPrice = token["lastPrice"].ConvertInvariant<decimal>(),
-                TimeStamp = CryptoUtility.ParseTimestamp(token["currentTimestamp"], TimestampType.Iso8601)
-            };
-            return result;
-        }
+		private ExchangePosition ParsePosition(JToken token)
+		{
+			ExchangePosition result = new ExchangePosition
+			{
+				MarketSymbol = token["symbol"].ToStringUpperInvariant(),
+				Amount = token["currentQty"].ConvertInvariant<decimal>(),
+				AveragePrice = token["avgEntryPrice"].ConvertInvariant<decimal>(),
+				LiquidationPrice = token["liquidationPrice"].ConvertInvariant<decimal>(),
+				Leverage = token["leverage"].ConvertInvariant<decimal>(),
+				LastPrice = token["lastPrice"].ConvertInvariant<decimal>(),
+				TimeStamp = CryptoUtility.ParseTimestamp(token["currentTimestamp"], TimestampType.Iso8601)
+			};
+			return result;
+		}
 
-        private ExchangeOrderResult ParseOrder(JToken token)
-        {
-            /*
+		private ExchangeOrderResult ParseOrder(JToken token)
+		{
+			/*
 {[
   {
-    "orderID": "b7b8518a-c0d8-028d-bb6e-d843f8f723a3",
-    "clOrdID": "",
-    "clOrdLinkID": "",
-    "account": 93592,
-    "symbol": "XBTUSD",
-    "side": "Buy",
-    "simpleOrderQty": null,
-    "orderQty": 1,
-    "price": 5500,
-    "displayQty": null,
-    "stopPx": null,
-    "pegOffsetValue": null,
-    "pegPriceType": "",
-    "currency": "USD",
-    "settlCurrency": "XBt",
-    "ordType": "Limit",
-    "timeInForce": "GoodTillCancel",
-    "execInst": "ParticipateDoNotInitiate",
-    "contingencyType": "",
-    "exDestination": "XBME",
-    "ordStatus": "Canceled",
-    "triggered": "",
-    "workingIndicator": false,
-    "ordRejReason": "",
-    "simpleLeavesQty": 0,
-    "leavesQty": 0,
-    "simpleCumQty": 0,
-    "cumQty": 0,
-    "avgPx": null,
-    "multiLegReportingType": "SingleSecurity",
-    "text": "Canceled: Canceled via API.\nSubmission from testnet.bitmex.com",
-    "transactTime": "2018-07-08T09:20:39.428Z",
-    "timestamp": "2018-07-08T11:35:05.334Z"
+	"orderID": "b7b8518a-c0d8-028d-bb6e-d843f8f723a3",
+	"clOrdID": "",
+	"clOrdLinkID": "",
+	"account": 93592,
+	"symbol": "XBTUSD",
+	"side": "Buy",
+	"simpleOrderQty": null,
+	"orderQty": 1,
+	"price": 5500,
+	"displayQty": null,
+	"stopPx": null,
+	"pegOffsetValue": null,
+	"pegPriceType": "",
+	"currency": "USD",
+	"settlCurrency": "XBt",
+	"ordType": "Limit",
+	"timeInForce": "GoodTillCancel",
+	"execInst": "ParticipateDoNotInitiate",
+	"contingencyType": "",
+	"exDestination": "XBME",
+	"ordStatus": "Canceled",
+	"triggered": "",
+	"workingIndicator": false,
+	"ordRejReason": "",
+	"simpleLeavesQty": 0,
+	"leavesQty": 0,
+	"simpleCumQty": 0,
+	"cumQty": 0,
+	"avgPx": null,
+	"multiLegReportingType": "SingleSecurity",
+	"text": "Canceled: Canceled via API.\nSubmission from testnet.bitmex.com",
+	"transactTime": "2018-07-08T09:20:39.428Z",
+	"timestamp": "2018-07-08T11:35:05.334Z"
   }
 ]}
-            */
-            ExchangeOrderResult result = new ExchangeOrderResult
-            {
-                Amount = token["orderQty"].ConvertInvariant<decimal>(),
-                AmountFilled = token["cumQty"].ConvertInvariant<decimal>(),
-                Price = token["price"].ConvertInvariant<decimal>(),
-                IsBuy = token["side"].ToStringInvariant().EqualsWithOption("Buy"),
-                OrderDate = token["transactTime"].ConvertInvariant<DateTime>(),
-                OrderId = token["orderID"].ToStringInvariant(),
-                ClientOrderId = token["clOrdID"].ToStringInvariant(),
-                MarketSymbol = token["symbol"].ToStringInvariant()
-            };
+			*/
+			ExchangeOrderResult result = new ExchangeOrderResult
+			{
+				Amount = token["orderQty"].ConvertInvariant<decimal>(),
+				AmountFilled = token["cumQty"].ConvertInvariant<decimal>(),
+				Price = token["price"].ConvertInvariant<decimal>(),
+				IsBuy = token["side"].ToStringInvariant().EqualsWithOption("Buy"),
+				OrderDate = token["transactTime"].ConvertInvariant<DateTime>(),
+				OrderId = token["orderID"].ToStringInvariant(),
+				ClientOrderId = token["clOrdID"].ToStringInvariant(),
+				MarketSymbol = token["symbol"].ToStringInvariant()
+			};
 
-            // http://www.onixs.biz/fix-dictionary/5.0.SP2/tagNum_39.html
-            switch (token["ordStatus"].ToStringInvariant())
-            {
-                case "New":
-                    result.Result = ExchangeAPIOrderResult.Pending;
-                    break;
-                case "PartiallyFilled":
-                    result.Result = ExchangeAPIOrderResult.FilledPartially;
-                    break;
-                case "Filled":
-                    result.Result = ExchangeAPIOrderResult.Filled;
-                    break;
-                case "Canceled":
-                    result.Result = ExchangeAPIOrderResult.Canceled;
-                    break;
+			// http://www.onixs.biz/fix-dictionary/5.0.SP2/tagNum_39.html
+			switch (token["ordStatus"].ToStringInvariant())
+			{
+				case "New":
+					result.Result = ExchangeAPIOrderResult.Pending;
+					break;
+				case "PartiallyFilled":
+					result.Result = ExchangeAPIOrderResult.FilledPartially;
+					break;
+				case "Filled":
+					result.Result = ExchangeAPIOrderResult.Filled;
+					break;
+				case "Canceled":
+					result.Result = ExchangeAPIOrderResult.Canceled;
+					break;
 
-                default:
-                    result.Result = ExchangeAPIOrderResult.Error;
-                    break;
-            }
+				default:
+					result.Result = ExchangeAPIOrderResult.Error;
+					break;
+			}
 
-            return result;
-        }
+			return result;
+		}
 
 
-        //private decimal GetInstrumentTickSize(ExchangeMarket market)
-        //{
-        //    if (market.MarketName == "XBTUSD")
-        //    {
-        //        return 0.01m;
-        //    }
-        //    return market.PriceStepSize.Value;
-        //}
+		//private decimal GetInstrumentTickSize(ExchangeMarket market)
+		//{
+		//    if (market.MarketName == "XBTUSD")
+		//    {
+		//        return 0.01m;
+		//    }
+		//    return market.PriceStepSize.Value;
+		//}
 
-        //private ExchangeMarket GetMarket(string symbol)
-        //{
-        //    var m = GetSymbolsMetadata();
-        //    return m.Where(x => x.MarketName == symbol).First();
-        //}
+		//private ExchangeMarket GetMarket(string symbol)
+		//{
+		//    var m = GetSymbolsMetadata();
+		//    return m.Where(x => x.MarketName == symbol).First();
+		//}
 
-        //private decimal GetPriceFromID(long id, ExchangeMarket market)
-        //{
-        //    return ((100000000L * market.Idx) - id) * GetInstrumentTickSize(market);
-        //}
+		//private decimal GetPriceFromID(long id, ExchangeMarket market)
+		//{
+		//    return ((100000000L * market.Idx) - id) * GetInstrumentTickSize(market);
+		//}
 
-        //private long GetIDFromPrice(decimal price, ExchangeMarket market)
-        //{
-        //    return (long)((100000000L * market.Idx) - (price / GetInstrumentTickSize(market)));
-        //}
-    }
+		//private long GetIDFromPrice(decimal price, ExchangeMarket market)
+		//{
+		//    return (long)((100000000L * market.Idx) - (price / GetInstrumentTickSize(market)));
+		//}
+	}
 
-    public partial class ExchangeName { public const string BitMEX = "BitMEX"; }
+	public partial class ExchangeName { public const string BitMEX = "BitMEX"; }
 }

--- a/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -188,7 +188,7 @@ namespace ExchangeSharp
 		protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] marketSymbols)
 		{
 			Dictionary<int, string> channelIdToSymbol = new Dictionary<int, string>();
-			return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token is JArray array)
@@ -229,7 +229,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync("/2", async (_socket, msg) => //use websocket V2 (beta, but millisecond timestamp)
+			return await ConnectPublicWebSocketAsync("/2", async (_socket, msg) => //use websocket V2 (beta, but millisecond timestamp)
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token is JArray array)
@@ -526,7 +526,7 @@ namespace ExchangeSharp
 
 		protected override Task<IWebSocket> OnGetCompletedOrderDetailsWebSocketAsync(Action<ExchangeOrderResult> callback)
 		{
-			return ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+			return ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token[1].ToStringInvariant() == "hb")

--- a/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -507,7 +507,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(null, messageCallback: async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["event"].ToStringInvariant() == "bts:error")

--- a/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
@@ -24,134 +24,134 @@ using Newtonsoft.Json.Linq;
 
 namespace ExchangeSharp
 {
-    public sealed partial class ExchangeBybitAPI : ExchangeAPI
-    {
-        private int _recvWindow = 30000;
+	public sealed partial class ExchangeBybitAPI : ExchangeAPI
+	{
+		private int _recvWindow = 30000;
 
-        public override string BaseUrl { get; set; } = "https://api.bybit.com";
-        public override string BaseUrlWebSocket { get; set; } = "wss://stream.bybit.com/realtime";
+		public override string BaseUrl { get; set; } = "https://api.bybit.com";
+		public override string BaseUrlWebSocket { get; set; } = "wss://stream.bybit.com/realtime";
 		// public override string BaseUrl { get; set; } = "https://api-testnet.bybit.com/";
 		// public override string BaseUrlWebSocket { get; set; } = "wss://stream-testnet.bybit.com/realtime";
 
 		private ExchangeBybitAPI()
-        {
+		{
 			NonceStyle = NonceStyle.UnixMilliseconds;
-            NonceOffset = TimeSpan.FromSeconds(1.0);
+			NonceOffset = TimeSpan.FromSeconds(1.0);
 
-            MarketSymbolSeparator = string.Empty;
-            RequestContentType = "application/json";
-            WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
+			MarketSymbolSeparator = string.Empty;
+			RequestContentType = "application/json";
+			WebSocketOrderBookType = WebSocketOrderBookType.FullBookFirstThenDeltas;
 
-            RateLimit = new RateGate(500, TimeSpan.FromMinutes(1));
-        }
+			RateLimit = new RateGate(500, TimeSpan.FromMinutes(1));
+		}
 
-        public override Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
-        {
-            throw new NotImplementedException();
-        }
+		public override Task<string> ExchangeMarketSymbolToGlobalMarketSymbolAsync(string marketSymbol)
+		{
+			throw new NotImplementedException();
+		}
 
-        public override Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
-        {
-            throw new NotImplementedException();
-        }
+		public override Task<string> GlobalMarketSymbolToExchangeMarketSymbolAsync(string marketSymbol)
+		{
+			throw new NotImplementedException();
+		}
 
-        // Was initially struggling with 10002 timestamp errors, so tried calcing clock drift on every request.
-        // Settled on positive NonceOffset so our clock is not likely ahead of theirs on arrival (assuming accurate client/server side clocks)
-        // And larger recv_window so our packets have plenty of time to arrive
-        // protected override async Task OnGetNonceOffset()
-        // {
-        //     string stringResult = await MakeRequestAsync("/v2/public/time");
-        //     var token  = JsonConvert.DeserializeObject<JToken>(stringResult);
-        //     DateTime serverDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(token["time_now"].ConvertInvariant<Double>());
-        //     var now = CryptoUtility.UtcNow;
-        //     NonceOffset = now - serverDate + TimeSpan.FromSeconds(1); // how much time to substract from Nonce when making a request
-        // }
+		// Was initially struggling with 10002 timestamp errors, so tried calcing clock drift on every request.
+		// Settled on positive NonceOffset so our clock is not likely ahead of theirs on arrival (assuming accurate client/server side clocks)
+		// And larger recv_window so our packets have plenty of time to arrive
+		// protected override async Task OnGetNonceOffset()
+		// {
+		//     string stringResult = await MakeRequestAsync("/v2/public/time");
+		//     var token  = JsonConvert.DeserializeObject<JToken>(stringResult);
+		//     DateTime serverDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(token["time_now"].ConvertInvariant<Double>());
+		//     var now = CryptoUtility.UtcNow;
+		//     NonceOffset = now - serverDate + TimeSpan.FromSeconds(1); // how much time to substract from Nonce when making a request
+		// }
 
-        protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
-        {
-            if ((payload != null) && payload.ContainsKey("sign") && request.Method == "POST")
-            {
-                await CryptoUtility.WritePayloadJsonToRequestAsync(request, payload);
-            }
-        }
+		protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
+		{
+			if ((payload != null) && payload.ContainsKey("sign") && request.Method == "POST")
+			{
+				await CryptoUtility.WritePayloadJsonToRequestAsync(request, payload);
+			}
+		}
 
 #nullable enable
-        //Not using MakeJsonRequest... so we can perform our own check on the ret_code 
-        private async Task<T> DoMakeJsonRequestAsync<T>(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? requestMethod = null)
-        {
-            await new SynchronizationContextRemover();
+		//Not using MakeJsonRequest... so we can perform our own check on the ret_code 
+		private async Task<T> DoMakeJsonRequestAsync<T>(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? requestMethod = null)
+		{
+			await new SynchronizationContextRemover();
 
-            string stringResult = await MakeRequestAsync(url, baseUrl, payload, requestMethod);
-            return JsonConvert.DeserializeObject<T>(stringResult);
-        }
+			string stringResult = await MakeRequestAsync(url, baseUrl, payload, requestMethod);
+			return JsonConvert.DeserializeObject<T>(stringResult);
+		}
 #nullable disable
 
-        private JToken CheckRetCode(JToken response, string[] allowedRetCodes)
-        {
-            var result = GetResult(response, out var retCode, out var retMessage);
-            if (!allowedRetCodes.Contains(retCode))
-            {
-                throw new Exception($"Invalid ret_code {retCode}, ret_msg {retMessage}");
-            }
-            return result;
-        }
+		private JToken CheckRetCode(JToken response, string[] allowedRetCodes)
+		{
+			var result = GetResult(response, out var retCode, out var retMessage);
+			if (!allowedRetCodes.Contains(retCode))
+			{
+				throw new Exception($"Invalid ret_code {retCode}, ret_msg {retMessage}");
+			}
+			return result;
+		}
    
-        private JToken CheckRetCode(JToken response)
-        {
-            return CheckRetCode(response, new string[] {"0"});
-        }
+		private JToken CheckRetCode(JToken response)
+		{
+			return CheckRetCode(response, new string[] {"0"});
+		}
 
-        private JToken GetResult(JToken response, out string retCode, out string retMessage)
-        {
-            retCode = response["ret_code"].ToStringInvariant();
-            retMessage = response["ret_msg"].ToStringInvariant();
-            return response["result"];
-        }
+		private JToken GetResult(JToken response, out string retCode, out string retMessage)
+		{
+			retCode = response["ret_code"].ToStringInvariant();
+			retMessage = response["ret_msg"].ToStringInvariant();
+			return response["result"];
+		}
 
-        private async Task SendWebsocketAuth(IWebSocket socket) {
-            var payload = await GetNoncePayloadAsync();
-            var nonce = (payload["nonce"].ConvertInvariant<long>() + 5000).ToStringInvariant();
-            var signature = CryptoUtility.SHA256Sign($"GET/realtime{nonce}", CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
+		private async Task SendWebsocketAuth(IWebSocket socket) {
+			var payload = await GetNoncePayloadAsync();
+			var nonce = (payload["nonce"].ConvertInvariant<long>() + 5000).ToStringInvariant();
+			var signature = CryptoUtility.SHA256Sign($"GET/realtime{nonce}", CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
 			await socket.SendMessageAsync(new { op = "auth", args = new [] {PublicApiKey.ToUnsecureString(), nonce, signature} });
-        }
+		}
 
-        private async Task<Dictionary<string, object>> GetAuthenticatedPayload(Dictionary<string, object> requestPayload = null)
-        {
-            var payload = await GetNoncePayloadAsync();
-            var nonce = payload["nonce"].ConvertInvariant<long>();
-            payload.Remove("nonce");
-            payload["api_key"] = PublicApiKey.ToUnsecureString();
-            payload["timestamp"] = nonce.ToStringInvariant();
-            payload["recv_window"] = _recvWindow; 
-            if (requestPayload != null)
-            {
-                payload = payload.Concat(requestPayload).ToDictionary(p => p.Key, p => p.Value);
-            }
+		private async Task<Dictionary<string, object>> GetAuthenticatedPayload(Dictionary<string, object> requestPayload = null)
+		{
+			var payload = await GetNoncePayloadAsync();
+			var nonce = payload["nonce"].ConvertInvariant<long>();
+			payload.Remove("nonce");
+			payload["api_key"] = PublicApiKey.ToUnsecureString();
+			payload["timestamp"] = nonce.ToStringInvariant();
+			payload["recv_window"] = _recvWindow; 
+			if (requestPayload != null)
+			{
+				payload = payload.Concat(requestPayload).ToDictionary(p => p.Key, p => p.Value);
+			}
 
-            string form = CryptoUtility.GetFormForPayload(payload, false, true);
-            form = form.Replace("=False", "=false");
-            form = form.Replace("=True", "=true");
-            payload["sign"] = CryptoUtility.SHA256Sign(form, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
-            return payload;
-        }
+			string form = CryptoUtility.GetFormForPayload(payload, false, true);
+			form = form.Replace("=False", "=false");
+			form = form.Replace("=True", "=true");
+			payload["sign"] = CryptoUtility.SHA256Sign(form, CryptoUtility.ToUnsecureBytesUTF8(PrivateApiKey));
+			return payload;
+		}
 
-        private async Task<string> GetAuthenticatedQueryString(Dictionary<string, object> requestPayload = null)
-        {
-            var payload = await GetAuthenticatedPayload(requestPayload);
-            var sign = payload["sign"].ToStringInvariant();
-            payload.Remove("sign");
-            string form = CryptoUtility.GetFormForPayload(payload, false, true);
-            form += "&sign=" + sign;
-            return form;
-        }
+		private async Task<string> GetAuthenticatedQueryString(Dictionary<string, object> requestPayload = null)
+		{
+			var payload = await GetAuthenticatedPayload(requestPayload);
+			var sign = payload["sign"].ToStringInvariant();
+			payload.Remove("sign");
+			string form = CryptoUtility.GetFormForPayload(payload, false, true);
+			form += "&sign=" + sign;
+			return form;
+		}
 
-        private Task<IWebSocket> DoConnectWebSocketAsync(Func<IWebSocket, Task> connected, Func<IWebSocket, JToken, Task> callback, int symbolArrayIndex = 3)
-        {
+		private Task<IWebSocket> DoConnectWebSocketAsync(Func<IWebSocket, Task> connected, Func<IWebSocket, JToken, Task> callback, int symbolArrayIndex = 3)
+		{
 			Timer pingTimer = null;
-            return ConnectPublicWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
-            {
+			return ConnectPublicWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
+			{
 				var msgString = msg.ToStringFromUTF8();
-                JToken token = JToken.Parse(msgString);
+				JToken token = JToken.Parse(msgString);
 
 				if (token["ret_msg"]?.ToStringInvariant() == "pong")
 				{ // received reply to our ping
@@ -159,895 +159,895 @@ namespace ExchangeSharp
 				}
 
 				if (token["topic"] != null)
-                {
-	                var data = token["data"];
-		            await callback(_socket, data);
-                } 
-                else
-                {
-                    /*
-                    subscription response:
-                    {
-                        "success": true, // Whether subscription is successful
-                        "ret_msg": "",   // Successful subscription: "", otherwise it shows error message
-                        "conn_id":"e0e10eee-4eff-4d21-881e-a0c55c25e2da",// current connection id
-                        "request": {     // Request to your subscription
-                            "op": "subscribe",
-                            "args": [
-                                "kline.BTCUSD.1m"
-                            ]
-                        }
-                    }
-                    */
-                    JToken response = token["request"];
-                    var op = response["op"]?.ToStringInvariant();
-                    if ((response != null) && ((op == "subscribe") || (op == "auth"))) 
-                    {
-                        var responseMessage = token["ret_msg"]?.ToStringInvariant();
-                        if (responseMessage != "")
-                        {
-						    Logger.Info("Websocket unable to connect: " + msgString);
-					    	return;
-					    }
-                        else if (pingTimer == null)
-                        {
-                            /*
-                            ping response:
-                            {
-                                "success": true, // Whether ping is successful
-                                "ret_msg": "pong",
-                                "conn_id": "036e5d21-804c-4447-a92d-b65a44d00700",// current connection id
-                                "request": {
-                                    "op": "ping",
-                                    "args": null
-                                }
-                            }
-                            */
-                            pingTimer = new Timer(callback: async s => await _socket.SendMessageAsync(new { op = "ping" }),
-                                state: null, dueTime: 0, period: 15000); // send a ping every 15 seconds
-                            return;
-                        }
-                    }
+				{
+					var data = token["data"];
+					await callback(_socket, data);
+				} 
+				else
+				{
+					/*
+					subscription response:
+					{
+						"success": true, // Whether subscription is successful
+						"ret_msg": "",   // Successful subscription: "", otherwise it shows error message
+						"conn_id":"e0e10eee-4eff-4d21-881e-a0c55c25e2da",// current connection id
+						"request": {     // Request to your subscription
+							"op": "subscribe",
+							"args": [
+								"kline.BTCUSD.1m"
+							]
+						}
+					}
+					*/
+					JToken response = token["request"];
+					var op = response["op"]?.ToStringInvariant();
+					if ((response != null) && ((op == "subscribe") || (op == "auth"))) 
+					{
+						var responseMessage = token["ret_msg"]?.ToStringInvariant();
+						if (responseMessage != "")
+						{
+							Logger.Info("Websocket unable to connect: " + msgString);
+							return;
+						}
+						else if (pingTimer == null)
+						{
+							/*
+							ping response:
+							{
+								"success": true, // Whether ping is successful
+								"ret_msg": "pong",
+								"conn_id": "036e5d21-804c-4447-a92d-b65a44d00700",// current connection id
+								"request": {
+									"op": "ping",
+									"args": null
+								}
+							}
+							*/
+							pingTimer = new Timer(callback: async s => await _socket.SendMessageAsync(new { op = "ping" }),
+								state: null, dueTime: 0, period: 15000); // send a ping every 15 seconds
+							return;
+						}
+					}
 				}
-            }, 
-            connectCallback: async (_socket) => 
-            {
-                await connected(_socket);
-                _socket.ConnectInterval = TimeSpan.FromHours(0);
-            }, 
-            disconnectCallback: s =>
+			}, 
+			connectCallback: async (_socket) => 
+			{
+				await connected(_socket);
+				_socket.ConnectInterval = TimeSpan.FromHours(0);
+			}, 
+			disconnectCallback: s =>
 			{
 				pingTimer.Dispose();
 				pingTimer = null;
 				return Task.CompletedTask;
 			});
-        }
+		}
 
-        private async Task AddMarketSymbolsToChannel(IWebSocket socket, string argsPrefix, string[] marketSymbols)
-        {
-            string fullArgs = argsPrefix;
+		private async Task AddMarketSymbolsToChannel(IWebSocket socket, string argsPrefix, string[] marketSymbols)
+		{
+			string fullArgs = argsPrefix;
 			if (marketSymbols == null || marketSymbols.Length == 0)
 			{
 				fullArgs += "*";
 			} 
-            else 
-            {
-                foreach (var symbol in marketSymbols)
-                {
-                    fullArgs += symbol + "|";
-                } 
-                fullArgs = fullArgs.TrimEnd('|');
-            }
+			else 
+			{
+				foreach (var symbol in marketSymbols)
+				{
+					fullArgs += symbol + "|";
+				} 
+				fullArgs = fullArgs.TrimEnd('|');
+			}
 
 			await socket.SendMessageAsync(new { op = "subscribe", args = new [] {fullArgs} });
-        }
+		}
 
-        protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
-        {
+		protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
+		{
 			/*
-            request:
-            {"op":"subscribe","args":["trade.BTCUSD|XRPUSD"]}
+			request:
+			{"op":"subscribe","args":["trade.BTCUSD|XRPUSD"]}
 			*/
 			/*
-			    response:
-                {
-                    "topic": "trade.BTCUSD",
-                    "data": [
-                        {
-                            "timestamp": "2020-01-12T16:59:59.000Z",
-                            "trade_time_ms": 1582793344685, // trade time in millisecond
-                            "symbol": "BTCUSD",
-                            "side": "Sell",
-                            "size": 328,
-                            "price": 8098,
-                            "tick_direction": "MinusTick",
-                            "trade_id": "00c706e1-ba52-5bb0-98d0-bf694bdc69f7",
-                            "cross_seq": 1052816407
-                        }
-                    ]
-                }
+				response:
+				{
+					"topic": "trade.BTCUSD",
+					"data": [
+						{
+							"timestamp": "2020-01-12T16:59:59.000Z",
+							"trade_time_ms": 1582793344685, // trade time in millisecond
+							"symbol": "BTCUSD",
+							"side": "Sell",
+							"size": 328,
+							"price": 8098,
+							"tick_direction": "MinusTick",
+							"trade_id": "00c706e1-ba52-5bb0-98d0-bf694bdc69f7",
+							"cross_seq": 1052816407
+						}
+					]
+				}
 			 */
 			return await DoConnectWebSocketAsync(async (_socket) =>
 			{
 				await AddMarketSymbolsToChannel(_socket, "trade.", marketSymbols);
 			}, async (_socket, token) =>
 			{
-                foreach (var dataRow in token)
-                {
-                    ExchangeTrade trade = dataRow.ParseTrade(
-                        amountKey: "size", 
-                        priceKey: "price",
-                        typeKey: "side", 
-                        timestampKey: "timestamp",
-                        timestampType: TimestampType.Iso8601, 
-                        idKey: "trade_id");
-                    await callback(new KeyValuePair<string, ExchangeTrade>(dataRow["symbol"].ToStringInvariant(), trade));
-                }
+				foreach (var dataRow in token)
+				{
+					ExchangeTrade trade = dataRow.ParseTrade(
+						amountKey: "size", 
+						priceKey: "price",
+						typeKey: "side", 
+						timestampKey: "timestamp",
+						timestampType: TimestampType.Iso8601, 
+						idKey: "trade_id");
+					await callback(new KeyValuePair<string, ExchangeTrade>(dataRow["symbol"].ToStringInvariant(), trade));
+				}
 			});
-        }
+		}
 
 		protected override async Task<IWebSocket> OnGetPositionsWebSocketAsync(Action<ExchangePosition> callback)
-        {
+		{
 			/*
-            request:
-            {"op": "subscribe", "args": ["position"]}
+			request:
+			{"op": "subscribe", "args": ["position"]}
 			*/
 			/*
-			    response:
-                {
-                "topic": "position",
-                "action": "update",
-                "data": [
-                    {
-                        "user_id":  1,                            // user ID
-                        "symbol": "BTCUSD",                       // the contract for this position
-                        "size": 11,                               // the current position amount
-                        "side": "Sell",                           // side
-                        "position_value": "0.00159252",           // positional value
-                        "entry_price": "6907.291588174717",       // entry price
-                        "liq_price": "7100.234",                  // liquidation price
-                        "bust_price": "7088.1234",                // bankruptcy price
-                        "leverage": "1",                           // leverage
-                        "order_margin":  "1",                      // order margin
-                        "position_margin":  "1",                   // position margin
-                        "available_balance":  "2",                 // available balance
-                        "take_profit": "0",                        // take profit price           
-                        "tp_trigger_by":  "LastPrice",             // take profit trigger price, eg: LastPrice, IndexPrice. Conditional order only
-                        "stop_loss": "0",                          // stop loss price
-                        "sl_trigger_by":  "",                     // stop loss trigger price, eg: LastPrice, IndexPrice. Conditional order only
-                        "realised_pnl":  "0.10",               // realised PNL
-                        "trailing_stop": "0",                  // trailing stop points
-                        "trailing_active": "0",                // trailing stop trigger price
-                        "wallet_balance":  "4.12",             // wallet balance
-                        "risk_id":  1,                       
-                        "occ_closing_fee":  "0.1",             // position closing
-                        "occ_funding_fee":  "0.1",             // funding fee
-                        "auto_add_margin": 0,                  // auto margin replenishment switch
-                        "cum_realised_pnl":  "0.12",           // Total realized profit and loss
-                        "position_status": "Normal",           // status of position (Normal: normal Liq: in the process of liquidation Adl: in the process of Auto-Deleveraging)
-                                        // Auto margin replenishment enabled (0: no 1: yes)
-                        "position_seq": 14                     // position version number
-                    }
-                ]
-                }
+				response:
+				{
+				"topic": "position",
+				"action": "update",
+				"data": [
+					{
+						"user_id":  1,                            // user ID
+						"symbol": "BTCUSD",                       // the contract for this position
+						"size": 11,                               // the current position amount
+						"side": "Sell",                           // side
+						"position_value": "0.00159252",           // positional value
+						"entry_price": "6907.291588174717",       // entry price
+						"liq_price": "7100.234",                  // liquidation price
+						"bust_price": "7088.1234",                // bankruptcy price
+						"leverage": "1",                           // leverage
+						"order_margin":  "1",                      // order margin
+						"position_margin":  "1",                   // position margin
+						"available_balance":  "2",                 // available balance
+						"take_profit": "0",                        // take profit price           
+						"tp_trigger_by":  "LastPrice",             // take profit trigger price, eg: LastPrice, IndexPrice. Conditional order only
+						"stop_loss": "0",                          // stop loss price
+						"sl_trigger_by":  "",                     // stop loss trigger price, eg: LastPrice, IndexPrice. Conditional order only
+						"realised_pnl":  "0.10",               // realised PNL
+						"trailing_stop": "0",                  // trailing stop points
+						"trailing_active": "0",                // trailing stop trigger price
+						"wallet_balance":  "4.12",             // wallet balance
+						"risk_id":  1,                       
+						"occ_closing_fee":  "0.1",             // position closing
+						"occ_funding_fee":  "0.1",             // funding fee
+						"auto_add_margin": 0,                  // auto margin replenishment switch
+						"cum_realised_pnl":  "0.12",           // Total realized profit and loss
+						"position_status": "Normal",           // status of position (Normal: normal Liq: in the process of liquidation Adl: in the process of Auto-Deleveraging)
+										// Auto margin replenishment enabled (0: no 1: yes)
+						"position_seq": 14                     // position version number
+					}
+				]
+				}
 			 */
 			return await DoConnectWebSocketAsync(async (_socket) =>
 			{
-                await SendWebsocketAuth(_socket);
-			    await _socket.SendMessageAsync(new { op = "subscribe", args = new [] {"position"} });
+				await SendWebsocketAuth(_socket);
+				await _socket.SendMessageAsync(new { op = "subscribe", args = new [] {"position"} });
 			}, async (_socket, token) =>
 			{
-                foreach (var dataRow in token)
-                {
-                    callback(ParsePosition(dataRow));
-                }
-                await Task.CompletedTask;
+				foreach (var dataRow in token)
+				{
+					callback(ParsePosition(dataRow));
+				}
+				await Task.CompletedTask;
 			});
-        }
+		}
 
-        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
-        {
-            var m = await GetMarketSymbolsMetadataAsync();
-            return m.Select(x => x.MarketSymbol);
-        }
+		protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
+		{
+			var m = await GetMarketSymbolsMetadataAsync();
+			return m.Select(x => x.MarketSymbol);
+		}
 
-        protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
-        {
-            /*
-            {
-            "ret_code": 0,
-            "ret_msg": "OK",
-            "ext_code": "",
-            "ext_info": "",
-            "result": [
-                {
-                "name": "BTCUSD",
-                "base_currency": "BTC",
-                "quote_currency": "USD",
-                "price_scale": 2,
-                "taker_fee": "0.00075",
-                "maker_fee": "-0.00025",
-                "leverage_filter": {
-                    "min_leverage": 1,
-                    "max_leverage": 100,
-                    "leverage_step": "0.01"
-                },
-                "price_filter": {
-                    "min_price": "0.5",
-                    "max_price": "999999.5",
-                    "tick_size": "0.5"
-                },
-                "lot_size_filter": {
-                    "max_trading_qty": 1000000,
-                    "min_trading_qty": 1,
-                    "qty_step": 1
-                }
-                },
-                {
-                "name": "ETHUSD",
-                "base_currency": "ETH",
-                "quote_currency": "USD",
-                "price_scale": 2,
-                "taker_fee": "0.00075",
-                "maker_fee": "-0.00025",
-                "leverage_filter": {
-                    "min_leverage": 1,
-                    "max_leverage": 50,
-                    "leverage_step": "0.01"
-                },
-                "price_filter": {
-                    "min_price": "0.05",
-                    "max_price": "99999.95",
-                    "tick_size": "0.05"
-                },
-                "lot_size_filter": {
-                    "max_trading_qty": 1000000,
-                    "min_trading_qty": 1,
-                    "qty_step": 1
-                }
-                },
-                {
-                "name": "EOSUSD",
-                "base_currency": "EOS",
-                "quote_currency": "USD",
-                "price_scale": 3,
-                "taker_fee": "0.00075",
-                "maker_fee": "-0.00025",
-                "leverage_filter": {
-                    "min_leverage": 1,
-                    "max_leverage": 50,
-                    "leverage_step": "0.01"
-                },
-                "price_filter": {
-                    "min_price": "0.001",
-                    "max_price": "1999.999",
-                    "tick_size": "0.001"
-                },
-                "lot_size_filter": {
-                    "max_trading_qty": 1000000,
-                    "min_trading_qty": 1,
-                    "qty_step": 1
-                }
-                },
-                {
-                "name": "XRPUSD",
-                "base_currency": "XRP",
-                "quote_currency": "USD",
-                "price_scale": 4,
-                "taker_fee": "0.00075",
-                "maker_fee": "-0.00025",
-                "leverage_filter": {
-                    "min_leverage": 1,
-                    "max_leverage": 50,
-                    "leverage_step": "0.01"
-                },
-                "price_filter": {
-                    "min_price": "0.0001",
-                    "max_price": "199.9999",
-                    "tick_size": "0.0001"
-                },
-                "lot_size_filter": {
-                    "max_trading_qty": 1000000,
-                    "min_trading_qty": 1,
-                    "qty_step": 1
-                }
-                }
-            ],
-            "time_now": "1581411225.414179"
-            }}
-             */
+		protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
+		{
+			/*
+			{
+			"ret_code": 0,
+			"ret_msg": "OK",
+			"ext_code": "",
+			"ext_info": "",
+			"result": [
+				{
+				"name": "BTCUSD",
+				"base_currency": "BTC",
+				"quote_currency": "USD",
+				"price_scale": 2,
+				"taker_fee": "0.00075",
+				"maker_fee": "-0.00025",
+				"leverage_filter": {
+					"min_leverage": 1,
+					"max_leverage": 100,
+					"leverage_step": "0.01"
+				},
+				"price_filter": {
+					"min_price": "0.5",
+					"max_price": "999999.5",
+					"tick_size": "0.5"
+				},
+				"lot_size_filter": {
+					"max_trading_qty": 1000000,
+					"min_trading_qty": 1,
+					"qty_step": 1
+				}
+				},
+				{
+				"name": "ETHUSD",
+				"base_currency": "ETH",
+				"quote_currency": "USD",
+				"price_scale": 2,
+				"taker_fee": "0.00075",
+				"maker_fee": "-0.00025",
+				"leverage_filter": {
+					"min_leverage": 1,
+					"max_leverage": 50,
+					"leverage_step": "0.01"
+				},
+				"price_filter": {
+					"min_price": "0.05",
+					"max_price": "99999.95",
+					"tick_size": "0.05"
+				},
+				"lot_size_filter": {
+					"max_trading_qty": 1000000,
+					"min_trading_qty": 1,
+					"qty_step": 1
+				}
+				},
+				{
+				"name": "EOSUSD",
+				"base_currency": "EOS",
+				"quote_currency": "USD",
+				"price_scale": 3,
+				"taker_fee": "0.00075",
+				"maker_fee": "-0.00025",
+				"leverage_filter": {
+					"min_leverage": 1,
+					"max_leverage": 50,
+					"leverage_step": "0.01"
+				},
+				"price_filter": {
+					"min_price": "0.001",
+					"max_price": "1999.999",
+					"tick_size": "0.001"
+				},
+				"lot_size_filter": {
+					"max_trading_qty": 1000000,
+					"min_trading_qty": 1,
+					"qty_step": 1
+				}
+				},
+				{
+				"name": "XRPUSD",
+				"base_currency": "XRP",
+				"quote_currency": "USD",
+				"price_scale": 4,
+				"taker_fee": "0.00075",
+				"maker_fee": "-0.00025",
+				"leverage_filter": {
+					"min_leverage": 1,
+					"max_leverage": 50,
+					"leverage_step": "0.01"
+				},
+				"price_filter": {
+					"min_price": "0.0001",
+					"max_price": "199.9999",
+					"tick_size": "0.0001"
+				},
+				"lot_size_filter": {
+					"max_trading_qty": 1000000,
+					"min_trading_qty": 1,
+					"qty_step": 1
+				}
+				}
+			],
+			"time_now": "1581411225.414179"
+			}}
+			 */
 
-            List<ExchangeMarket> markets = new List<ExchangeMarket>();
-            JToken allSymbols = CheckRetCode(await DoMakeJsonRequestAsync<JToken>("/v2/public/symbols"));
+			List<ExchangeMarket> markets = new List<ExchangeMarket>();
+			JToken allSymbols = CheckRetCode(await DoMakeJsonRequestAsync<JToken>("/v2/public/symbols"));
 			foreach (JToken marketSymbolToken in allSymbols)
-            {
-                var market = new ExchangeMarket
-                {
-                    MarketSymbol = marketSymbolToken["name"].ToStringUpperInvariant(),
-                    IsActive = true,
-                    QuoteCurrency = marketSymbolToken["quote_currency"].ToStringUpperInvariant(),
-                    BaseCurrency = marketSymbolToken["base_currency"].ToStringUpperInvariant(),
-                };
+			{
+				var market = new ExchangeMarket
+				{
+					MarketSymbol = marketSymbolToken["name"].ToStringUpperInvariant(),
+					IsActive = true,
+					QuoteCurrency = marketSymbolToken["quote_currency"].ToStringUpperInvariant(),
+					BaseCurrency = marketSymbolToken["base_currency"].ToStringUpperInvariant(),
+				};
 
-                try
-                {
-                    JToken priceFilter = marketSymbolToken["price_filter"];
-                    market.MinPrice = priceFilter["min_price"].ConvertInvariant<decimal>();
-                    market.MaxPrice = priceFilter["max_price"].ConvertInvariant<decimal>();
-                    market.PriceStepSize = priceFilter["tick_size"].ConvertInvariant<decimal>();
+				try
+				{
+					JToken priceFilter = marketSymbolToken["price_filter"];
+					market.MinPrice = priceFilter["min_price"].ConvertInvariant<decimal>();
+					market.MaxPrice = priceFilter["max_price"].ConvertInvariant<decimal>();
+					market.PriceStepSize = priceFilter["tick_size"].ConvertInvariant<decimal>();
 
-                    JToken lotSizeFilter = marketSymbolToken["lot_size_filter"];
-                    market.MinTradeSize = lotSizeFilter["min_trading_qty"].ConvertInvariant<decimal>();
-                    market.MaxTradeSize = lotSizeFilter["max_trading_qty"].ConvertInvariant<decimal>();
-                    market.QuantityStepSize = lotSizeFilter["qty_step"].ConvertInvariant<decimal>();
-                }
-                catch
-                {
+					JToken lotSizeFilter = marketSymbolToken["lot_size_filter"];
+					market.MinTradeSize = lotSizeFilter["min_trading_qty"].ConvertInvariant<decimal>();
+					market.MaxTradeSize = lotSizeFilter["max_trading_qty"].ConvertInvariant<decimal>();
+					market.QuantityStepSize = lotSizeFilter["qty_step"].ConvertInvariant<decimal>();
+				}
+				catch
+				{
 
-                }
-                markets.Add(market);
-            }
-            return markets;
-        }
+				}
+				markets.Add(market);
+			}
+			return markets;
+		}
 
-        
-        private async Task<Dictionary<string, decimal>> DoGetAmountsAsync(string field)
-        {
-            /*
-            {
-                "ret_code": 0,
-                "ret_msg": "OK",
-                "ext_code": "",
-                "ext_info": "",
-                "result": {
-                    "BTC": {
-                        "equity": 1002,                         //equity = wallet_balance + unrealised_pnl
-                        "available_balance": 999.99987471,      //available_balance
-                        //In Isolated Margin Mode:
-                        // available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin)
-                        //In Cross Margin Mode:
-                        //if unrealised_pnl > 0:
-                        //available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin)；
-                        //if unrealised_pnl < 0:
-                        //available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin) + unrealised_pnl
-                        "used_margin": 0.00012529,              //used_margin = wallet_balance - available_balance
-                        "order_margin": 0.00012529,             //Used margin by order
-                        "position_margin": 0,                   //position margin
-                        "occ_closing_fee": 0,                   //position closing fee
-                        "occ_funding_fee": 0,                   //funding fee
-                        "wallet_balance": 1000,                 //wallet balance. When in Cross Margin mod, the number minus your unclosed loss is your real wallet balance.
-                        "realised_pnl": 0,                      //daily realized profit and loss
-                        "unrealised_pnl": 2,                    //unrealised profit and loss
-                            //when side is sell:
-                            // unrealised_pnl = size * (1.0 / mark_price -  1.0 / entry_price）
-                            //when side is buy:
-                            // unrealised_pnl = size * (1.0 / entry_price -  1.0 / mark_price）
-                        "cum_realised_pnl": 0,                  //total relised profit and loss
-                        "given_cash": 0,                        //given_cash
-                        "service_cash": 0                       //service_cash
-                    }
-                },
-                "time_now": "1578284274.816029",
-                "rate_limit_status": 98,
-                "rate_limit_reset_ms": 1580885703683,
-                "rate_limit": 100
-            }
-            */
-            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
-            var queryString = await GetAuthenticatedQueryString();
-            JToken currencies = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/wallet/balance?" + queryString, BaseUrl, null, "GET"));
-            foreach (JProperty currency in currencies.Children<JProperty>())
-            {
-                var balance = currency.Value[field].ConvertInvariant<decimal>();
-                if (amounts.ContainsKey(currency.Name))
-                {
-                    amounts[currency.Name] += balance;
-                }
-                else
-                {
-                    amounts[currency.Name] = balance;
-                }
-            }
-            return amounts;
-        }
+		
+		private async Task<Dictionary<string, decimal>> DoGetAmountsAsync(string field)
+		{
+			/*
+			{
+				"ret_code": 0,
+				"ret_msg": "OK",
+				"ext_code": "",
+				"ext_info": "",
+				"result": {
+					"BTC": {
+						"equity": 1002,                         //equity = wallet_balance + unrealised_pnl
+						"available_balance": 999.99987471,      //available_balance
+						//In Isolated Margin Mode:
+						// available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin)
+						//In Cross Margin Mode:
+						//if unrealised_pnl > 0:
+						//available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin)；
+						//if unrealised_pnl < 0:
+						//available_balance = wallet_balance - (position_margin + occ_closing_fee + occ_funding_fee + order_margin) + unrealised_pnl
+						"used_margin": 0.00012529,              //used_margin = wallet_balance - available_balance
+						"order_margin": 0.00012529,             //Used margin by order
+						"position_margin": 0,                   //position margin
+						"occ_closing_fee": 0,                   //position closing fee
+						"occ_funding_fee": 0,                   //funding fee
+						"wallet_balance": 1000,                 //wallet balance. When in Cross Margin mod, the number minus your unclosed loss is your real wallet balance.
+						"realised_pnl": 0,                      //daily realized profit and loss
+						"unrealised_pnl": 2,                    //unrealised profit and loss
+							//when side is sell:
+							// unrealised_pnl = size * (1.0 / mark_price -  1.0 / entry_price）
+							//when side is buy:
+							// unrealised_pnl = size * (1.0 / entry_price -  1.0 / mark_price）
+						"cum_realised_pnl": 0,                  //total relised profit and loss
+						"given_cash": 0,                        //given_cash
+						"service_cash": 0                       //service_cash
+					}
+				},
+				"time_now": "1578284274.816029",
+				"rate_limit_status": 98,
+				"rate_limit_reset_ms": 1580885703683,
+				"rate_limit": 100
+			}
+			*/
+			Dictionary<string, decimal> amounts = new Dictionary<string, decimal>();
+			var queryString = await GetAuthenticatedQueryString();
+			JToken currencies = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/wallet/balance?" + queryString, BaseUrl, null, "GET"));
+			foreach (JProperty currency in currencies.Children<JProperty>())
+			{
+				var balance = currency.Value[field].ConvertInvariant<decimal>();
+				if (amounts.ContainsKey(currency.Name))
+				{
+					amounts[currency.Name] += balance;
+				}
+				else
+				{
+					amounts[currency.Name] = balance;
+				}
+			}
+			return amounts;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
-        {
-            return await DoGetAmountsAsync("equity");
-        }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+		{
+			return await DoGetAmountsAsync("equity");
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
-        {
-            return await DoGetAmountsAsync("available_balance");
-        }
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
-        {
-            /*
-            {
-                "ret_code": 0,                              // return code
-                "ret_msg": "OK",                            // error message
-                "ext_code": "",                             // additional error code
-                "ext_info": "",                             // additional error info
-                "result": [
-                    {
-                        "symbol": "BTCUSD",                 // symbol
-                        "price": "9487",                    // price
-                        "size": 336241,                     // size (in USD contracts)
-                        "side": "Buy"                       // side
-                    },
-                    {
-                        "symbol": "BTCUSD",                 // symbol
-                        "price": "9487.5",                  // price
-                        "size": 522147,                     // size (in USD contracts)
-                        "side": "Sell"                      // side
-                    }
-                ],
-                "time_now": "1567108756.834357"             // UTC timestamp
-            }
-            */
-            var tokens = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/public/orderBook/L2?symbol={marketSymbol}"));
-            var orderBook = new ExchangeOrderBook();
-            foreach (var token in tokens) 
-            {
-                var orderPrice = new ExchangeOrderPrice();
-                orderPrice.Price = token["price"].ConvertInvariant<decimal>();
-                orderPrice.Amount = token["size"].ConvertInvariant<decimal>();
-                if (token["side"].ToStringInvariant() == "Sell")
-                    orderBook.Asks.Add(orderPrice.Price, orderPrice);
-                else
-                    orderBook.Bids.Add(orderPrice.Price, orderPrice);
-            }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+		{
+			return await DoGetAmountsAsync("available_balance");
+		}
+		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
+		{
+			/*
+			{
+				"ret_code": 0,                              // return code
+				"ret_msg": "OK",                            // error message
+				"ext_code": "",                             // additional error code
+				"ext_info": "",                             // additional error info
+				"result": [
+					{
+						"symbol": "BTCUSD",                 // symbol
+						"price": "9487",                    // price
+						"size": 336241,                     // size (in USD contracts)
+						"side": "Buy"                       // side
+					},
+					{
+						"symbol": "BTCUSD",                 // symbol
+						"price": "9487.5",                  // price
+						"size": 522147,                     // size (in USD contracts)
+						"side": "Sell"                      // side
+					}
+				],
+				"time_now": "1567108756.834357"             // UTC timestamp
+			}
+			*/
+			var tokens = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/public/orderBook/L2?symbol={marketSymbol}"));
+			var orderBook = new ExchangeOrderBook();
+			foreach (var token in tokens) 
+			{
+				var orderPrice = new ExchangeOrderPrice();
+				orderPrice.Price = token["price"].ConvertInvariant<decimal>();
+				orderPrice.Amount = token["size"].ConvertInvariant<decimal>();
+				if (token["side"].ToStringInvariant() == "Sell")
+					orderBook.Asks.Add(orderPrice.Price, orderPrice);
+				else
+					orderBook.Bids.Add(orderPrice.Price, orderPrice);
+			}
 
-            return orderBook;
-        }
+			return orderBook;
+		}
 
-        public async Task<IEnumerable<ExchangePosition>> GetCurrentPositionsAsync()
-        {
-            /*
-            {
-                "ret_code": 0,
-                "ret_msg": "OK",
-                "ext_code": "",
-                "ext_info": "",
-                "result": {
-                    "id": 27913,
-                    "user_id": 1,
-                    "risk_id": 1,
-                    "symbol": "BTCUSD",
-                    "side": "Buy",
-                    "size": 5,
-                    "position_value": "0.0006947",
-                    "entry_price": "7197.35137469",
-                    "is_isolated":true,
-                    "auto_add_margin": 0,
-                    "leverage": "1",  //In Isolated Margin mode, the value is set by user. In Cross Margin mode, the value is the max leverage at current risk level
-                    "effective_leverage": "1", // Effective Leverage. In Isolated Margin mode, its value equals `leverage`; In Cross Margin mode, The formula to calculate:
-                        effective_leverage = position size / mark_price / (wallet_balance + unrealised_pnl)
-                    "position_margin": "0.0006947",
-                    "liq_price": "3608",
-                    "bust_price": "3599",
-                    "occ_closing_fee": "0.00000105",
-                    "occ_funding_fee": "0",
-                    "take_profit": "0",
-                    "stop_loss": "0",
-                    "trailing_stop": "0",
-                    "position_status": "Normal",
-                    "deleverage_indicator": 4,
-                    "oc_calc_data": "{\"blq\":2,\"blv\":\"0.0002941\",\"slq\":0,\"bmp\":6800.408,\"smp\":0,\"fq\":-5,\"fc\":-0.00029477,\"bv2c\":1.00225,\"sv2c\":1.0007575}",
-                    "order_margin": "0.00029477",
-                    "wallet_balance": "0.03000227",
-                    "realised_pnl": "-0.00000126",
-                    "unrealised_pnl": 0,
-                    "cum_realised_pnl": "-0.00001306",
-                    "cross_seq": 444081383,
-                    "position_seq": 287141589,
-                    "created_at": "2019-10-19T17:04:55Z",
-                    "updated_at": "2019-12-27T20:25:45.158767Z"
-                },
-                "time_now": "1577480599.097287",
-                "rate_limit_status": 119,
-                "rate_limit_reset_ms": 1580885703683,
-                "rate_limit": 120
-            }
-            */
-            var queryString = await GetAuthenticatedQueryString();
-            JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/position/list?" + queryString, BaseUrl, null, "GET"));
-            List<ExchangePosition> positions = new List<ExchangePosition>();
-            foreach (var item in token)
-            {
-                positions.Add(ParsePosition(item["data"]));
-            }
-            return positions;
-        }
+		public async Task<IEnumerable<ExchangePosition>> GetCurrentPositionsAsync()
+		{
+			/*
+			{
+				"ret_code": 0,
+				"ret_msg": "OK",
+				"ext_code": "",
+				"ext_info": "",
+				"result": {
+					"id": 27913,
+					"user_id": 1,
+					"risk_id": 1,
+					"symbol": "BTCUSD",
+					"side": "Buy",
+					"size": 5,
+					"position_value": "0.0006947",
+					"entry_price": "7197.35137469",
+					"is_isolated":true,
+					"auto_add_margin": 0,
+					"leverage": "1",  //In Isolated Margin mode, the value is set by user. In Cross Margin mode, the value is the max leverage at current risk level
+					"effective_leverage": "1", // Effective Leverage. In Isolated Margin mode, its value equals `leverage`; In Cross Margin mode, The formula to calculate:
+						effective_leverage = position size / mark_price / (wallet_balance + unrealised_pnl)
+					"position_margin": "0.0006947",
+					"liq_price": "3608",
+					"bust_price": "3599",
+					"occ_closing_fee": "0.00000105",
+					"occ_funding_fee": "0",
+					"take_profit": "0",
+					"stop_loss": "0",
+					"trailing_stop": "0",
+					"position_status": "Normal",
+					"deleverage_indicator": 4,
+					"oc_calc_data": "{\"blq\":2,\"blv\":\"0.0002941\",\"slq\":0,\"bmp\":6800.408,\"smp\":0,\"fq\":-5,\"fc\":-0.00029477,\"bv2c\":1.00225,\"sv2c\":1.0007575}",
+					"order_margin": "0.00029477",
+					"wallet_balance": "0.03000227",
+					"realised_pnl": "-0.00000126",
+					"unrealised_pnl": 0,
+					"cum_realised_pnl": "-0.00001306",
+					"cross_seq": 444081383,
+					"position_seq": 287141589,
+					"created_at": "2019-10-19T17:04:55Z",
+					"updated_at": "2019-12-27T20:25:45.158767Z"
+				},
+				"time_now": "1577480599.097287",
+				"rate_limit_status": 119,
+				"rate_limit_reset_ms": 1580885703683,
+				"rate_limit": 120
+			}
+			*/
+			var queryString = await GetAuthenticatedQueryString();
+			JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/position/list?" + queryString, BaseUrl, null, "GET"));
+			List<ExchangePosition> positions = new List<ExchangePosition>();
+			foreach (var item in token)
+			{
+				positions.Add(ParsePosition(item["data"]));
+			}
+			return positions;
+		}
 
-        public async Task<ExchangeFunding> GetCurrentFundingRateAsync(string marketSymbol)
-        {
-            /*
-            {
-                "ret_code": 0,
-                "ret_msg": "ok",
-                "ext_code": "",
-                "result": {
-                    "symbol": "BTCUSD",
-                    "funding_rate": "0.00010000",
-                    "funding_rate_timestamp": 1577433600
-                },
-                "ext_info": null,
-                "time_now": "1577445586.446797",
-                "rate_limit_status": 119,
-                "rate_limit_reset_ms": 1577445586454,
-                "rate_limit": 120
-            }
-            */
-            JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/public/funding/prev-funding-rate?symbol={marketSymbol}"));
-            var funding = new ExchangeFunding();
-            funding.MarketSymbol = token["symbol"].ToStringInvariant();
-            funding.Rate = token["funding_rate"].ConvertInvariant<decimal>();
-            // funding.TimeStamp = Convert.ToDateTime(TimeSpan.FromSeconds(token["funding_rate_timestamp"].ConvertInvariant<int>()));
-            funding.TimeStamp = CryptoUtility.UnixTimeStampToDateTimeSeconds(token["funding_rate_timestamp"].ConvertInvariant<int>());
+		public async Task<ExchangeFunding> GetCurrentFundingRateAsync(string marketSymbol)
+		{
+			/*
+			{
+				"ret_code": 0,
+				"ret_msg": "ok",
+				"ext_code": "",
+				"result": {
+					"symbol": "BTCUSD",
+					"funding_rate": "0.00010000",
+					"funding_rate_timestamp": 1577433600
+				},
+				"ext_info": null,
+				"time_now": "1577445586.446797",
+				"rate_limit_status": 119,
+				"rate_limit_reset_ms": 1577445586454,
+				"rate_limit": 120
+			}
+			*/
+			JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/public/funding/prev-funding-rate?symbol={marketSymbol}"));
+			var funding = new ExchangeFunding();
+			funding.MarketSymbol = token["symbol"].ToStringInvariant();
+			funding.Rate = token["funding_rate"].ConvertInvariant<decimal>();
+			// funding.TimeStamp = Convert.ToDateTime(TimeSpan.FromSeconds(token["funding_rate_timestamp"].ConvertInvariant<int>()));
+			funding.TimeStamp = CryptoUtility.UnixTimeStampToDateTimeSeconds(token["funding_rate_timestamp"].ConvertInvariant<int>());
 
-            return funding;
-        }
+			return funding;
+		}
 
-        public async Task<ExchangeFunding> GetPredictedFundingRateAsync(string marketSymbol)
-        {
-            /*
-            {
-                "ret_code": 0,
-                "ret_msg": "ok",
-                "ext_code": "",
-                "result": {
-                    "predicted_funding_rate": 0.0001,
-                    "predicted_funding_fee": 0
-                },
-                "ext_info": null,
-                "time_now": "1577447415.583259",
-                "rate_limit_status": 118,
-                "rate_limit_reset_ms": 1577447415590,
-                "rate_limit": 120
-            }
-            */
-            var extraParams = new Dictionary<string, object>();
-            extraParams["symbol"] = marketSymbol;
-            var queryString = await GetAuthenticatedQueryString(extraParams);
-            JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/funding/predicted-funding?" + queryString, BaseUrl, null, "GET"));
-            var funding = new ExchangeFunding();
-            funding.MarketSymbol = marketSymbol;
-            funding.Rate = token["predicted_funding_rate"].ConvertInvariant<decimal>();
+		public async Task<ExchangeFunding> GetPredictedFundingRateAsync(string marketSymbol)
+		{
+			/*
+			{
+				"ret_code": 0,
+				"ret_msg": "ok",
+				"ext_code": "",
+				"result": {
+					"predicted_funding_rate": 0.0001,
+					"predicted_funding_fee": 0
+				},
+				"ext_info": null,
+				"time_now": "1577447415.583259",
+				"rate_limit_status": 118,
+				"rate_limit_reset_ms": 1577447415590,
+				"rate_limit": 120
+			}
+			*/
+			var extraParams = new Dictionary<string, object>();
+			extraParams["symbol"] = marketSymbol;
+			var queryString = await GetAuthenticatedQueryString(extraParams);
+			JToken token = CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/funding/predicted-funding?" + queryString, BaseUrl, null, "GET"));
+			var funding = new ExchangeFunding();
+			funding.MarketSymbol = marketSymbol;
+			funding.Rate = token["predicted_funding_rate"].ConvertInvariant<decimal>();
 
-            return funding;
-        }
+			return funding;
+		}
 
-        private async Task<IEnumerable<ExchangeOrderResult>> DoGetOrderDetailsAsync(string orderId, string marketSymbol = null)
-        {
-            var extraParams = new Dictionary<string, object>();
+		private async Task<IEnumerable<ExchangeOrderResult>> DoGetOrderDetailsAsync(string orderId, string marketSymbol = null)
+		{
+			var extraParams = new Dictionary<string, object>();
 
-            if (orderId != null) 
-            {
-                extraParams["order_id"] = orderId;
-            }
+			if (orderId != null) 
+			{
+				extraParams["order_id"] = orderId;
+			}
 
-            if (!string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                extraParams["symbol"] = marketSymbol;
-            }
-            else
-            {
-                throw new Exception("marketSymbol is required");
-            }
-            
-            var queryString = await GetAuthenticatedQueryString(extraParams);
-            JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order?" + queryString, BaseUrl, null, "GET"), out var retCode, out var retMessage);
+			if (!string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				extraParams["symbol"] = marketSymbol;
+			}
+			else
+			{
+				throw new Exception("marketSymbol is required");
+			}
+			
+			var queryString = await GetAuthenticatedQueryString(extraParams);
+			JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order?" + queryString, BaseUrl, null, "GET"), out var retCode, out var retMessage);
 
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            if (orderId == null) 
-            {
-                foreach (JToken order in token)
-                {
-                    orders.Add(ParseOrder(order, retCode, retMessage));
-                }
-            }
-            else
-            {
-                orders.Add(ParseOrder(token, retCode, retMessage));
-            }
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			if (orderId == null) 
+			{
+				foreach (JToken order in token)
+				{
+					orders.Add(ParseOrder(order, retCode, retMessage));
+				}
+			}
+			else
+			{
+				orders.Add(ParseOrder(token, retCode, retMessage));
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        //Note, Bybit is not recommending the use of "/v2/private/order/list" now that "/v2/private/order" is capable of returning multiple results
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
-        {
-            var orders = await DoGetOrderDetailsAsync(null, marketSymbol);
-            return orders;
-        }
+		//Note, Bybit is not recommending the use of "/v2/private/order/list" now that "/v2/private/order" is capable of returning multiple results
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
+		{
+			var orders = await DoGetOrderDetailsAsync(null, marketSymbol);
+			return orders;
+		}
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
-        {
-            var orders = await DoGetOrderDetailsAsync(orderId, marketSymbol);
-            if (orders.Count() > 0)
-            {
-                return orders.First();
-            }
-            else
-            {
-                return null;
-            }
-        }
+		protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
+		{
+			var orders = await DoGetOrderDetailsAsync(orderId, marketSymbol);
+			if (orders.Count() > 0)
+			{
+				return orders.First();
+			}
+			else
+			{
+				return null;
+			}
+		}
 
-        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
-        {
-            var extraParams = new Dictionary<string, object>();
-            extraParams["order_id"] = orderId;
-            if (!string.IsNullOrWhiteSpace(marketSymbol))
-            {
-                extraParams["symbol"] = marketSymbol;
-            }
-            else
-            {
-                throw new Exception("marketSymbol is required");
-            }
-            
-            var payload = await GetAuthenticatedPayload(extraParams);
-            CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order/cancel", BaseUrl, payload, "POST"));
-                // new string[] {"0", "30032"});
-                //30032: order has been finished or canceled
-        }
-    
-        public async Task CancelAllOrdersAsync(string marketSymbol)
-        {
-            var extraParams = new Dictionary<string, object>();
-            extraParams["symbol"] = marketSymbol;
-            var payload = await GetAuthenticatedPayload(extraParams);
-            CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order/cancelAll", BaseUrl, payload, "POST"));
-        }
+		protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
+		{
+			var extraParams = new Dictionary<string, object>();
+			extraParams["order_id"] = orderId;
+			if (!string.IsNullOrWhiteSpace(marketSymbol))
+			{
+				extraParams["symbol"] = marketSymbol;
+			}
+			else
+			{
+				throw new Exception("marketSymbol is required");
+			}
+			
+			var payload = await GetAuthenticatedPayload(extraParams);
+			CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order/cancel", BaseUrl, payload, "POST"));
+				// new string[] {"0", "30032"});
+				//30032: order has been finished or canceled
+		}
+	
+		public async Task CancelAllOrdersAsync(string marketSymbol)
+		{
+			var extraParams = new Dictionary<string, object>();
+			extraParams["symbol"] = marketSymbol;
+			var payload = await GetAuthenticatedPayload(extraParams);
+			CheckRetCode(await DoMakeJsonRequestAsync<JToken>($"/v2/private/order/cancelAll", BaseUrl, payload, "POST"));
+		}
 
-        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
-        {
-            var payload = new Dictionary<string, object>();
-            await AddOrderToPayload(order, payload);
-            payload = await GetAuthenticatedPayload(payload);
-            JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>("/v2/private/order/create", BaseUrl, payload, "POST"), out var retCode, out var retMessage);
-            return ParseOrder(token, retCode, retMessage);
-        }
+		protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+		{
+			var payload = new Dictionary<string, object>();
+			await AddOrderToPayload(order, payload);
+			payload = await GetAuthenticatedPayload(payload);
+			JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>("/v2/private/order/create", BaseUrl, payload, "POST"), out var retCode, out var retMessage);
+			return ParseOrder(token, retCode, retMessage);
+		}
 
-        public async Task<ExchangeOrderResult> OnAmendOrderAsync(ExchangeOrderRequest order)
-        {
-            var payload = new Dictionary<string, object>();
-            payload["symbol"] = order.MarketSymbol;
-            if(order.OrderId != null)
-                payload["order_id"] = order.OrderId;
-            else if(order.ClientOrderId != null)
-                payload["order_link_id"] = order.ClientOrderId;
-            else 
-                throw new Exception("Need either OrderId or ClientOrderId");
+		public async Task<ExchangeOrderResult> OnAmendOrderAsync(ExchangeOrderRequest order)
+		{
+			var payload = new Dictionary<string, object>();
+			payload["symbol"] = order.MarketSymbol;
+			if(order.OrderId != null)
+				payload["order_id"] = order.OrderId;
+			else if(order.ClientOrderId != null)
+				payload["order_link_id"] = order.ClientOrderId;
+			else 
+				throw new Exception("Need either OrderId or ClientOrderId");
 
-            payload["p_r_qty"] = (long) await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-            if(order.OrderType!=OrderType.Market)
-                payload["p_r_price"] = order.Price;
+			payload["p_r_qty"] = (long) await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+			if(order.OrderType!=OrderType.Market)
+				payload["p_r_price"] = order.Price;
 
-            payload = await GetAuthenticatedPayload(payload);
-            JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>("/v2/private/order/replace", BaseUrl, payload, "POST"), out var retCode, out var retMessage);
+			payload = await GetAuthenticatedPayload(payload);
+			JToken token = GetResult(await DoMakeJsonRequestAsync<JToken>("/v2/private/order/replace", BaseUrl, payload, "POST"), out var retCode, out var retMessage);
 
-            var result = new ExchangeOrderResult();
-            result.ResultCode = retCode;
-            result.Message = retMessage;
-            if (retCode == "0")
-                result.OrderId = token["order_id"].ToStringInvariant();
-            return result;
-        }
+			var result = new ExchangeOrderResult();
+			result.ResultCode = retCode;
+			result.Message = retMessage;
+			if (retCode == "0")
+				result.OrderId = token["order_id"].ToStringInvariant();
+			return result;
+		}
 
-        private async Task AddOrderToPayload(ExchangeOrderRequest order, Dictionary<string, object> payload)
-        {
-            /*
-            side	true	string	Side
-            symbol	true	string	Symbol
-            order_type	true	string	Active order type
-            qty	true	integer	Order quantity in USD
-            price	false	number	Order price
-            time_in_force	true	string	Time in force
-            take_profit	false	number	Take profit price, only take effect upon opening the position
-            stop_loss	false	number	Stop loss price, only take effect upon opening the position
-            reduce_only	false	bool	What is a reduce-only order? True means your position can only reduce in size if this order is triggered
-            close_on_trigger	false	bool	What is a close on trigger order? For a closing order. It can only reduce your position, not increase it. If the account has insufficient available balance when the closing order is triggered, then other active orders of similar contracts will be cancelled or reduced. It can be used to ensure your stop loss reduces your position regardless of current available margin.
-            order_link_id	false	string	Customised order ID, maximum length at 36 characters, and order ID under the same agency has to be unique.
-            */
+		private async Task AddOrderToPayload(ExchangeOrderRequest order, Dictionary<string, object> payload)
+		{
+			/*
+			side	true	string	Side
+			symbol	true	string	Symbol
+			order_type	true	string	Active order type
+			qty	true	integer	Order quantity in USD
+			price	false	number	Order price
+			time_in_force	true	string	Time in force
+			take_profit	false	number	Take profit price, only take effect upon opening the position
+			stop_loss	false	number	Stop loss price, only take effect upon opening the position
+			reduce_only	false	bool	What is a reduce-only order? True means your position can only reduce in size if this order is triggered
+			close_on_trigger	false	bool	What is a close on trigger order? For a closing order. It can only reduce your position, not increase it. If the account has insufficient available balance when the closing order is triggered, then other active orders of similar contracts will be cancelled or reduced. It can be used to ensure your stop loss reduces your position regardless of current available margin.
+			order_link_id	false	string	Customised order ID, maximum length at 36 characters, and order ID under the same agency has to be unique.
+			*/
 
-            payload["side"] = order.IsBuy ? "Buy" : "Sell";
-            payload["symbol"] = order.MarketSymbol;
-            payload["order_type"] = order.OrderType.ToStringInvariant();
-            payload["qty"] = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
+			payload["side"] = order.IsBuy ? "Buy" : "Sell";
+			payload["symbol"] = order.MarketSymbol;
+			payload["order_type"] = order.OrderType.ToStringInvariant();
+			payload["qty"] = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
 
-            if(order.OrderType!=OrderType.Market)
-                payload["price"] = order.Price;
+			if(order.OrderType!=OrderType.Market)
+				payload["price"] = order.Price;
 
-            if(order.ClientOrderId != null)
-                payload["order_link_id"] = order.ClientOrderId;
+			if(order.ClientOrderId != null)
+				payload["order_link_id"] = order.ClientOrderId;
 
-            if (order.ExtraParameters.TryGetValue("reduce_only", out var reduceOnly))
-            {
-                payload["reduce_only"] = reduceOnly;
-            }
+			if (order.ExtraParameters.TryGetValue("reduce_only", out var reduceOnly))
+			{
+				payload["reduce_only"] = reduceOnly;
+			}
 
-            if (order.ExtraParameters.TryGetValue("time_in_force", out var timeInForce))
-            {
-                payload["time_in_force"] = timeInForce;
-            }
-            else
-            {
-                payload["time_in_force"] = "GoodTillCancel";
-            }
-        }
+			if (order.ExtraParameters.TryGetValue("time_in_force", out var timeInForce))
+			{
+				payload["time_in_force"] = timeInForce;
+			}
+			else
+			{
+				payload["time_in_force"] = "GoodTillCancel";
+			}
+		}
 
-        private ExchangePosition ParsePosition(JToken token)
-        {
-            /*
-            "id": 27913,
-            "user_id": 1,
-            "risk_id": 1,
-            "symbol": "BTCUSD",
-            "side": "Buy",
-            "size": 5,
-            "position_value": "0.0006947",
-            "entry_price": "7197.35137469",
-            "is_isolated":true,
-            "auto_add_margin": 0,
-            "leverage": "1",  //In Isolated Margin mode, the value is set by user. In Cross Margin mode, the value is the max leverage at current risk level
-            "effective_leverage": "1", // Effective Leverage. In Isolated Margin mode, its value equals `leverage`; In Cross Margin mode, The formula to calculate:
-                effective_leverage = position size / mark_price / (wallet_balance + unrealised_pnl)
-            "position_margin": "0.0006947",
-            "liq_price": "3608",
-            "bust_price": "3599",
-            "occ_closing_fee": "0.00000105",
-            "occ_funding_fee": "0",
-            "take_profit": "0",
-            "stop_loss": "0",
-            "trailing_stop": "0",
-            "position_status": "Normal",
-            "deleverage_indicator": 4,
-            "oc_calc_data": "{\"blq\":2,\"blv\":\"0.0002941\",\"slq\":0,\"bmp\":6800.408,\"smp\":0,\"fq\":-5,\"fc\":-0.00029477,\"bv2c\":1.00225,\"sv2c\":1.0007575}",
-            "order_margin": "0.00029477",
-            "wallet_balance": "0.03000227",
-            "realised_pnl": "-0.00000126",
-            "unrealised_pnl": 0,
-            "cum_realised_pnl": "-0.00001306",
-            "cross_seq": 444081383,
-            "position_seq": 287141589,
-            "created_at": "2019-10-19T17:04:55Z",
-            "updated_at": "2019-12-27T20:25:45.158767Z
-            */
-            ExchangePosition result = new ExchangePosition
-            {
-                MarketSymbol = token["symbol"].ToStringUpperInvariant(),
-                Amount = token["size"].ConvertInvariant<decimal>(),
-                AveragePrice = token["entry_price"].ConvertInvariant<decimal>(),
-                LiquidationPrice = token["liq_price"].ConvertInvariant<decimal>(),
-                Leverage = token["effective_leverage"].ConvertInvariant<decimal>(),
-                TimeStamp = CryptoUtility.ParseTimestamp(token["updated_at"], TimestampType.Iso8601)
-            };
-            if (token["side"].ToStringInvariant() == "Sell")
-                result.Amount *= -1;
-            return result;
-        }
+		private ExchangePosition ParsePosition(JToken token)
+		{
+			/*
+			"id": 27913,
+			"user_id": 1,
+			"risk_id": 1,
+			"symbol": "BTCUSD",
+			"side": "Buy",
+			"size": 5,
+			"position_value": "0.0006947",
+			"entry_price": "7197.35137469",
+			"is_isolated":true,
+			"auto_add_margin": 0,
+			"leverage": "1",  //In Isolated Margin mode, the value is set by user. In Cross Margin mode, the value is the max leverage at current risk level
+			"effective_leverage": "1", // Effective Leverage. In Isolated Margin mode, its value equals `leverage`; In Cross Margin mode, The formula to calculate:
+				effective_leverage = position size / mark_price / (wallet_balance + unrealised_pnl)
+			"position_margin": "0.0006947",
+			"liq_price": "3608",
+			"bust_price": "3599",
+			"occ_closing_fee": "0.00000105",
+			"occ_funding_fee": "0",
+			"take_profit": "0",
+			"stop_loss": "0",
+			"trailing_stop": "0",
+			"position_status": "Normal",
+			"deleverage_indicator": 4,
+			"oc_calc_data": "{\"blq\":2,\"blv\":\"0.0002941\",\"slq\":0,\"bmp\":6800.408,\"smp\":0,\"fq\":-5,\"fc\":-0.00029477,\"bv2c\":1.00225,\"sv2c\":1.0007575}",
+			"order_margin": "0.00029477",
+			"wallet_balance": "0.03000227",
+			"realised_pnl": "-0.00000126",
+			"unrealised_pnl": 0,
+			"cum_realised_pnl": "-0.00001306",
+			"cross_seq": 444081383,
+			"position_seq": 287141589,
+			"created_at": "2019-10-19T17:04:55Z",
+			"updated_at": "2019-12-27T20:25:45.158767Z
+			*/
+			ExchangePosition result = new ExchangePosition
+			{
+				MarketSymbol = token["symbol"].ToStringUpperInvariant(),
+				Amount = token["size"].ConvertInvariant<decimal>(),
+				AveragePrice = token["entry_price"].ConvertInvariant<decimal>(),
+				LiquidationPrice = token["liq_price"].ConvertInvariant<decimal>(),
+				Leverage = token["effective_leverage"].ConvertInvariant<decimal>(),
+				TimeStamp = CryptoUtility.ParseTimestamp(token["updated_at"], TimestampType.Iso8601)
+			};
+			if (token["side"].ToStringInvariant() == "Sell")
+				result.Amount *= -1;
+			return result;
+		}
 
-        private ExchangeOrderResult ParseOrder(JToken token, string resultCode, string resultMessage)
-        {
-            /*
-            Active Order:
-            {
-            "ret_code": 0,
-            "ret_msg": "OK",
-            "ext_code": "",
-            "ext_info": "",
-            "result": {
-                "user_id": 106958,
-                "symbol": "BTCUSD",
-                "side": "Buy",
-                "order_type": "Limit",
-                "price": "11756.5",
-                "qty": 1,
-                "time_in_force": "PostOnly",
-                "order_status": "Filled",
-                "ext_fields": {
-                    "o_req_num": -68948112492,
-                    "xreq_type": "x_create"
-                },
-                "last_exec_time": "1596304897.847944",
-                "last_exec_price": "11756.5",
-                "leaves_qty": 0,
-                "leaves_value": "0",
-                "cum_exec_qty": 1,
-                "cum_exec_value": "0.00008505",
-                "cum_exec_fee": "-0.00000002",
-                "reject_reason": "",
-                "cancel_type": "",
-                "order_link_id": "",
-                "created_at": "2020-08-01T18:00:26Z",
-                "updated_at": "2020-08-01T18:01:37Z",
-                "order_id": "e66b101a-ef3f-4647-83b5-28e0f38dcae0"
-            },
-            "time_now": "1597171013.867068",
-            "rate_limit_status": 599,
-            "rate_limit_reset_ms": 1597171013861,
-            "rate_limit": 600
-            }
+		private ExchangeOrderResult ParseOrder(JToken token, string resultCode, string resultMessage)
+		{
+			/*
+			Active Order:
+			{
+			"ret_code": 0,
+			"ret_msg": "OK",
+			"ext_code": "",
+			"ext_info": "",
+			"result": {
+				"user_id": 106958,
+				"symbol": "BTCUSD",
+				"side": "Buy",
+				"order_type": "Limit",
+				"price": "11756.5",
+				"qty": 1,
+				"time_in_force": "PostOnly",
+				"order_status": "Filled",
+				"ext_fields": {
+					"o_req_num": -68948112492,
+					"xreq_type": "x_create"
+				},
+				"last_exec_time": "1596304897.847944",
+				"last_exec_price": "11756.5",
+				"leaves_qty": 0,
+				"leaves_value": "0",
+				"cum_exec_qty": 1,
+				"cum_exec_value": "0.00008505",
+				"cum_exec_fee": "-0.00000002",
+				"reject_reason": "",
+				"cancel_type": "",
+				"order_link_id": "",
+				"created_at": "2020-08-01T18:00:26Z",
+				"updated_at": "2020-08-01T18:01:37Z",
+				"order_id": "e66b101a-ef3f-4647-83b5-28e0f38dcae0"
+			},
+			"time_now": "1597171013.867068",
+			"rate_limit_status": 599,
+			"rate_limit_reset_ms": 1597171013861,
+			"rate_limit": 600
+			}
 
-            Active Order List:
-            {
-                "ret_code": 0,
-                "ret_msg": "OK",
-                "ext_code": "",
-                "ext_info": "",
-                "result": {
-                    "data": [ 
-                        {
-                            "user_id": 160861,
-                            "order_status": "Cancelled",
-                            "symbol": "BTCUSD",
-                            "side": "Buy",
-                            "order_type": "Market",
-                            "price": "9800",
-                            "qty": "16737",
-                            "time_in_force": "ImmediateOrCancel",
-                            "order_link_id": "",
-                            "order_id": "fead08d7-47c0-4d6a-b9e7-5c71d5df8ba1",
-                            "created_at": "2020-07-24T08:22:30Z",
-                            "updated_at": "2020-07-24T08:22:30Z",
-                            "leaves_qty": "0",
-                            "leaves_value": "0",
-                            "cum_exec_qty": "0",
-                            "cum_exec_value": "0",
-                            "cum_exec_fee": "0",
-                            "reject_reason": "EC_NoImmediateQtyToFill"
-                        }
-                    ],
-                    "cursor": "w01XFyyZc8lhtCLl6NgAaYBRfsN9Qtpp1f2AUy3AS4+fFDzNSlVKa0od8DKCqgAn"
-                },
-                "time_now": "1604653633.173848",
-                "rate_limit_status": 599,
-                "rate_limit_reset_ms": 1604653633171,
-                "rate_limit": 600
-            }
-            */
-            ExchangeOrderResult result = new ExchangeOrderResult();
-            if (token.Count() > 0)
-            {
-                result.Amount = token["qty"].ConvertInvariant<Decimal>();
-                result.AmountFilled = token["cum_exec_qty"].ConvertInvariant<decimal>();
-                result.Price = token["price"].ConvertInvariant<decimal>();
-                result.IsBuy = token["side"].ToStringInvariant().EqualsWithOption("Buy");
-                result.OrderDate = token["created_at"].ConvertInvariant<DateTime>();
-                result.OrderId = token["order_id"].ToStringInvariant();
-                result.ClientOrderId = token["order_link_id"].ToStringInvariant();
-                result.MarketSymbol = token["symbol"].ToStringInvariant();
+			Active Order List:
+			{
+				"ret_code": 0,
+				"ret_msg": "OK",
+				"ext_code": "",
+				"ext_info": "",
+				"result": {
+					"data": [ 
+						{
+							"user_id": 160861,
+							"order_status": "Cancelled",
+							"symbol": "BTCUSD",
+							"side": "Buy",
+							"order_type": "Market",
+							"price": "9800",
+							"qty": "16737",
+							"time_in_force": "ImmediateOrCancel",
+							"order_link_id": "",
+							"order_id": "fead08d7-47c0-4d6a-b9e7-5c71d5df8ba1",
+							"created_at": "2020-07-24T08:22:30Z",
+							"updated_at": "2020-07-24T08:22:30Z",
+							"leaves_qty": "0",
+							"leaves_value": "0",
+							"cum_exec_qty": "0",
+							"cum_exec_value": "0",
+							"cum_exec_fee": "0",
+							"reject_reason": "EC_NoImmediateQtyToFill"
+						}
+					],
+					"cursor": "w01XFyyZc8lhtCLl6NgAaYBRfsN9Qtpp1f2AUy3AS4+fFDzNSlVKa0od8DKCqgAn"
+				},
+				"time_now": "1604653633.173848",
+				"rate_limit_status": 599,
+				"rate_limit_reset_ms": 1604653633171,
+				"rate_limit": 600
+			}
+			*/
+			ExchangeOrderResult result = new ExchangeOrderResult();
+			if (token.Count() > 0)
+			{
+				result.Amount = token["qty"].ConvertInvariant<Decimal>();
+				result.AmountFilled = token["cum_exec_qty"].ConvertInvariant<decimal>();
+				result.Price = token["price"].ConvertInvariant<decimal>();
+				result.IsBuy = token["side"].ToStringInvariant().EqualsWithOption("Buy");
+				result.OrderDate = token["created_at"].ConvertInvariant<DateTime>();
+				result.OrderId = token["order_id"].ToStringInvariant();
+				result.ClientOrderId = token["order_link_id"].ToStringInvariant();
+				result.MarketSymbol = token["symbol"].ToStringInvariant();
 
-                switch (token["order_status"].ToStringInvariant())
-                {
-                    case "Created":
-                    case "New":
-                        result.Result = ExchangeAPIOrderResult.Pending;
-                        break;
-                    case "PartiallyFilled":
-                        result.Result = ExchangeAPIOrderResult.FilledPartially;
-                        break;
-                    case "Filled":
-                        result.Result = ExchangeAPIOrderResult.Filled;
-                        break;
-                    case "Cancelled":
-                        result.Result = ExchangeAPIOrderResult.Canceled;
-                        break;
+				switch (token["order_status"].ToStringInvariant())
+				{
+					case "Created":
+					case "New":
+						result.Result = ExchangeAPIOrderResult.Pending;
+						break;
+					case "PartiallyFilled":
+						result.Result = ExchangeAPIOrderResult.FilledPartially;
+						break;
+					case "Filled":
+						result.Result = ExchangeAPIOrderResult.Filled;
+						break;
+					case "Cancelled":
+						result.Result = ExchangeAPIOrderResult.Canceled;
+						break;
 
-                    default:
-                        result.Result = ExchangeAPIOrderResult.Error;
-                        break;
-                }
-            }
-            result.ResultCode = resultCode;
-            result.Message = resultMessage;
+					default:
+						result.Result = ExchangeAPIOrderResult.Error;
+						break;
+				}
+			}
+			result.ResultCode = resultCode;
+			result.Message = resultMessage;
 
-            return result;
-        }
-    }
+			return result;
+		}
+	}
 
-    public partial class ExchangeName { public const string Bybit = "Bybit"; }
+	public partial class ExchangeName { public const string Bybit = "Bybit"; }
 }

--- a/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
@@ -148,7 +148,7 @@ namespace ExchangeSharp
         private Task<IWebSocket> DoConnectWebSocketAsync(Func<IWebSocket, Task> connected, Func<IWebSocket, JToken, Task> callback, int symbolArrayIndex = 3)
         {
 			Timer pingTimer = null;
-            return ConnectWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
+            return ConnectPublicWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
             {
 				var msgString = msg.ToStringFromUTF8();
                 JToken token = JToken.Parse(msgString);
@@ -286,7 +286,7 @@ namespace ExchangeSharp
 			});
         }
 
-        public async Task<IWebSocket> GetPositionWebSocketAsync(Action<ExchangePosition> callback)
+		protected override async Task<IWebSocket> OnGetPositionsWebSocketAsync(Action<ExchangePosition> callback)
         {
 			/*
             request:

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -296,7 +296,7 @@ namespace ExchangeSharp
 
         protected override Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
-            return ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+            return ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
             {
                 string message = msg.ToStringFromUTF8();
                 var book = new ExchangeOrderBook();
@@ -365,7 +365,7 @@ namespace ExchangeSharp
 
         protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] marketSymbols)
         {
-            return await ConnectWebSocketAsync("/", async (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
                 if (token["type"].ToStringInvariant() == "ticker")
@@ -399,7 +399,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-            return await ConnectWebSocketAsync("/", async (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["type"].ToStringInvariant() == "error")

--- a/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
@@ -459,7 +459,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
 			{
 				// {
 				//    "method": "trades.update",
@@ -536,7 +536,7 @@ namespace ExchangeSharp
 			}
 			await inited.Task;
 
-			return await ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
 			{
 				//{
 				//  "method": "depth.update",

--- a/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
@@ -396,7 +396,7 @@ namespace ExchangeSharp
 				}
 			}
 
-			return await ConnectWebSocketAsync(null, messageCallback: (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(null, messageCallback: (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["result"].ToStringInvariant() == "error")
@@ -559,7 +559,7 @@ namespace ExchangeSharp
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
 
-			return await ConnectWebSocketAsync(BaseUrlWebSocket, messageCallback: async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(BaseUrlWebSocket, messageCallback: async (_socket, msg) =>
 		   {
 			   JToken token = JToken.Parse(msg.ToStringFromUTF8());
 			   if (token["result"].ToStringInvariant() == "error")
@@ -614,7 +614,7 @@ namespace ExchangeSharp
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
 
-			return await ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
 			{
 				string message = msg.ToStringFromUTF8();
 				var book = new ExchangeOrderBook();

--- a/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -467,7 +467,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(null, messageCallback: async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(null, messageCallback: async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["error"] != null)

--- a/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -222,7 +222,7 @@ namespace ExchangeSharp
 
         protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
         {
-            return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
             {
                 /*
 {"id":"id1","status":"ok","subbed":"market.btcusdt.trade.detail","ts":1527574853489}
@@ -289,7 +289,7 @@ namespace ExchangeSharp
 
         protected override async Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
-            return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
             {
                 /*
 {{

--- a/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
@@ -471,7 +471,7 @@ namespace ExchangeSharp
 		protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] marketSymbols)
 		{
 			var websocketUrlToken = GetWebsocketBulletToken();
-			return await ConnectWebSocketAsync
+			return await ConnectPublicWebSocketAsync
 			(
 				$"?token={websocketUrlToken}&acceptUserMessage=true", async (_socket, msg) =>
 				{
@@ -530,7 +530,7 @@ namespace ExchangeSharp
 			//  }
 			//}
             var websocketUrlToken = GetWebsocketBulletToken();
-			return await ConnectWebSocketAsync
+			return await ConnectPublicWebSocketAsync
             (
                 $"?token={websocketUrlToken}", async (_socket, msg) =>
 

--- a/src/ExchangeSharp/API/Exchanges/NDAX/ExchangeNDAXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/NDAX/ExchangeNDAXAPI.cs
@@ -377,7 +377,7 @@ namespace ExchangeSharp
 				(await GetMarketSymbolsMetadataAsync()).Select(s => (long?)long.Parse(s.AltMarketSymbol)).ToArray() :
 				await GetInstrumentIdFromMarketSymbol(marketSymbols);
 
-			return await ConnectWebSocketAsync("", async (socket, bytes) =>
+			return await ConnectPublicWebSocketAsync("", async (socket, bytes) =>
                 {
                     var messageFrame =
                         JsonConvert.DeserializeObject<MessageFrame>(bytes.ToStringFromUTF8().TrimEnd('\0'));
@@ -430,7 +430,7 @@ namespace ExchangeSharp
 				await EnsureInstrumentIdsAvailable();
 				instrumentIds = await GetInstrumentIdFromMarketSymbol(marketSymbols);
 			}
-			return await ConnectWebSocketAsync("", async (socket, bytes) =>
+			return await ConnectPublicWebSocketAsync("", async (socket, bytes) =>
 				{
 					var messageFrame =
 						JsonConvert.DeserializeObject<MessageFrame>(bytes.ToStringFromUTF8().TrimEnd('\0'));

--- a/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
@@ -653,7 +653,7 @@ namespace ExchangeSharp.OKGroup
         private Task<IWebSocket> ConnectWebSocketOkexAsync(Func<IWebSocket, Task> connected, Func<IWebSocket, string, string[], JToken, Task> callback, int symbolArrayIndex = 3)
         {
 			Timer pingTimer = null;
-            return ConnectWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
+            return ConnectPublicWebSocketAsync(url: string.Empty, messageCallback: async (_socket, msg) =>
             {
 				// https://github.com/okcoin-okex/API-docs-OKEx.com/blob/master/README-en.md
 				// All the messages returning from WebSocket API will be optimized by Deflate compression

--- a/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -383,7 +383,7 @@ namespace ExchangeSharp
         protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] symbols)
         {
             Dictionary<string, string> idsToSymbols = new Dictionary<string, string>();
-            return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
                 if (token[0].ConvertInvariant<int>() == 1002)
@@ -412,7 +412,7 @@ namespace ExchangeSharp
 		protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
 		{
 			Dictionary<int, Tuple<string, long>> messageIdToSymbol = new Dictionary<int, Tuple<string, long>>();
-			return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
 			{
 				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				int msgId = token[0].ConvertInvariant<int>();
@@ -470,7 +470,7 @@ namespace ExchangeSharp
 		protected override async Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
         {
             Dictionary<int, Tuple<string, long>> messageIdToSymbol = new Dictionary<int, Tuple<string, long>>();
-            return await ConnectWebSocketAsync(string.Empty, (_socket, msg) =>
+            return await ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
                 int msgId = token[0].ConvertInvariant<int>();

--- a/src/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/ZBcom/ExchangeZBcomAPI.cs
@@ -155,7 +155,7 @@ namespace ExchangeSharp
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-			return await ConnectWebSocketAsync(string.Empty, async (_socket, msg) =>
+			return await ConnectPublicWebSocketAsync(string.Empty, async (_socket, msg) =>
             {
                 JToken token = JToken.Parse(msg.ToStringFromUTF8());
                 if (token["dataType"].ToStringInvariant() == "trades")

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -180,6 +180,8 @@ namespace ExchangeSharp
 			throw new NotImplementedException();
 		protected virtual Task<IWebSocket> OnGetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols) =>
 			throw new NotImplementedException();
+		protected virtual Task<IWebSocket> OnGetPositionsWebSocketAsync(Action<ExchangePosition> callback) =>
+			throw new NotImplementedException();
 		protected virtual Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> tickers, params string[] marketSymbols) =>
 			throw new NotImplementedException();
 		protected virtual Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols) =>
@@ -1009,6 +1011,17 @@ namespace ExchangeSharp
 		{
 			callbackAsync.ThrowIfNull(nameof(callbackAsync), "Callback must not be null");
 			return OnGetCandlesWebSocketAsync(callbackAsync, periodSeconds, marketSymbols);
+		}
+
+		/// <summary>
+		/// Get all position updates via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		public virtual Task<IWebSocket> GetPositionsWebSocketAsync(Action<ExchangePosition> callback)
+		{
+			callback.ThrowIfNull(nameof(callback), "Callback must not be null");
+			return OnGetPositionsWebSocketAsync(callback);
 		}
 
 		/// <summary>

--- a/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/IExchangeAPI.cs
@@ -247,6 +247,13 @@ namespace ExchangeSharp
 		Task<IWebSocket> GetCandlesWebSocketAsync(Func<MarketCandle, Task> callbackAsync, int periodSeconds, params string[] marketSymbols);
 
 		/// <summary>
+		/// Get all position updates via web socket
+		/// </summary>
+		/// <param name="callback">Callback</param>
+		/// <returns>Web socket, call Dispose to close</returns>
+		Task<IWebSocket> GetPositionsWebSocketAsync(Action<ExchangePosition> callback);
+
+		/// <summary>
 		/// Get all tickers via web socket
 		/// </summary>
 		/// <param name="callback">Callback</param>

--- a/src/ExchangeSharpConsole/Options/WebSocketsCandesOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsCandesOption.cs
@@ -9,7 +9,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("ws-candles", HelpText =
-		"Connects to the given exchange websocket and keeps printing the candles from that exchange." +
+		"Connects to the given exchange websocket and keeps printing the candles from that exchange.\n" +
 		"If market symbol is not set then uses all.")]
 	public class WebSocketsCandlesOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol, IOptionWithPeriod
 	{

--- a/src/ExchangeSharpConsole/Options/WebSocketsOrderbookOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsOrderbookOption.cs
@@ -9,7 +9,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("ws-orderbook", HelpText =
-		"Connects to the given exchange websocket and keeps printing the first bid and ask prices and amounts for the given market symbols."
+		"Connects to the given exchange websocket and keeps printing the first bid and ask prices and amounts for the given market symbols.\n"
 		+ "If market symbol is not set then uses all.")]
 	public class WebSocketsOrderbookOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol
 	{

--- a/src/ExchangeSharpConsole/Options/WebSocketsPositionsOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsPositionsOption.cs
@@ -18,9 +18,9 @@ namespace ExchangeSharpConsole.Options
 			{
 				api.LoadAPIKeys(KeyPath);
 
-				return await api.GetPositionsWebSocketAsync(message =>
+				return await api.GetPositionsWebSocketAsync(position =>
 					{
-						Console.WriteLine($"{message.MarketSymbol}: Amount: {message.Amount} Price: {message.AveragePrice}");
+						Console.WriteLine($"Open TimeStamp: {position.TimeStamp} Market: {position.MarketSymbol}: Amount: {position.Amount} Average Price: {position.AveragePrice}");
 					}
 				);
 			}

--- a/src/ExchangeSharpConsole/Options/WebSocketsPositionsOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsPositionsOption.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using ExchangeSharp;
+using ExchangeSharpConsole.Options.Interfaces;
+
+namespace ExchangeSharpConsole.Options
+{
+	[Verb("ws-positions", HelpText =
+		"Connects to the given exchange private websocket and keeps printing your position updates from that exchange.")]
+	public class WebSocketsPositionsOption : BaseOption, IOptionPerExchange, IOptionWithKey
+	{
+		public override async Task RunCommand()
+		{
+			async Task<IWebSocket> GetWebSocket(IExchangeAPI api)
+			{
+				api.LoadAPIKeys(KeyPath);
+
+				return await api.GetPositionsWebSocketAsync(message =>
+					{
+						Console.WriteLine($"{message.MarketSymbol}: Amount: {message.Amount} Price: {message.AveragePrice}");
+					}
+				);
+			}
+
+			await RunWebSocket(ExchangeName, GetWebSocket);
+		}
+
+		public string ExchangeName { get; set; }
+
+		public string KeyPath { get; set; }
+	}
+}

--- a/src/ExchangeSharpConsole/Options/WebSocketsTickersOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsTickersOption.cs
@@ -9,7 +9,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("ws-tickers", HelpText =
-		"Connects to the given exchange websocket and keeps printing tickers from that exchange." +
+		"Connects to the given exchange websocket and keeps printing tickers from that exchange.\n" +
 		"If market symbol is not set then uses all.")]
 	public class WebSocketsTickersOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol
 	{

--- a/src/ExchangeSharpConsole/Options/WebSocketsTradesOption.cs
+++ b/src/ExchangeSharpConsole/Options/WebSocketsTradesOption.cs
@@ -9,7 +9,7 @@ using ExchangeSharpConsole.Options.Interfaces;
 namespace ExchangeSharpConsole.Options
 {
 	[Verb("ws-trades", HelpText =
-		"Connects to the given exchange websocket and keeps printing the trades from that exchange." +
+		"Connects to the given exchange websocket and keeps printing the trades from that exchange.\n" +
 		"If market symbol is not set then uses all.")]
 	public class WebSocketsTradesOption : BaseOption, IOptionPerExchange, IOptionWithMultipleMarketSymbol
 	{

--- a/src/ExchangeSharpConsole/Program.cs
+++ b/src/ExchangeSharpConsole/Program.cs
@@ -34,6 +34,7 @@ namespace ExchangeSharpConsole
 			typeof(TickerOption),
 			typeof(TradeHistoryOption),
 			typeof(WebSocketsOrderbookOption),
+			typeof(WebSocketsPositionsOption),
 			typeof(WebSocketsTickersOption),
 			typeof(WebSocketsTradesOption),
 			typeof(WebSocketsCandlesOption)


### PR DESCRIPTION
Adds support to base classes for exchanges that have a separate private WebSocket URL that requires authentication. Kraken has one as documented here:
https://docs.kraken.com/websockets/#connectionDetails

Rename `ConnectWebSocketAsync` to `ConnectPublicWebSocketAsync` and add `ConnectPrivateWebSocketAsync`. Both of which call a new `ConnectWebSocketAsync`, which only uses the passed in `url` parameter.

Adds a new `WebSocketsPositionsOption` to the console app for testing this feature.

Implements Kraken's `openOrders` event to return position updates for your account as documented here:
https://docs.kraken.com/websockets/#message-openOrders