### PR TITLE
Fixes #610 - Use TryAddWithoutValidation() when setting HTTP headers. 

### DIFF
--- a/src/ExchangeSharp/API/Common/APIRequestMaker.cs
+++ b/src/ExchangeSharp/API/Common/APIRequestMaker.cs
@@ -21,110 +21,110 @@ using System.Threading.Tasks;
 
 namespace ExchangeSharp
 {
-    /// <summary>
-    /// Handles all the logic for making API calls.
-    /// </summary>
-    /// <seealso cref="ExchangeSharp.IAPIRequestMaker" />
-    public sealed class APIRequestMaker : IAPIRequestMaker
-    {
-        private readonly IAPIRequestHandler api;
+	/// <summary>
+	/// Handles all the logic for making API calls.
+	/// </summary>
+	/// <seealso cref="ExchangeSharp.IAPIRequestMaker" />
+	public sealed class APIRequestMaker : IAPIRequestMaker
+	{
+		private readonly IAPIRequestHandler api;
 
-        /// <summary>
-        /// Proxy for http requests, reads from HTTP_PROXY environment var by default
-        /// You can also set via code if you like
-        /// </summary>
-        private static readonly HttpClientHandler ClientHandler = new HttpClientHandler();
-        public static IWebProxy? Proxy
-        {
-            get => ClientHandler.Proxy;
-            set
-            {
-                ClientHandler.Proxy = value;
-            }
-        }
-        public static readonly HttpClient Client = new HttpClient(ClientHandler);
+		/// <summary>
+		/// Proxy for http requests, reads from HTTP_PROXY environment var by default
+		/// You can also set via code if you like
+		/// </summary>
+		private static readonly HttpClientHandler ClientHandler = new HttpClientHandler();
+		public static IWebProxy? Proxy
+		{
+			get => ClientHandler.Proxy;
+			set
+			{
+				ClientHandler.Proxy = value;
+			}
+		}
+		public static readonly HttpClient Client = new HttpClient(ClientHandler);
 
-        /// <summary>
-        /// Static constructor
-        /// </summary>
-        static APIRequestMaker()
-        {
-            var httpProxy = Environment.GetEnvironmentVariable("http_proxy");
-            httpProxy ??= Environment.GetEnvironmentVariable("HTTP_PROXY");
+		/// <summary>
+		/// Static constructor
+		/// </summary>
+		static APIRequestMaker()
+		{
+			var httpProxy = Environment.GetEnvironmentVariable("http_proxy");
+			httpProxy ??= Environment.GetEnvironmentVariable("HTTP_PROXY");
 
-            if (!string.IsNullOrWhiteSpace(httpProxy))
-            {
-                var uri = new Uri(httpProxy);
-                Proxy = new WebProxy(uri);
-            }
+			if (!string.IsNullOrWhiteSpace(httpProxy))
+			{
+				var uri = new Uri(httpProxy);
+				Proxy = new WebProxy(uri);
+			}
 
-            Client.DefaultRequestHeaders.ConnectionClose = true; // disable keep-alive
-            Client.Timeout = Timeout.InfiniteTimeSpan; // we handle timeout by ourselves
-        }
+			Client.DefaultRequestHeaders.ConnectionClose = true; // disable keep-alive
+			Client.Timeout = Timeout.InfiniteTimeSpan; // we handle timeout by ourselves
+		}
 
-        internal class InternalHttpWebRequest : IHttpWebRequest
-        {
-            internal readonly HttpRequestMessage Request;
-            internal HttpResponseMessage? Response;
-            private string? contentType;
+		internal class InternalHttpWebRequest : IHttpWebRequest
+		{
+			internal readonly HttpRequestMessage Request;
+			internal HttpResponseMessage? Response;
+			private string? contentType;
 
-            public InternalHttpWebRequest(string method, Uri fullUri)
-            {
-                Request = new HttpRequestMessage(new HttpMethod(method), fullUri);
-            }
+			public InternalHttpWebRequest(string method, Uri fullUri)
+			{
+				Request = new HttpRequestMessage(new HttpMethod(method), fullUri);
+			}
 
-            public void AddHeader(string header, string value)
-            {
-                switch (header.ToLowerInvariant())
-                {
-                    case "content-type":
-                        contentType = value;
-                        break;
-                    default:
-                        Request.Headers.Add(header, value);
-                        break;
-                }
-            }
+			public void AddHeader(string header, string value)
+			{
+				switch (header.ToLowerInvariant())
+				{
+					case "content-type":
+						contentType = value;
+						break;
+					default:
+						Request.Headers.TryAddWithoutValidation(header, value);
+						break;
+				}
+			}
 
-            public Uri RequestUri
-            {
-                get { return Request.RequestUri; }
-            }
+			public Uri RequestUri
+			{
+				get { return Request.RequestUri; }
+			}
 
-            public string Method
-            {
-                get { return Request.Method.Method; }
-                set { Request.Method = new HttpMethod(value); }
-            }
+			public string Method
+			{
+				get { return Request.Method.Method; }
+				set { Request.Method = new HttpMethod(value); }
+			}
 
-            public int Timeout { get; set; }
+			public int Timeout { get; set; }
 
-            public int ReadWriteTimeout
-            {
-                get => Timeout;
-                set => Timeout = value;
-            }
+			public int ReadWriteTimeout
+			{
+				get => Timeout;
+				set => Timeout = value;
+			}
 
 
-            public Task WriteAllAsync(byte[] data, int index, int length)
-            {
-                Request.Content = new ByteArrayContent(data, index, length);
-                Request.Content.Headers.Add("content-type", contentType);
+			public Task WriteAllAsync(byte[] data, int index, int length)
+			{
+				Request.Content = new ByteArrayContent(data, index, length);
+				Request.Content.Headers.Add("content-type", contentType);
 				return Task.CompletedTask;
-            }
-        }
+			}
+		}
 
-        internal class InternalHttpWebResponse : IHttpWebResponse
-        {
-            private readonly HttpResponseMessage response;
+		internal class InternalHttpWebResponse : IHttpWebResponse
+		{
+			private readonly HttpResponseMessage response;
 
-            public InternalHttpWebResponse(HttpResponseMessage response)
-            {
-                this.response = response;
-            }
+			public InternalHttpWebResponse(HttpResponseMessage response)
+			{
+				this.response = response;
+			}
 
-            public IReadOnlyList<string> GetHeader(string name)
-            {
+			public IReadOnlyList<string> GetHeader(string name)
+			{
 				try
 				{
 					return response.Headers.GetValues(name).ToArray(); // throws InvalidOperationException when name not exist
@@ -135,102 +135,102 @@ namespace ExchangeSharp
 				}
 			}
 
-            public Dictionary<string, IReadOnlyList<string>> Headers
-            {
-                get
-                {
-                    return response.Headers.ToDictionary(x => x.Key, x => (IReadOnlyList<string>)x.Value.ToArray());
-                }
-            }
-        }
+			public Dictionary<string, IReadOnlyList<string>> Headers
+			{
+				get
+				{
+					return response.Headers.ToDictionary(x => x.Key, x => (IReadOnlyList<string>)x.Value.ToArray());
+				}
+			}
+		}
 
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="api">API</param>
-        public APIRequestMaker(IAPIRequestHandler api)
-        {
-            this.api = api;
-        }
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="api">API</param>
+		public APIRequestMaker(IAPIRequestHandler api)
+		{
+			this.api = api;
+		}
 
-        /// <summary>
-        /// Make a request to a path on the API
-        /// </summary>
-        /// <param name="url">Path and query</param>
-        /// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
-        /// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
-        /// The encoding of payload is API dependant but is typically json.</param>
-        /// <param name="method">Request method or null for default. Example: 'GET' or 'POST'.</param>
-        /// <returns>Raw response</returns>
-        public async Task<string> MakeRequestAsync(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? method = null)
-        {
-            await new SynchronizationContextRemover();
-            await api.RateLimit.WaitToProceedAsync();
+		/// <summary>
+		/// Make a request to a path on the API
+		/// </summary>
+		/// <param name="url">Path and query</param>
+		/// <param name="baseUrl">Override the base url, null for the default BaseUrl</param>
+		/// <param name="payload">Payload, can be null. For private API end points, the payload must contain a 'nonce' key set to GenerateNonce value.</param>
+		/// The encoding of payload is API dependant but is typically json.</param>
+		/// <param name="method">Request method or null for default. Example: 'GET' or 'POST'.</param>
+		/// <returns>Raw response</returns>
+		public async Task<string> MakeRequestAsync(string url, string? baseUrl = null, Dictionary<string, object>? payload = null, string? method = null)
+		{
+			await new SynchronizationContextRemover();
+			await api.RateLimit.WaitToProceedAsync();
 
-            if (url[0] != '/')
-            {
-                url = "/" + url;
-            }
+			if (url[0] != '/')
+			{
+				url = "/" + url;
+			}
 
-            // prepare the request
-            string fullUrl = (baseUrl ?? api.BaseUrl) + url;
-            method ??= api.RequestMethod;
-            Uri uri = api.ProcessRequestUrl(new UriBuilder(fullUrl), payload, method);
-            var request = new InternalHttpWebRequest(method, uri);
-            request.AddHeader("accept-language", "en-US,en;q=0.5");
-            request.AddHeader("content-type", api.RequestContentType);
-            request.AddHeader("user-agent", BaseAPI.RequestUserAgent);
-            request.Timeout = (int)api.RequestTimeout.TotalMilliseconds;
-            await api.ProcessRequestAsync(request, payload);
+			// prepare the request
+			string fullUrl = (baseUrl ?? api.BaseUrl) + url;
+			method ??= api.RequestMethod;
+			Uri uri = api.ProcessRequestUrl(new UriBuilder(fullUrl), payload, method);
+			var request = new InternalHttpWebRequest(method, uri);
+			request.AddHeader("accept-language", "en-US,en;q=0.5");
+			request.AddHeader("content-type", api.RequestContentType);
+			request.AddHeader("user-agent", BaseAPI.RequestUserAgent);
+			request.Timeout = (int)api.RequestTimeout.TotalMilliseconds;
+			await api.ProcessRequestAsync(request, payload);
 
-            // send the request
-            var response = request.Response;
-            string responseString;
-            using var cancel = new CancellationTokenSource(request.Timeout);
-            try
-            {
-                RequestStateChanged?.Invoke(this, RequestMakerState.Begin, uri.AbsoluteUri);// when start make a request we send the uri, this helps developers to track the http requests.
-                response = await Client.SendAsync(request.Request, cancel.Token);
-                if (response == null)
-                {
-                    throw new APIException("Unknown response from server");
-                }
-                responseString = await response.Content.ReadAsStringAsync();
+			// send the request
+			var response = request.Response;
+			string responseString;
+			using var cancel = new CancellationTokenSource(request.Timeout);
+			try
+			{
+				RequestStateChanged?.Invoke(this, RequestMakerState.Begin, uri.AbsoluteUri);// when start make a request we send the uri, this helps developers to track the http requests.
+				response = await Client.SendAsync(request.Request, cancel.Token);
+				if (response == null)
+				{
+					throw new APIException("Unknown response from server");
+				}
+				responseString = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Created)
-                {
-                    // 404 maybe return empty responseString
-                    if (string.IsNullOrWhiteSpace(responseString))
-                    {
-                        throw new APIException(string.Format("{0} - {1}", response.StatusCode.ConvertInvariant<int>(), response.StatusCode));
-                    }
+				if (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Created)
+				{
+					// 404 maybe return empty responseString
+					if (string.IsNullOrWhiteSpace(responseString))
+					{
+						throw new APIException(string.Format("{0} - {1}", response.StatusCode.ConvertInvariant<int>(), response.StatusCode));
+					}
 
-                    throw new APIException(responseString);
-                }
+					throw new APIException(responseString);
+				}
 
 				api.ProcessResponse(new InternalHttpWebResponse(response));
-                RequestStateChanged?.Invoke(this, RequestMakerState.Finished, responseString);
-            }
-            catch (OperationCanceledException ex) when (cancel.IsCancellationRequested)
-            {
-                RequestStateChanged?.Invoke(this, RequestMakerState.Error, ex);
-                throw new TimeoutException("APIRequest timeout", ex);
-            }
-            catch (Exception ex)
-            {
-                RequestStateChanged?.Invoke(this, RequestMakerState.Error, ex);
-                throw;
-            }
-            finally
-            {
-                response?.Dispose();
-            }
-            return responseString;
-        }
+				RequestStateChanged?.Invoke(this, RequestMakerState.Finished, responseString);
+			}
+			catch (OperationCanceledException ex) when (cancel.IsCancellationRequested)
+			{
+				RequestStateChanged?.Invoke(this, RequestMakerState.Error, ex);
+				throw new TimeoutException("APIRequest timeout", ex);
+			}
+			catch (Exception ex)
+			{
+				RequestStateChanged?.Invoke(this, RequestMakerState.Error, ex);
+				throw;
+			}
+			finally
+			{
+				response?.Dispose();
+			}
+			return responseString;
+		}
 
-        /// <summary>
-        /// An action to execute when a request has been made (this request and state and object (response or exception))
-        /// </summary>
-        public Action<IAPIRequestMaker, RequestMakerState, object>? RequestStateChanged { get; set; }
-    }
+		/// <summary>
+		/// An action to execute when a request has been made (this request and state and object (response or exception))
+		/// </summary>
+		public Action<IAPIRequestMaker, RequestMakerState, object>? RequestStateChanged { get; set; }
+	}
 }

