### PR TITLE
Add trade count to MarketCandle, and scrape from Kraken Exchange

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -720,7 +720,7 @@ namespace ExchangeSharp
 				JProperty prop = json.Children().First() as JProperty;
 				foreach (JToken jsonCandle in prop.Value)
 				{
-					MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5);
+					MarketCandle candle = this.ParseCandle(jsonCandle, marketSymbol, periodSeconds, 1, 2, 3, 4, 0, TimestampType.UnixSeconds, 6, null, 5, 7);
 					if (candle.Timestamp >= startDate.Value && candle.Timestamp <= endDate.Value)
 					{
 						candles.Add(candle);
@@ -950,7 +950,7 @@ namespace ExchangeSharp
 					string marketSymbol = token[3].ToStringInvariant();
 					//Kraken updates the candle open time to the current time, but we want it as open-time i.e. close-time - interval
 					token[1][0] = token[1][1].ConvertInvariant<long>() - interval * 60;
-					var candle = this.ParseCandle(token[1], marketSymbol, interval * 60, 2, 3, 4, 5, 0, TimestampType.UnixSeconds, 7, null, 6);
+					var candle = this.ParseCandle(token[1], marketSymbol, interval * 60, 2, 3, 4, 5, 0, TimestampType.UnixSeconds, 7, null, 6,8);
 					await callbackAsync(candle);
 				}
 			}, connectCallback: async (_socket) =>

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -721,7 +721,7 @@ namespace ExchangeSharp
 		/// <param name="weightedAverageKey">Weighted average key</param>
 		/// <returns>MarketCandle</returns>
 		internal static MarketCandle ParseCandle(this INamed named, JToken token, string marketSymbol, int periodSeconds, object openKey, object highKey, object lowKey,
-			object closeKey, object timestampKey, TimestampType timestampType, object baseVolumeKey, object? quoteVolumeKey = null, object? weightedAverageKey = null)
+			object closeKey, object timestampKey, TimestampType timestampType, object baseVolumeKey, object? quoteVolumeKey = null, object? weightedAverageKey = null, object? countKey = null)
 		{
 			MarketCandle candle = new MarketCandle
 			{
@@ -741,6 +741,10 @@ namespace ExchangeSharp
 			if (weightedAverageKey != null)
 			{
 				candle.WeightedAverage = token[weightedAverageKey].ConvertInvariant<decimal>();
+			}
+			if( countKey != null)	
+			{
+				candle.Count = token[countKey].ConvertInvariant<int>();
 			}
 			return candle;
 		}

--- a/src/ExchangeSharp/Model/MarketCandle.cs
+++ b/src/ExchangeSharp/Model/MarketCandle.cs
@@ -79,12 +79,17 @@ namespace ExchangeSharp
         public decimal WeightedAverage { get; set; }
 
         /// <summary>
+		/// The number of trades if provided. 
+		/// </summary>
+        public int Count { get; set; }
+
+        /// <summary>
         /// ToString
         /// </summary>
         /// <returns>String</returns>
         public override string ToString()
         {
-            return string.Format("{0}/{1}: {2}, {3}, {4}, {5}, {6}, {7}, {8}", Timestamp, PeriodSeconds, OpenPrice, HighPrice, LowPrice, ClosePrice, BaseCurrencyVolume, QuoteCurrencyVolume, WeightedAverage);
+            return string.Format("{0}/{1}: {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", Timestamp, PeriodSeconds, OpenPrice, HighPrice, LowPrice, ClosePrice, BaseCurrencyVolume, QuoteCurrencyVolume, WeightedAverage, Count);
         }
     }
 }


### PR DESCRIPTION
1. Add trivial new property `Count` to `MarketCandle` (will be zero if not supplied).
2. Add implementation to `KrakenExchangeAPI` for both REST and WS Candle methods (tested)

Other exchanges may provide this data, if people wish to implement it.

https://docs.kraken.com/websockets/#message-ohlc
https://docs.kraken.com/rest/#operation/getOHLCData