### PR TITLE
Fix Kraken WS orderbook updates and add checksum support

### DIFF
--- a/src/ExchangeSharp/Model/ExchangeOrderBook.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderBook.cs
@@ -93,10 +93,17 @@ namespace ExchangeSharp
         public SortedDictionary<decimal, ExchangeOrderPrice> Bids { get; } = new SortedDictionary<decimal, ExchangeOrderPrice>(new DescendingComparer<decimal>());
 
         /// <summary>
-        /// ToString
-        /// </summary>
-        /// <returns>String</returns>
-        public override string ToString()
+		/// If provided by the exchange, a checksum value that may be used to check orderbook integrity.
+		/// Otherwise it will be null. 
+        /// This property is not serialized using the ToBinary and FromBinary methods.
+		/// </summary>
+        public string Checksum { get; set; }
+
+		/// <summary>
+		/// ToString
+		/// </summary>
+		/// <returns>String</returns>
+		public override string ToString()
         {
             return string.Format("Book {0}, Asks: {1} ({2:0.00}), Bids: {3} ({4:0.00})", MarketSymbol,
 				Asks.Count,


### PR DESCRIPTION
The existing Kraken implementation for order-book updates is incorrect. It assumes each update will include either one "a" or one "b" block and that the message contains exactly 5 elements.
In most cases this is the case however the API can and sometimes does send both an "a" and "b" block in the same message. I have verified this myself with a live feed (examples are is also shown in the API docs) and in this case the behavior is faulty. The market symbol is read wrongly and the whole message will therefore get missed leading to order-book mismatch locally.

My change follows the spec more accurately and also adds support for Kraken's checksum property (https://docs.kraken.com/websockets/#book-checksum). I do not know if other exchanges provide this but it is _vital_ to ensure your local order book is correct in case of missed messages. I have implemented the simplest possible API change for `ExchangeOrderBook.Checksum` which could be used by other exchange implementations if desired.