### PR TITLE
Make market orders possible by removing price requirement

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BL3P/ExchangeBL3PAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BL3P/ExchangeBL3PAPI.cs
@@ -252,10 +252,10 @@ namespace ExchangeSharp
 			switch (order.OrderType)
 			{
 				case OrderType.Limit:
-					data["price_int"] = converterToFive.FromDecimal(order.Price);
+					data["price_int"] = converterToFive.FromDecimal(order.Price.Value);
 					break;
 				case OrderType.Market:
-					data["amount_funds_int"] = converterToFive.FromDecimal(roundedAmount * order.Price);
+					data["amount_funds_int"] = converterToFive.FromDecimal(roundedAmount * order.Price.Value);
 					break;
 				default:
 					throw new NotSupportedException($"{order.OrderType} is not supported");

--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
@@ -443,7 +443,7 @@ namespace ExchangeSharp.BinanceGroup
 			// TODO : Refactor into a common layer once more Exchanges implement this pattern
 			// https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list
 			if(limit > 1000) limit = 1000;	//Binance max = 1000
-			var maxRequestLimit = 1000; 
+			var maxRequestLimit = 1000;
 			var trades = new List<ExchangeTrade>();
 			var processedIds = new HashSet<long>();
 			marketSymbol = NormalizeMarketSymbol(marketSymbol);
@@ -559,7 +559,7 @@ namespace ExchangeSharp.BinanceGroup
 
 			// Binance has strict rules on which prices and quantities are allowed. They have to match the rules defined in the market definition.
 			decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-			decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+			decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price.Value);
 
 			// Binance does not accept quantities with more than 20 decimal places.
 			payload["quantity"] = Math.Round(outputQuantity, 20);

