### PR TITLE
Keep order removals in Gemini order book deltas.

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
@@ -642,10 +642,8 @@ namespace ExchangeSharp
 							decimal amount = change[2].ConvertInvariant<decimal>();
 
 							SortedDictionary<decimal, ExchangeOrderPrice> dict = (sell ? book.Asks : book.Bids);
-							if (amount == 0m)
-								dict.Remove(price);
-							else
-								dict[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
+
+							dict[price] = new ExchangeOrderPrice { Amount = amount, Price = price };
 						}
 					}
 


### PR DESCRIPTION
WebSocket order book wasn't correct for Gemini, and it looks like it's because the removed orders were not present in the deltas during the merge. This commit preserves the removed orders in the delta book.