### PR TITLE
Added parsing of kraken order fees

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -206,6 +206,7 @@ namespace ExchangeSharp
 			orderResult.AmountFilled = order["vol_exec"].ConvertInvariant<decimal>();
 			orderResult.Price = order["descr"]["price"].ConvertInvariant<decimal>();
 			orderResult.AveragePrice = order["price"].ConvertInvariant<decimal>();
+			orderResult.Fees = order["fee"].ConvertInvariant<decimal>();
 
 			return orderResult;
 		}


### PR DESCRIPTION
I noticed the ParseOrder method in the Kraken exchange wasn't parsing the fees from the response and adding it to the order result. I have made the change to allow this.