--- a/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -481,7 +481,7 @@ namespace ExchangeSharp
 
 			if (order.OrderType != OrderType.Market)
 			{
-				payload["price"] = (await ClampOrderPrice(marketSymbol, order.Price)).ToStringInvariant();
+				payload["price"] = (await ClampOrderPrice(marketSymbol, order.Price.Value)).ToStringInvariant();
 			}
 			else
 			{

--- a/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -442,7 +442,7 @@ namespace ExchangeSharp
             List<ExchangeOrderResult> orders2 = new List<ExchangeOrderResult>();
             foreach (var group in groupings)
             {
-                decimal spentQuoteCurrency = group.Sum(o => o.AveragePrice * o.AmountFilled);
+                decimal spentQuoteCurrency = group.Sum(o => o.AveragePrice.Value * o.AmountFilled);
                 ExchangeOrderResult order = group.First();
                 order.AmountFilled = group.Sum(o => o.AmountFilled);
                 order.AveragePrice = spentQuoteCurrency / order.AmountFilled;

--- a/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -84,7 +84,7 @@ namespace ExchangeSharp
 			decimal amountFilled = token["fillQuantity"].ConvertInvariant<decimal>();
 			order.Amount = amount;
 			order.AmountFilled = amountFilled;
-			order.Price = token["limit"].ConvertInvariant<decimal>(order.AveragePrice);
+			order.Price = token["limit"].ConvertInvariant<decimal>(order.AveragePrice.Value);
 			order.Message = string.Empty;
 			order.OrderId = token["id"].ToStringInvariant();
 
@@ -378,7 +378,7 @@ namespace ExchangeSharp
 		{
 
 			decimal orderAmount = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-			decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+			decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price.Value);
 			string url = "/orders";
 			Dictionary<string, object> orderParams = await GetNoncePayloadAsync();
 			orderParams.Add("marketSymbol", order.MarketSymbol);
@@ -507,7 +507,7 @@ namespace ExchangeSharp
 		{
 			/*
 				"currencySymbol": "string",
-				"quantity": "number (double)",			
+				"quantity": "number (double)",
 				"cryptoAddress": "string",
 				"cryptoAddressTag": "string",
 				"clientWithdrawalId": "string (uuid)"

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -12,30 +12,30 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace ExchangeSharp
 {
-    using ExchangeSharp.Coinbase;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Net;
-    using System.Threading.Tasks;
+	using ExchangeSharp.Coinbase;
+	using Newtonsoft.Json;
+	using Newtonsoft.Json.Linq;
+	using System;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.Linq;
+	using System.Net;
+	using System.Threading.Tasks;
 
-    public sealed partial class ExchangeCoinbaseAPI : ExchangeAPI
-    {
-        public override string BaseUrl { get; set; } = "https://api.pro.coinbase.com";
-        public override string BaseUrlWebSocket { get; set; } = "wss://ws-feed.pro.coinbase.com";
+	public sealed partial class ExchangeCoinbaseAPI : ExchangeAPI
+	{
+		public override string BaseUrl { get; set; } = "https://api.pro.coinbase.com";
+		public override string BaseUrlWebSocket { get; set; } = "wss://ws-feed.pro.coinbase.com";
 
-        /// <summary>
-        /// The response will also contain a CB-AFTER header which will return the cursor id to use in your next request for the page after this one. The page after is an older page and not one that happened after this one in chronological time.
-        /// </summary>
-        private string cursorAfter;
+		/// <summary>
+		/// The response will also contain a CB-AFTER header which will return the cursor id to use in your next request for the page after this one. The page after is an older page and not one that happened after this one in chronological time.
+		/// </summary>
+		private string cursorAfter;
 
-        /// <summary>
-        /// The response will contain a CB-BEFORE header which will return the cursor id to use in your next request for the page before the current one. The page before is a newer page and not one that happened before in chronological time.
-        /// </summary>
-        private string cursorBefore;
+		/// <summary>
+		/// The response will contain a CB-BEFORE header which will return the cursor id to use in your next request for the page before the current one. The page before is a newer page and not one that happened before in chronological time.
+		/// </summary>
+		private string cursorBefore;
 
 		private ExchangeCoinbaseAPI()
 		{
@@ -49,359 +49,359 @@ namespace ExchangeSharp
 
 
 		private ExchangeOrderResult ParseFill(JToken result)
-        {
-            decimal amount = result["size"].ConvertInvariant<decimal>();
-            decimal price = result["price"].ConvertInvariant<decimal>();
-            string symbol = result["product_id"].ToStringInvariant();
+		{
+			decimal amount = result["size"].ConvertInvariant<decimal>();
+			decimal price = result["price"].ConvertInvariant<decimal>();
+			string symbol = result["product_id"].ToStringInvariant();
 
-            decimal fees = result["fee"].ConvertInvariant<decimal>();
+			decimal fees = result["fee"].ConvertInvariant<decimal>();
 
-            ExchangeOrderResult order = new ExchangeOrderResult
-            {
-                TradeId = result["trade_id"].ToStringInvariant(),
-                Amount = amount,
-                AmountFilled = amount,
-                Price = price,
-                Fees = fees,
-                AveragePrice = price,
-                IsBuy = (result["side"].ToStringInvariant() == "buy"),
-                OrderDate = result["created_at"].ToDateTimeInvariant(),
-                MarketSymbol = symbol,
-                OrderId = result["order_id"].ToStringInvariant(),
-            };
+			ExchangeOrderResult order = new ExchangeOrderResult
+			{
+				TradeId = result["trade_id"].ToStringInvariant(),
+				Amount = amount,
+				AmountFilled = amount,
+				Price = price,
+				Fees = fees,
+				AveragePrice = price,
+				IsBuy = (result["side"].ToStringInvariant() == "buy"),
+				OrderDate = result["created_at"].ToDateTimeInvariant(),
+				MarketSymbol = symbol,
+				OrderId = result["order_id"].ToStringInvariant(),
+			};
 
-            return order;
-        }
+			return order;
+		}
 
-        private ExchangeOrderResult ParseOrder(JToken result)
-        {
-            decimal executedValue = result["executed_value"].ConvertInvariant<decimal>();
-            decimal amountFilled = result["filled_size"].ConvertInvariant<decimal>();
-            decimal amount = result["size"].ConvertInvariant<decimal>(amountFilled);
-            decimal price = result["price"].ConvertInvariant<decimal>();
-            decimal stop_price = result["stop_price"].ConvertInvariant<decimal>();
-            decimal averagePrice = (amountFilled <= 0m ? 0m : executedValue / amountFilled);
-            decimal fees = result["fill_fees"].ConvertInvariant<decimal>();
-            string marketSymbol = result["product_id"].ToStringInvariant(result["id"].ToStringInvariant());
+		private ExchangeOrderResult ParseOrder(JToken result)
+		{
+			decimal executedValue = result["executed_value"].ConvertInvariant<decimal>();
+			decimal amountFilled = result["filled_size"].ConvertInvariant<decimal>();
+			decimal amount = result["size"].ConvertInvariant<decimal>(amountFilled);
+			decimal price = result["price"].ConvertInvariant<decimal>();
+			decimal stop_price = result["stop_price"].ConvertInvariant<decimal>();
+			decimal averagePrice = (amountFilled <= 0m ? 0m : executedValue / amountFilled);
+			decimal fees = result["fill_fees"].ConvertInvariant<decimal>();
+			string marketSymbol = result["product_id"].ToStringInvariant(result["id"].ToStringInvariant());
 
-            ExchangeOrderResult order = new ExchangeOrderResult
-            {
-                Amount = amount,
-                AmountFilled = amountFilled,
-                Price = price <= 0m ? stop_price : price,
-                Fees = fees,
-                FeesCurrency = marketSymbol.Substring(0, marketSymbol.IndexOf('-')),
-                AveragePrice = averagePrice,
-                IsBuy = (result["side"].ToStringInvariant() == "buy"),
-                OrderDate = result["created_at"].ToDateTimeInvariant(),
-                FillDate = result["done_at"].ToDateTimeInvariant(),
-                MarketSymbol = marketSymbol,
-                OrderId = result["id"].ToStringInvariant()
-            };
-            switch (result["status"].ToStringInvariant())
-            {
-                case "pending":
-                    order.Result = ExchangeAPIOrderResult.Pending;
-                    break;
-                case "active":
-                case "open":
-                    if (order.Amount == order.AmountFilled)
-                    {
-                        order.Result = ExchangeAPIOrderResult.Filled;
-                    }
-                    else if (order.AmountFilled > 0.0m)
-                    {
-                        order.Result = ExchangeAPIOrderResult.FilledPartially;
-                    }
-                    else
-                    {
-                        order.Result = ExchangeAPIOrderResult.Pending;
-                    }
-                    break;
-                case "done":
-                case "settled":
-                    switch (result["done_reason"].ToStringInvariant())
-                    {
-                        case "cancelled":
-                        case "canceled":
-                            order.Result = ExchangeAPIOrderResult.Canceled;
-                            break;
-                        case "filled":
-                            order.Result = ExchangeAPIOrderResult.Filled;
-                            break;
-                        default:
-                            order.Result = ExchangeAPIOrderResult.Unknown;
-                            break;
-                    }
-                    break;
-                case "cancelled":
-                case "canceled":
-                    order.Result = ExchangeAPIOrderResult.Canceled;
-                    break;
-                default:
-                    order.Result = ExchangeAPIOrderResult.Unknown;
-                    break;
-            }
-            return order;
-        }
+			ExchangeOrderResult order = new ExchangeOrderResult
+			{
+				Amount = amount,
+				AmountFilled = amountFilled,
+				Price = price <= 0m ? stop_price : price,
+				Fees = fees,
+				FeesCurrency = marketSymbol.Substring(0, marketSymbol.IndexOf('-')),
+				AveragePrice = averagePrice,
+				IsBuy = (result["side"].ToStringInvariant() == "buy"),
+				OrderDate = result["created_at"].ToDateTimeInvariant(),
+				FillDate = result["done_at"].ToDateTimeInvariant(),
+				MarketSymbol = marketSymbol,
+				OrderId = result["id"].ToStringInvariant()
+			};
+			switch (result["status"].ToStringInvariant())
+			{
+				case "pending":
+					order.Result = ExchangeAPIOrderResult.Pending;
+					break;
+				case "active":
+				case "open":
+					if (order.Amount == order.AmountFilled)
+					{
+						order.Result = ExchangeAPIOrderResult.Filled;
+					}
+					else if (order.AmountFilled > 0.0m)
+					{
+						order.Result = ExchangeAPIOrderResult.FilledPartially;
+					}
+					else
+					{
+						order.Result = ExchangeAPIOrderResult.Pending;
+					}
+					break;
+				case "done":
+				case "settled":
+					switch (result["done_reason"].ToStringInvariant())
+					{
+						case "cancelled":
+						case "canceled":
+							order.Result = ExchangeAPIOrderResult.Canceled;
+							break;
+						case "filled":
+							order.Result = ExchangeAPIOrderResult.Filled;
+							break;
+						default:
+							order.Result = ExchangeAPIOrderResult.Unknown;
+							break;
+					}
+					break;
+				case "cancelled":
+				case "canceled":
+					order.Result = ExchangeAPIOrderResult.Canceled;
+					break;
+				default:
+					order.Result = ExchangeAPIOrderResult.Unknown;
+					break;
+			}
+			return order;
+		}
 
-        protected override bool CanMakeAuthenticatedRequest(IReadOnlyDictionary<string, object> payload)
-        {
-            return base.CanMakeAuthenticatedRequest(payload) && Passphrase != null;
-        }
+		protected override bool CanMakeAuthenticatedRequest(IReadOnlyDictionary<string, object> payload)
+		{
+			return base.CanMakeAuthenticatedRequest(payload) && Passphrase != null;
+		}
 
-        protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
-        {
-            if (CanMakeAuthenticatedRequest(payload))
-            {
-                // Coinbase is funny and wants a seconds double for the nonce, weird... we convert it to double and back to string invariantly to ensure decimal dot is used and not comma
-                string timestamp = payload["nonce"].ToStringInvariant();
-                payload.Remove("nonce");
-                string form = CryptoUtility.GetJsonForPayload(payload);
-                byte[] secret = CryptoUtility.ToBytesBase64Decode(PrivateApiKey);
-                string toHash = timestamp + request.Method.ToUpperInvariant() + request.RequestUri.PathAndQuery + form;
-                string signatureBase64String = CryptoUtility.SHA256SignBase64(toHash, secret);
-                secret = null;
-                toHash = null;
-                request.AddHeader("CB-ACCESS-KEY", PublicApiKey.ToUnsecureString());
-                request.AddHeader("CB-ACCESS-SIGN", signatureBase64String);
-                request.AddHeader("CB-ACCESS-TIMESTAMP", timestamp);
-                request.AddHeader("CB-ACCESS-PASSPHRASE", CryptoUtility.ToUnsecureString(Passphrase));
-                if (request.Method == "POST")
-                {
-                    await CryptoUtility.WriteToRequestAsync(request, form);
-                }
-            }
-        }
+		protected override async Task ProcessRequestAsync(IHttpWebRequest request, Dictionary<string, object> payload)
+		{
+			if (CanMakeAuthenticatedRequest(payload))
+			{
+				// Coinbase is funny and wants a seconds double for the nonce, weird... we convert it to double and back to string invariantly to ensure decimal dot is used and not comma
+				string timestamp = payload["nonce"].ToStringInvariant();
+				payload.Remove("nonce");
+				string form = CryptoUtility.GetJsonForPayload(payload);
+				byte[] secret = CryptoUtility.ToBytesBase64Decode(PrivateApiKey);
+				string toHash = timestamp + request.Method.ToUpperInvariant() + request.RequestUri.PathAndQuery + form;
+				string signatureBase64String = CryptoUtility.SHA256SignBase64(toHash, secret);
+				secret = null;
+				toHash = null;
+				request.AddHeader("CB-ACCESS-KEY", PublicApiKey.ToUnsecureString());
+				request.AddHeader("CB-ACCESS-SIGN", signatureBase64String);
+				request.AddHeader("CB-ACCESS-TIMESTAMP", timestamp);
+				request.AddHeader("CB-ACCESS-PASSPHRASE", CryptoUtility.ToUnsecureString(Passphrase));
+				if (request.Method == "POST")
+				{
+					await CryptoUtility.WriteToRequestAsync(request, form);
+				}
+			}
+		}
 
-        protected override void ProcessResponse(IHttpWebResponse response)
-        {
-            base.ProcessResponse(response);
-            cursorAfter = response.GetHeader("CB-AFTER").FirstOrDefault();
-            cursorBefore = response.GetHeader("CB-BEFORE").FirstOrDefault();
-        }
+		protected override void ProcessResponse(IHttpWebResponse response)
+		{
+			base.ProcessResponse(response);
+			cursorAfter = response.GetHeader("CB-AFTER").FirstOrDefault();
+			cursorBefore = response.GetHeader("CB-BEFORE").FirstOrDefault();
+		}
 
-        protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
-        {
-            var markets = new List<ExchangeMarket>();
-            JToken products = await MakeJsonRequestAsync<JToken>("/products");
-            foreach (JToken product in products)
-            {
-                var market = new ExchangeMarket
-                {
-                    MarketSymbol = product["id"].ToStringUpperInvariant(),
-                    QuoteCurrency = product["quote_currency"].ToStringUpperInvariant(),
-                    BaseCurrency = product["base_currency"].ToStringUpperInvariant(),
-                    IsActive = string.Equals(product["status"].ToStringInvariant(), "online", StringComparison.OrdinalIgnoreCase),
-                    MinTradeSize = product["base_min_size"].ConvertInvariant<decimal>(),
-                    MaxTradeSize = product["base_max_size"].ConvertInvariant<decimal>(),
-                    PriceStepSize = product["quote_increment"].ConvertInvariant<decimal>()
-                };
-                markets.Add(market);
-            }
+		protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
+		{
+			var markets = new List<ExchangeMarket>();
+			JToken products = await MakeJsonRequestAsync<JToken>("/products");
+			foreach (JToken product in products)
+			{
+				var market = new ExchangeMarket
+				{
+					MarketSymbol = product["id"].ToStringUpperInvariant(),
+					QuoteCurrency = product["quote_currency"].ToStringUpperInvariant(),
+					BaseCurrency = product["base_currency"].ToStringUpperInvariant(),
+					IsActive = string.Equals(product["status"].ToStringInvariant(), "online", StringComparison.OrdinalIgnoreCase),
+					MinTradeSize = product["base_min_size"].ConvertInvariant<decimal>(),
+					MaxTradeSize = product["base_max_size"].ConvertInvariant<decimal>(),
+					PriceStepSize = product["quote_increment"].ConvertInvariant<decimal>()
+				};
+				markets.Add(market);
+			}
 
-            return markets;
-        }
+			return markets;
+		}
 
-        protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
-        {
-            return (await GetMarketSymbolsMetadataAsync()).Select(market => market.MarketSymbol);
-        }
+		protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
+		{
+			return (await GetMarketSymbolsMetadataAsync()).Select(market => market.MarketSymbol);
+		}
 
-        protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
-        {
-            var currencies = new Dictionary<string, ExchangeCurrency>();
-            JToken products = await MakeJsonRequestAsync<JToken>("/currencies");
-            foreach (JToken product in products)
-            {
-                var currency = new ExchangeCurrency
-                {
-                    Name = product["id"].ToStringUpperInvariant(),
-                    FullName = product["name"].ToStringInvariant(),
-                    DepositEnabled = true,
-                    WithdrawalEnabled = true
-                };
+		protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()
+		{
+			var currencies = new Dictionary<string, ExchangeCurrency>();
+			JToken products = await MakeJsonRequestAsync<JToken>("/currencies");
+			foreach (JToken product in products)
+			{
+				var currency = new ExchangeCurrency
+				{
+					Name = product["id"].ToStringUpperInvariant(),
+					FullName = product["name"].ToStringInvariant(),
+					DepositEnabled = true,
+					WithdrawalEnabled = true
+				};
 
-                currencies[currency.Name] = currency;
-            }
+				currencies[currency.Name] = currency;
+			}
 
-            return currencies;
-        }
+			return currencies;
+		}
 
-        protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
-        {
-            JToken ticker = await MakeJsonRequestAsync<JToken>("/products/" + marketSymbol + "/ticker");
-            return await this.ParseTickerAsync(ticker, marketSymbol, "ask", "bid", "price", "volume", null, "time", TimestampType.Iso8601);
-        }
+		protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)
+		{
+			JToken ticker = await MakeJsonRequestAsync<JToken>("/products/" + marketSymbol + "/ticker");
+			return await this.ParseTickerAsync(ticker, marketSymbol, "ask", "bid", "price", "volume", null, "time", TimestampType.Iso8601);
+		}
 
-        protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
-        {
-            // Hack found here: https://github.com/coinbase/gdax-node/issues/91#issuecomment-352441654 + using Fiddler
+		protected override async Task<ExchangeDepositDetails> OnGetDepositAddressAsync(string symbol, bool forceRegenerate = false)
+		{
+			// Hack found here: https://github.com/coinbase/gdax-node/issues/91#issuecomment-352441654 + using Fiddler
 
-            // Get coinbase accounts
-            JArray accounts = await this.MakeJsonRequestAsync<JArray>("/coinbase-accounts", null, await GetNoncePayloadAsync(), "GET");
+			// Get coinbase accounts
+			JArray accounts = await this.MakeJsonRequestAsync<JArray>("/coinbase-accounts", null, await GetNoncePayloadAsync(), "GET");
 
-            foreach (JToken token in accounts)
-            {
-                string currency = token["currency"].ConvertInvariant<string>();
-                if (currency.Equals(symbol, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    JToken accountWalletAddress = await this.MakeJsonRequestAsync<JToken>(
-                                                                                          $"/coinbase-accounts/{token["id"]}/addresses",
-                                                                                          null,
-                                                                                          await GetNoncePayloadAsync(),
-                                                                                          "POST");
+			foreach (JToken token in accounts)
+			{
+				string currency = token["currency"].ConvertInvariant<string>();
+				if (currency.Equals(symbol, StringComparison.InvariantCultureIgnoreCase))
+				{
+					JToken accountWalletAddress = await this.MakeJsonRequestAsync<JToken>(
+																						  $"/coinbase-accounts/{token["id"]}/addresses",
+																						  null,
+																						  await GetNoncePayloadAsync(),
+																						  "POST");
 
-                    return new ExchangeDepositDetails { Address = accountWalletAddress["address"].ToStringInvariant(), Currency = currency };
-                }
+					return new ExchangeDepositDetails { Address = accountWalletAddress["address"].ToStringInvariant(), Currency = currency };
+				}
 
-            }
-            throw new APIException($"Address not found for {symbol}");
-        }
+			}
+			throw new APIException($"Address not found for {symbol}");
+		}
 
-        protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
-        {
-            Dictionary<string, ExchangeTicker> tickers = new Dictionary<string, ExchangeTicker>(StringComparer.OrdinalIgnoreCase);
-            System.Threading.ManualResetEvent evt = new System.Threading.ManualResetEvent(false);
-            List<string> symbols = (await GetMarketSymbolsAsync()).ToList();
+		protected override async Task<IEnumerable<KeyValuePair<string, ExchangeTicker>>> OnGetTickersAsync()
+		{
+			Dictionary<string, ExchangeTicker> tickers = new Dictionary<string, ExchangeTicker>(StringComparer.OrdinalIgnoreCase);
+			System.Threading.ManualResetEvent evt = new System.Threading.ManualResetEvent(false);
+			List<string> symbols = (await GetMarketSymbolsAsync()).ToList();
 
-            // stupid Coinbase does not have a one shot API call for tickers outside of web sockets
-            using (var socket = await GetTickersWebSocketAsync((t) =>
-            {
-                lock (tickers)
-                {
-                    if (symbols.Count != 0)
-                    {
-                        foreach (var kv in t)
-                        {
-                            if (!tickers.ContainsKey(kv.Key))
-                            {
-                                tickers[kv.Key] = kv.Value;
-                                symbols.Remove(kv.Key);
-                            }
-                        }
-                        if (symbols.Count == 0)
-                        {
-                            evt.Set();
-                        }
-                    }
-                }
-            }
-            ))
-            {
-                evt.WaitOne(10000);
-                return tickers;
-            }
-        }
+			// stupid Coinbase does not have a one shot API call for tickers outside of web sockets
+			using (var socket = await GetTickersWebSocketAsync((t) =>
+			{
+				lock (tickers)
+				{
+					if (symbols.Count != 0)
+					{
+						foreach (var kv in t)
+						{
+							if (!tickers.ContainsKey(kv.Key))
+							{
+								tickers[kv.Key] = kv.Value;
+								symbols.Remove(kv.Key);
+							}
+						}
+						if (symbols.Count == 0)
+						{
+							evt.Set();
+						}
+					}
+				}
+			}
+			))
+			{
+				evt.WaitOne(10000);
+				return tickers;
+			}
+		}
 
-        protected override Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
-        {
-            return ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
-            {
-                string message = msg.ToStringFromUTF8();
-                var book = new ExchangeOrderBook();
+		protected override Task<IWebSocket> OnGetDeltaOrderBookWebSocketAsync(Action<ExchangeOrderBook> callback, int maxCount = 20, params string[] marketSymbols)
+		{
+			return ConnectPublicWebSocketAsync(string.Empty, (_socket, msg) =>
+			{
+				string message = msg.ToStringFromUTF8();
+				var book = new ExchangeOrderBook();
 
-                // string comparison on the json text for faster deserialization
-                // More likely to be an l2update so check for that first
-                if (message.Contains(@"""l2update"""))
-                {
-                    // parse delta update
-                    var delta = JsonConvert.DeserializeObject<Level2>(message);
-                    book.MarketSymbol = delta.ProductId;
-                    book.SequenceId = delta.Time.Ticks;
-                    foreach (string[] change in delta.Changes)
-                    {
-                        decimal price = change[1].ConvertInvariant<decimal>();
-                        decimal amount = change[2].ConvertInvariant<decimal>();
-                        if (change[0] == "buy")
-                        {
-                            book.Bids[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
-                        }
-                        else
-                        {
-                            book.Asks[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
-                        }
-                    }
-                }
-                else if (message.Contains(@"""snapshot"""))
-                {
-                    // parse snapshot
-                    var snapshot = JsonConvert.DeserializeObject<Snapshot>(message);
-                    book.MarketSymbol = snapshot.ProductId;
-                    foreach (decimal[] ask in snapshot.Asks)
-                    {
-                        decimal price = ask[0];
-                        decimal amount = ask[1];
-                        book.Asks[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
-                    }
+				// string comparison on the json text for faster deserialization
+				// More likely to be an l2update so check for that first
+				if (message.Contains(@"""l2update"""))
+				{
+					// parse delta update
+					var delta = JsonConvert.DeserializeObject<Level2>(message);
+					book.MarketSymbol = delta.ProductId;
+					book.SequenceId = delta.Time.Ticks;
+					foreach (string[] change in delta.Changes)
+					{
+						decimal price = change[1].ConvertInvariant<decimal>();
+						decimal amount = change[2].ConvertInvariant<decimal>();
+						if (change[0] == "buy")
+						{
+							book.Bids[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
+						}
+						else
+						{
+							book.Asks[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
+						}
+					}
+				}
+				else if (message.Contains(@"""snapshot"""))
+				{
+					// parse snapshot
+					var snapshot = JsonConvert.DeserializeObject<Snapshot>(message);
+					book.MarketSymbol = snapshot.ProductId;
+					foreach (decimal[] ask in snapshot.Asks)
+					{
+						decimal price = ask[0];
+						decimal amount = ask[1];
+						book.Asks[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
+					}
 
-                    foreach (decimal[] bid in snapshot.Bids)
-                    {
-                        decimal price = bid[0];
-                        decimal amount = bid[1];
-                        book.Bids[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
-                    }
-                }
-                else
-                {
-                    // no other message type handled
-                    return Task.CompletedTask;
-                }
+					foreach (decimal[] bid in snapshot.Bids)
+					{
+						decimal price = bid[0];
+						decimal amount = bid[1];
+						book.Bids[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
+					}
+				}
+				else
+				{
+					// no other message type handled
+					return Task.CompletedTask;
+				}
 
-                callback(book);
-                return Task.CompletedTask;
-            }, async (_socket) =>
-            {
-                // subscribe to order book channel for each symbol
-                if (marketSymbols == null || marketSymbols.Length == 0)
-                {
-                    marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
-                }
-                var chan = new Channel { Name = ChannelType.Level2, ProductIds = marketSymbols.ToList() };
-                var channelAction = new ChannelAction { Type = ActionType.Subscribe, Channels = new List<Channel> { chan } };
-                await _socket.SendMessageAsync(channelAction);
-            });
-        }
+				callback(book);
+				return Task.CompletedTask;
+			}, async (_socket) =>
+			{
+				// subscribe to order book channel for each symbol
+				if (marketSymbols == null || marketSymbols.Length == 0)
+				{
+					marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
+				}
+				var chan = new Channel { Name = ChannelType.Level2, ProductIds = marketSymbols.ToList() };
+				var channelAction = new ChannelAction { Type = ActionType.Subscribe, Channels = new List<Channel> { chan } };
+				await _socket.SendMessageAsync(channelAction);
+			});
+		}
 
-        protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] marketSymbols)
-        {
-            return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
-            {
-                JToken token = JToken.Parse(msg.ToStringFromUTF8());
-                if (token["type"].ToStringInvariant() == "ticker")
-                {
-                    ExchangeTicker ticker = await this.ParseTickerAsync(token, token["product_id"].ToStringInvariant(), "best_ask", "best_bid", "price", "volume_24h", null, "time", TimestampType.Iso8601);
-                    callback(new List<KeyValuePair<string, ExchangeTicker>>() { new KeyValuePair<string, ExchangeTicker>(token["product_id"].ToStringInvariant(), ticker) });
-                }
-            }, async (_socket) =>
-            {
-                marketSymbols = marketSymbols == null || marketSymbols.Length == 0 ? (await GetMarketSymbolsAsync()).ToArray() : marketSymbols;
-                var subscribeRequest = new
-                {
-                    type = "subscribe",
-                    product_ids = marketSymbols,
-                    channels = new object[]
-                    {
-                        new
-                        {
-                            name = "ticker",
-                            product_ids = marketSymbols.ToArray()
-                        }
-                    }
-                };
-                await _socket.SendMessageAsync(subscribeRequest);
-            });
-        }
+		protected override async Task<IWebSocket> OnGetTickersWebSocketAsync(Action<IReadOnlyCollection<KeyValuePair<string, ExchangeTicker>>> callback, params string[] marketSymbols)
+		{
+			return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
+			{
+				JToken token = JToken.Parse(msg.ToStringFromUTF8());
+				if (token["type"].ToStringInvariant() == "ticker")
+				{
+					ExchangeTicker ticker = await this.ParseTickerAsync(token, token["product_id"].ToStringInvariant(), "best_ask", "best_bid", "price", "volume_24h", null, "time", TimestampType.Iso8601);
+					callback(new List<KeyValuePair<string, ExchangeTicker>>() { new KeyValuePair<string, ExchangeTicker>(token["product_id"].ToStringInvariant(), ticker) });
+				}
+			}, async (_socket) =>
+			{
+				marketSymbols = marketSymbols == null || marketSymbols.Length == 0 ? (await GetMarketSymbolsAsync()).ToArray() : marketSymbols;
+				var subscribeRequest = new
+				{
+					type = "subscribe",
+					product_ids = marketSymbols,
+					channels = new object[]
+					{
+						new
+						{
+							name = "ticker",
+							product_ids = marketSymbols.ToArray()
+						}
+					}
+				};
+				await _socket.SendMessageAsync(subscribeRequest);
+			});
+		}
 
-        protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
-        {
+		protected override async Task<IWebSocket> OnGetTradesWebSocketAsync(Func<KeyValuePair<string, ExchangeTrade>, Task> callback, params string[] marketSymbols)
+		{
 			if (marketSymbols == null || marketSymbols.Length == 0)
 			{
 				marketSymbols = (await GetMarketSymbolsAsync()).ToArray();
 			}
-            return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
-            {
-                JToken token = JToken.Parse(msg.ToStringFromUTF8());
+			return await ConnectPublicWebSocketAsync("/", async (_socket, msg) =>
+			{
+				JToken token = JToken.Parse(msg.ToStringFromUTF8());
 				if (token["type"].ToStringInvariant() == "error")
 				{ // {{ "type": "error", "message": "Failed to subscribe", "reason": "match is not a valid channel" }}
 					Logger.Info(token["message"].ToStringInvariant() + ": " + token["reason"].ToStringInvariant());
@@ -409,36 +409,36 @@ namespace ExchangeSharp
 				}
 				if (token["type"].ToStringInvariant() != "match") return; //the ticker channel provides the trade information as well
 				if (token["time"] == null) return;
-                ExchangeTrade trade = ParseTradeWebSocket(token);
-                string marketSymbol = token["product_id"].ToStringInvariant();
-                await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
-            }, async (_socket) =>
-            {
+				ExchangeTrade trade = ParseTradeWebSocket(token);
+				string marketSymbol = token["product_id"].ToStringInvariant();
+				await callback(new KeyValuePair<string, ExchangeTrade>(marketSymbol, trade));
+			}, async (_socket) =>
+			{
 				var subscribeRequest = new
-                {
-                    type = "subscribe",
-                    product_ids = marketSymbols,
-                    channels = new object[]
-                    {
-                        new
-                        {
-                            name = "matches",
-                            product_ids = marketSymbols
-                        }
-                    }
-                };
-                await _socket.SendMessageAsync(subscribeRequest);
-            });
-        }
+				{
+					type = "subscribe",
+					product_ids = marketSymbols,
+					channels = new object[]
+					{
+						new
+						{
+							name = "matches",
+							product_ids = marketSymbols
+						}
+					}
+				};
+				await _socket.SendMessageAsync(subscribeRequest);
+			});
+		}
 
-        private ExchangeTrade ParseTradeWebSocket(JToken token)
-        {
-            return token.ParseTradeCoinbase("size", "price", "side", "time", TimestampType.Iso8601, "trade_id");
-        }
+		private ExchangeTrade ParseTradeWebSocket(JToken token)
+		{
+			return token.ParseTradeCoinbase("size", "price", "side", "time", TimestampType.Iso8601, "trade_id");
+		}
 
-        protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            /*
+		protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			/*
             [{
                 "time": "2014-11-07T22:19:28.578544Z",
                 "trade_id": 74,
@@ -454,218 +454,218 @@ namespace ExchangeSharp
             }]
             */
 
-            ExchangeHistoricalTradeHelper state = new ExchangeHistoricalTradeHelper(this)
-            {
-                Callback = callback,
-                EndDate = endDate,
-                ParseFunction = (JToken token) => token.ParseTrade("size", "price", "side", "time", TimestampType.Iso8601, "trade_id"),
-                StartDate = startDate,
-                MarketSymbol = marketSymbol,
-                Url = "/products/[marketSymbol]/trades",
-                UrlFunction = (ExchangeHistoricalTradeHelper _state) =>
-                {
-                    return _state.Url + (string.IsNullOrWhiteSpace(cursorBefore) ? string.Empty : "?before=" + cursorBefore.ToStringInvariant());
-                }
-            };
-            await state.ProcessHistoricalTrades();
-        }
+			ExchangeHistoricalTradeHelper state = new ExchangeHistoricalTradeHelper(this)
+			{
+				Callback = callback,
+				EndDate = endDate,
+				ParseFunction = (JToken token) => token.ParseTrade("size", "price", "side", "time", TimestampType.Iso8601, "trade_id"),
+				StartDate = startDate,
+				MarketSymbol = marketSymbol,
+				Url = "/products/[marketSymbol]/trades",
+				UrlFunction = (ExchangeHistoricalTradeHelper _state) =>
+				{
+					return _state.Url + (string.IsNullOrWhiteSpace(cursorBefore) ? string.Empty : "?before=" + cursorBefore.ToStringInvariant());
+				}
+			};
+			await state.ProcessHistoricalTrades();
+		}
 
-        protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol, int? limit = null)
-        {
+		protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol, int? limit = null)
+		{
 			//https://docs.pro.coinbase.com/#pagination Coinbase limit is 100, however pagination can return more (4 later)
 			int requestLimit = (limit == null || limit < 1 || limit > 100) ? 100 : (int)limit;
 
 			string baseUrl = "/products/" + marketSymbol.ToUpperInvariant() + "/trades" + "?limit=" + requestLimit;
-            JToken trades = await MakeJsonRequestAsync<JToken>(baseUrl);
-            List<ExchangeTrade> tradeList = new List<ExchangeTrade>();
-            foreach (JToken trade in trades)
-            {
-                tradeList.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.Iso8601, "trade_id"));
-            }
-            return tradeList;
-        }
+			JToken trades = await MakeJsonRequestAsync<JToken>(baseUrl);
+			List<ExchangeTrade> tradeList = new List<ExchangeTrade>();
+			foreach (JToken trade in trades)
+			{
+				tradeList.Add(trade.ParseTrade("size", "price", "side", "time", TimestampType.Iso8601, "trade_id"));
+			}
+			return tradeList;
+		}
 
