### PR TITLE
Add simple orderbook merging from updates

### DIFF
--- a/src/ExchangeSharp/Model/ExchangeOrderBook.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderBook.cs
@@ -195,5 +195,30 @@ namespace ExchangeSharp
 
             return sellPrice;
         }
+
+        /// <summary>
+		/// Updates this order book with a partial order book update. items with a price-level
+		/// of 0 are removed from the orderbook, all others are inserted/updated with the supplied value
+		/// </summary>
+		/// <param name="partialUpdate">Set of changes to make</param>
+        public void ApplyUpdates(ExchangeOrderBook partialUpdate)
+        {
+            MergeOrderBookDelta(partialUpdate.Asks, this.Asks);
+            MergeOrderBookDelta(partialUpdate.Bids, this.Bids);
+
+            static void MergeOrderBookDelta(
+                SortedDictionary<decimal, ExchangeOrderPrice> newData,
+                SortedDictionary<decimal, ExchangeOrderPrice> bookData)
+            {
+                newData.ToList().ForEach(x =>
+                {
+                    if (x.Value.Amount == 0m)
+                        bookData.Remove(x.Key);
+                    else
+                        bookData[x.Key] = x.Value;
+                });
+            }
+
+        }
     }
 }

--- a/src/ExchangeSharp/Model/ExchangeOrderBook.cs
+++ b/src/ExchangeSharp/Model/ExchangeOrderBook.cs
@@ -93,10 +93,17 @@ namespace ExchangeSharp
         public SortedDictionary<decimal, ExchangeOrderPrice> Bids { get; } = new SortedDictionary<decimal, ExchangeOrderPrice>(new DescendingComparer<decimal>());
 
         /// <summary>
-        /// ToString
-        /// </summary>
-        /// <returns>String</returns>
-        public override string ToString()
+		/// If provided by the exchange, a checksum value that may be used to check orderbook integrity.
+		/// Otherwise it will be null. 
+        /// This property is not serialized using the ToBinary and FromBinary methods.
+		/// </summary>
+        public string Checksum { get; set; }
+
+		/// <summary>
+		/// ToString
+		/// </summary>
+		/// <returns>String</returns>
+		public override string ToString()
         {
             return string.Format("Book {0}, Asks: {1} ({2:0.00}), Bids: {3} ({4:0.00})", MarketSymbol,
 				Asks.Count,


### PR DESCRIPTION
Kraken definitely uses this partial orderbook update format (volume==0 means deletion) and I think Binance does too, so it seems like a useful utility method.

(_again_, my fork has got messed up and insists it is ahead of yours. It is telling me the last PR which you accepted still needs to be committed even though I updated my repo from upstream before making changes. )