--- a/src/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/src/ExchangeSharp/API/Common/BaseAPI.cs
@@ -510,7 +510,7 @@ namespace ExchangeSharp
 		/// <param name="messageCallback">Callback for messages</param>
 		/// <param name="connectCallback">Connect callback</param>
 		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
-		public Task<IWebSocket> ConnectWebSocketAsync
+		public virtual Task<IWebSocket> ConnectWebSocketAsync
 		(
 			string url,
 			Func<IWebSocket, byte[], Task> messageCallback,
@@ -551,7 +551,7 @@ namespace ExchangeSharp
 		/// <param name="messageCallback">Callback for messages</param>
 		/// <param name="connectCallback">Connect callback</param>
 		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
-		public Task<IWebSocket> ConnectPublicWebSocketAsync
+		public virtual Task<IWebSocket> ConnectPublicWebSocketAsync
 		(
 			string url,
 			Func<IWebSocket, byte[], Task> messageCallback,
@@ -577,7 +577,7 @@ namespace ExchangeSharp
 		/// <param name="connectCallback">Connect callback</param>
 		/// <param name="textMessageCallback">Text Message callback</param>
 		/// <returns>Web socket - dispose of the wrapper to shutdown the socket</returns>
-		public Task<IWebSocket> ConnectPrivateWebSocketAsync
+		public virtual Task<IWebSocket> ConnectPrivateWebSocketAsync
 		(
 			string url,
 			Func<IWebSocket, byte[], Task> messageCallback,


### PR DESCRIPTION
* Use `TryAddWithoutValidation()` when setting HTTP headers. 
* Switch `APIRequestMaker.cs` to tab indention.
* Allow override of `ConnectWebSocketAsync()` and friends to prep for Bittrex v3 WebSocket support.