-        protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 50)
-        {
-            string url = "/products/" + marketSymbol.ToUpperInvariant() + "/book?level=2";
-            JToken token = await MakeJsonRequestAsync<JToken>(url);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, maxCount: maxCount);
-        }
+		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 50)
+		{
+			string url = "/products/" + marketSymbol.ToUpperInvariant() + "/book?level=2";
+			JToken token = await MakeJsonRequestAsync<JToken>(url);
+			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, maxCount: maxCount);
+		}
 
-        protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
-        {
-            if (limit != null)
-            {
-                throw new APIException("Limit parameter not supported");
-            }
+		protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
+		{
+			if (limit != null)
+			{
+				throw new APIException("Limit parameter not supported");
+			}
 
-            // /products/<product-id>/candles
-            // https://api.pro.coinbase.com/products/LTC-BTC/candles?granularity=86400&start=2017-12-04T18:15:33&end=2017-12-11T18:15:33
-            List<MarketCandle> candles = new List<MarketCandle>();
-            string url = "/products/" + marketSymbol + "/candles?granularity=" + periodSeconds;
-            if (startDate == null)
-            {
-                startDate = CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(1.0));
-            }
-            url += "&start=" + startDate.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture);
-            if (endDate == null)
-            {
-                endDate = CryptoUtility.UtcNow;
-            }
-            url += "&end=" + endDate.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture);
+			// /products/<product-id>/candles
+			// https://api.pro.coinbase.com/products/LTC-BTC/candles?granularity=86400&start=2017-12-04T18:15:33&end=2017-12-11T18:15:33
+			List<MarketCandle> candles = new List<MarketCandle>();
+			string url = "/products/" + marketSymbol + "/candles?granularity=" + periodSeconds;
+			if (startDate == null)
+			{
+				startDate = CryptoUtility.UtcNow.Subtract(TimeSpan.FromDays(1.0));
+			}
+			url += "&start=" + startDate.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture);
+			if (endDate == null)
+			{
+				endDate = CryptoUtility.UtcNow;
+			}
+			url += "&end=" + endDate.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture);
 
-            // time, low, high, open, close, volume
-            JToken token = await MakeJsonRequestAsync<JToken>(url);
-            foreach (JToken candle in token)
-            {
-                candles.Add(this.ParseCandle(candle, marketSymbol, periodSeconds, 3, 2, 1, 4, 0, TimestampType.UnixSeconds, 5));
-            }
-            // re-sort in ascending order
-            candles.Sort((c1, c2) => c1.Timestamp.CompareTo(c2.Timestamp));
-            return candles;
-        }
+			// time, low, high, open, close, volume
+			JToken token = await MakeJsonRequestAsync<JToken>(url);
+			foreach (JToken candle in token)
+			{
+				candles.Add(this.ParseCandle(candle, marketSymbol, periodSeconds, 3, 2, 1, 4, 0, TimestampType.UnixSeconds, 5));
+			}
+			// re-sort in ascending order
+			candles.Sort((c1, c2) => c1.Timestamp.CompareTo(c2.Timestamp));
+			return candles;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
-        {
-            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
-            JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, await GetNoncePayloadAsync(), "GET");
-            foreach (JToken token in array)
-            {
-                decimal amount = token["balance"].ConvertInvariant<decimal>();
-                if (amount > 0m)
-                {
-                    amounts[token["currency"].ToStringInvariant()] = amount;
-                }
-            }
-            return amounts;
-        }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAsync()
+		{
+			Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+			JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, await GetNoncePayloadAsync(), "GET");
+			foreach (JToken token in array)
+			{
+				decimal amount = token["balance"].ConvertInvariant<decimal>();
+				if (amount > 0m)
+				{
+					amounts[token["currency"].ToStringInvariant()] = amount;
+				}
+			}
+			return amounts;
+		}
 
-        protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
-        {
-            Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
-            JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, await GetNoncePayloadAsync(), "GET");
-            foreach (JToken token in array)
-            {
-                decimal amount = token["available"].ConvertInvariant<decimal>();
-                if (amount > 0m)
-                {
-                    amounts[token["currency"].ToStringInvariant()] = amount;
-                }
-            }
-            return amounts;
-        }
+		protected override async Task<Dictionary<string, decimal>> OnGetAmountsAvailableToTradeAsync()
+		{
+			Dictionary<string, decimal> amounts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+			JArray array = await MakeJsonRequestAsync<JArray>("/accounts", null, await GetNoncePayloadAsync(), "GET");
+			foreach (JToken token in array)
+			{
+				decimal amount = token["available"].ConvertInvariant<decimal>();
+				if (amount > 0m)
+				{
+					amounts[token["currency"].ToStringInvariant()] = amount;
+				}
+			}
+			return amounts;
+		}
 
-        protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
-        {
-            object nonce = await GenerateNonceAsync();
-            Dictionary<string, object> payload = new Dictionary<string, object>
-            {
-                { "nonce", nonce },
-                { "type", order.OrderType.ToStringLowerInvariant() },
-                { "side", (order.IsBuy ? "buy" : "sell") },
-                { "product_id", order.MarketSymbol },
-                { "size", order.RoundAmount().ToStringInvariant() }
-            };
-            payload["time_in_force"] = "GTC"; // good til cancel
-            payload["price"] = order.Price.ToStringInvariant();
-            switch (order.OrderType)
-            {
-                case OrderType.Limit:
-                    // set payload["post_only"] to true for default scenario when order.ExtraParameters["post_only"] is not specified
-                    // to place non-post-only limit order one can set and pass order.ExtraParameters["post_only"]="false"
-                    payload["post_only"] = order.ExtraParameters.TryGetValueOrDefault("post_only", "true");
-                    break;
+		protected override async Task<ExchangeOrderResult> OnPlaceOrderAsync(ExchangeOrderRequest order)
+		{
+			object nonce = await GenerateNonceAsync();
+			Dictionary<string, object> payload = new Dictionary<string, object>
+			{
+				{ "nonce", nonce },
+				{ "type", order.OrderType.ToStringLowerInvariant() },
+				{ "side", (order.IsBuy ? "buy" : "sell") },
+				{ "product_id", order.MarketSymbol },
+				{ "size", order.RoundAmount().ToStringInvariant() }
+			};
+			payload["time_in_force"] = "GTC"; // good til cancel
+			switch (order.OrderType)
+			{
+				case OrderType.Limit:
+					// set payload["post_only"] to true for default scenario when order.ExtraParameters["post_only"] is not specified
+					// to place non-post-only limit order one can set and pass order.ExtraParameters["post_only"]="false"
+					payload["post_only"] = order.ExtraParameters.TryGetValueOrDefault("post_only", "true");
+					payload["price"] = order.Price.ToStringInvariant();
+					break;
 
-                case OrderType.Stop:
-                    payload["stop"] = (order.IsBuy ? "entry" : "loss");
-                    payload["stop_price"] = order.StopPrice.ToStringInvariant();
-                    payload["type"] = order.Price > 0m ? "limit" : "market";
-                    break;
+				case OrderType.Stop:
+					payload["stop"] = (order.IsBuy ? "entry" : "loss");
+					payload["stop_price"] = order.StopPrice.ToStringInvariant();
+					payload["type"] = order.Price > 0m ? "limit" : "market";
+					break;
 
-                case OrderType.Market:
-                default:
-                    break;
-            }
+				case OrderType.Market:
+				default:
+					break;
+			}
 
-            order.ExtraParameters.CopyTo(payload);
-            JToken result = await MakeJsonRequestAsync<JToken>("/orders", null, payload, "POST");
-            return ParseOrder(result);
-        }
+			order.ExtraParameters.CopyTo(payload);
+			JToken result = await MakeJsonRequestAsync<JToken>("/orders", null, payload, "POST");
+			return ParseOrder(result);
+		}
 
-        protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
-        {
-            JToken obj = await MakeJsonRequestAsync<JToken>("/orders/" + orderId, null, await GetNoncePayloadAsync(), "GET");
-            return ParseOrder(obj);
-        }
+		protected override async Task<ExchangeOrderResult> OnGetOrderDetailsAsync(string orderId, string marketSymbol = null)
+		{
+			JToken obj = await MakeJsonRequestAsync<JToken>("/orders/" + orderId, null, await GetNoncePayloadAsync(), "GET");
+			return ParseOrder(obj);
+		}
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
-        {
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JArray array = await MakeJsonRequestAsync<JArray>("orders?status=all" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "&product_id=" + marketSymbol), null, await GetNoncePayloadAsync(), "GET");
-            foreach (JToken token in array)
-            {
-                orders.Add(ParseOrder(token));
-            }
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetOpenOrderDetailsAsync(string marketSymbol = null)
+		{
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			JArray array = await MakeJsonRequestAsync<JArray>("orders?status=all" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "&product_id=" + marketSymbol), null, await GetNoncePayloadAsync(), "GET");
+			foreach (JToken token in array)
+			{
+				orders.Add(ParseOrder(token));
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
-        {
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            JArray array = await MakeJsonRequestAsync<JArray>("orders?status=done" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "&product_id=" + marketSymbol), null, await GetNoncePayloadAsync(), "GET");
-            foreach (JToken token in array)
-            {
-                ExchangeOrderResult result = ParseOrder(token);
-                if (afterDate == null || result.OrderDate >= afterDate)
-                {
-                    orders.Add(result);
-                }
-            }
+		protected override async Task<IEnumerable<ExchangeOrderResult>> OnGetCompletedOrderDetailsAsync(string marketSymbol = null, DateTime? afterDate = null)
+		{
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			JArray array = await MakeJsonRequestAsync<JArray>("orders?status=done" + (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "&product_id=" + marketSymbol), null, await GetNoncePayloadAsync(), "GET");
+			foreach (JToken token in array)
+			{
+				ExchangeOrderResult result = ParseOrder(token);
+				if (afterDate == null || result.OrderDate >= afterDate)
+				{
+					orders.Add(result);
+				}
+			}
 
-            return orders;
-        }
+			return orders;
+		}
 
-        public async Task<IEnumerable<ExchangeOrderResult>> GetFillsAsync(string marketSymbol = null, DateTime? afterDate = null)
-        {
-            List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
-            marketSymbol = NormalizeMarketSymbol(marketSymbol);
-            var productId = (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "product_id=" + marketSymbol);
-            do
-            {
-                var after = cursorAfter == null ? string.Empty : $"after={cursorAfter}&";
-                await new SynchronizationContextRemover();
-                await MakeFillRequest(afterDate, productId, orders, after);
-            } while (cursorAfter != null);
-            return orders;
-        }
+		public async Task<IEnumerable<ExchangeOrderResult>> GetFillsAsync(string marketSymbol = null, DateTime? afterDate = null)
+		{
+			List<ExchangeOrderResult> orders = new List<ExchangeOrderResult>();
+			marketSymbol = NormalizeMarketSymbol(marketSymbol);
+			var productId = (string.IsNullOrWhiteSpace(marketSymbol) ? string.Empty : "product_id=" + marketSymbol);
+			do
+			{
+				var after = cursorAfter == null ? string.Empty : $"after={cursorAfter}&";
+				await new SynchronizationContextRemover();
+				await MakeFillRequest(afterDate, productId, orders, after);
+			} while (cursorAfter != null);
+			return orders;
+		}
 
-        private async Task MakeFillRequest(DateTime? afterDate, string productId, List<ExchangeOrderResult> orders, string after)
-        {
-            var interrogation = after != "" || productId != "" ? "?" : string.Empty;
-            JArray array = await MakeJsonRequestAsync<JArray>($"fills{interrogation}{after}{productId}", null, await GetNoncePayloadAsync());
+		private async Task MakeFillRequest(DateTime? afterDate, string productId, List<ExchangeOrderResult> orders, string after)
+		{
+			var interrogation = after != "" || productId != "" ? "?" : string.Empty;
+			JArray array = await MakeJsonRequestAsync<JArray>($"fills{interrogation}{after}{productId}", null, await GetNoncePayloadAsync());
 
-            foreach (JToken token in array)
-            {
-                ExchangeOrderResult result = ParseFill(token);
-                if (afterDate == null || result.OrderDate >= afterDate)
-                {
-                    orders.Add(result);
-                }
+			foreach (JToken token in array)
+			{
+				ExchangeOrderResult result = ParseFill(token);
+				if (afterDate == null || result.OrderDate >= afterDate)
+				{
+					orders.Add(result);
+				}
 
-                if (afterDate != null && result.OrderDate < afterDate)
-                {
-                    cursorAfter = null;
-                    break;
-                }
-            }
-        }
+				if (afterDate != null && result.OrderDate < afterDate)
+				{
+					cursorAfter = null;
+					break;
+				}
+			}
+		}
 
-        protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
-        {
-            await MakeJsonRequestAsync<JArray>("orders/" + orderId, null, await GetNoncePayloadAsync(), "DELETE");
-        }
-    }
+		protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)
+		{
+			await MakeJsonRequestAsync<JArray>("orders/" + orderId, null, await GetNoncePayloadAsync(), "DELETE");
+		}
+	}
 
-    public partial class ExchangeName { public const string Coinbase = "Coinbase"; }
+	public partial class ExchangeName { public const string Coinbase = "Coinbase"; }
 }

--- a/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -682,7 +682,7 @@ namespace ExchangeSharp
             payload.Add("source", order.IsMargin ? "margin-api" : "api");
 
             decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price.Value);
 
             payload["amount"] = outputQuantity.ToStringInvariant();
 

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -761,7 +761,7 @@ namespace ExchangeSharp
 			if (order.OrderType != OrderType.Market)
 			{
 				int precision = BitConverter.GetBytes(Decimal.GetBits((decimal)market.PriceStepSize)[3])[2];
-				payload.Add("price", Math.Round(order.Price, precision).ToStringInvariant());
+				payload.Add("price", Math.Round(order.Price.Value, precision).ToStringInvariant());
 			}
 			order.ExtraParameters.CopyTo(payload);
 
@@ -972,7 +972,7 @@ namespace ExchangeSharp
 							}
 						}
 					}
-					
+
 					await Task.CompletedTask;
 				},
 				connectCallback: async (_socket) =>

--- a/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
@@ -413,7 +413,7 @@ namespace ExchangeSharp.OKGroup
 
             // Okex has strict rules on which prices and quantities are allowed. They have to match the rules defined in the market definition.
             decimal outputQuantity = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+            decimal outputPrice = await ClampOrderPrice(order.MarketSymbol, order.Price.Value);
 
             if (order.OrderType == OrderType.Market)
             {

--- a/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -134,7 +134,7 @@ namespace ExchangeSharp
             order.AmountFilled = amount - order.Amount;
 
             // fee is a percentage taken from the traded amount rounded to 8 decimals
-            order.Fees = CalculateFees(amount, order.Price, order.IsBuy, result["fee"].ConvertInvariant<decimal>());
+            order.Fees = CalculateFees(amount, order.Price.Value, order.IsBuy, result["fee"].ConvertInvariant<decimal>());
 
             return order;
         }
@@ -769,7 +769,7 @@ namespace ExchangeSharp
             }
 
             decimal orderAmount = await ClampOrderQuantity(order.MarketSymbol, order.Amount);
-            decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price);
+            decimal orderPrice = await ClampOrderPrice(order.MarketSymbol, order.Price.Value);
 
             List<object> orderParams = new List<object>
             {

--- a/src/ExchangeSharp/Model/ExchangeOrderRequest.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderRequest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT LICENSE
 
 Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
@@ -34,13 +34,13 @@ namespace ExchangeSharp
         /// <summary>
         /// The price to buy or sell at
         /// </summary>
-        public decimal Price { get; set; }
+        public decimal? Price { get; set; }
 
         /// <summary>
         /// The price to trigger a stop
         /// </summary>
         public decimal StopPrice { get; set; }
-    
+
         /// <summary>
         /// True if this is a buy, false if a sell
         /// </summary>

--- a/src/ExchangeSharp/Model/ExchangeOrderResult.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderResult.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT LICENSE
 
 Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
@@ -34,12 +34,12 @@ namespace ExchangeSharp
         /// Result/Error code from exchange
         /// Not all exchanges support this
         /// </summary>
-        public string ResultCode { get; set; } 
+        public string ResultCode { get; set; }
 
         /// <summary>Message if any</summary>
         public string Message { get; set; }
 
-        /// <summary>Original order amount in the market currency. 
+        /// <summary>Original order amount in the market currency.
         /// E.g. ADA/BTC would be ADA</summary>
         public decimal Amount { get; set; }
 
@@ -48,18 +48,18 @@ namespace ExchangeSharp
 
         /// <summary>The limit price on the order in the ratio of base/market currency.
         /// E.g. 0.000342 ADA/ETH</summary>
-        public decimal Price { get; set; }
+        public decimal? Price { get; set; }
 
         /// <summary>Price per unit in the ratio of base/market currency.
         /// E.g. 0.000342 ADA/ETH</summary>
-        public decimal AveragePrice { get; set; }
+        public decimal? AveragePrice { get; set; }
 
         /// <summary>Order datetime in UTC</summary>
         public DateTime OrderDate { get; set; }
 
         /// <summary>Fill datetime in UTC</summary>
         public DateTime FillDate { get; set; }
-    
+
         /// <summary>Market Symbol. E.g. ADA/ETH</summary>
         public string MarketSymbol { get; set; }
 
@@ -70,7 +70,7 @@ namespace ExchangeSharp
         /// E.g. 0.0025 ETH</summary>
         public decimal Fees { get; set; }
 
-        /// <summary>The currency the fees are in. 
+        /// <summary>The currency the fees are in.
         /// If not set, this is probably the base currency</summary>
         public string FeesCurrency { get; set; }
 


### PR DESCRIPTION
This change was required to make Marketorders possible on CoinbasePro.
Not sure what the other echanges allow and or require so I've kept it simple by just assuming the price is given.

I suppose it's also possible to add checks and fail in a nicer way, what's your take on it?