### PR TITLE
Added Expired and PendingOpen to ExchangeAPIOrderResult

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Aquanow/ExchangeAquanowAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Aquanow/ExchangeAquanowAPI.cs
@@ -189,7 +189,7 @@ namespace ExchangeSharp
 					break;
 
 				default:
-					orderDetails.Result = ExchangeAPIOrderResult.Error;
+					orderDetails.Result = ExchangeAPIOrderResult.Rejected;
 					break;
 			}
 			return orderDetails;
@@ -226,7 +226,7 @@ namespace ExchangeSharp
 					break;
 
 				default:
-					orderDetails.Result = ExchangeAPIOrderResult.Error;
+					orderDetails.Result = ExchangeAPIOrderResult.Rejected;
 					break;
 			}
 

--- a/src/ExchangeSharp/API/Exchanges/BL3P/Extensions/BL3PExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/BL3P/Extensions/BL3PExtensions.cs
@@ -9,9 +9,9 @@ namespace ExchangeSharp.BL3P
 				BL3POrderStatus.Cancelled => ExchangeAPIOrderResult.Canceled,
 				BL3POrderStatus.Closed => ExchangeAPIOrderResult.Filled,
 				BL3POrderStatus.Open when amount.Value > 0 => ExchangeAPIOrderResult.FilledPartially,
-				BL3POrderStatus.Open => ExchangeAPIOrderResult.Pending,
-				BL3POrderStatus.Pending => ExchangeAPIOrderResult.Pending,
-				BL3POrderStatus.Placed => ExchangeAPIOrderResult.Pending,
+				BL3POrderStatus.Open => ExchangeAPIOrderResult.Open,
+				BL3POrderStatus.Pending => ExchangeAPIOrderResult.PendingOpen,
+				BL3POrderStatus.Placed => ExchangeAPIOrderResult.Open,
 				_ => ExchangeAPIOrderResult.Unknown
 			};
 		}

--- a/src/ExchangeSharp/API/Exchanges/BTSE/ExchangeBTSEAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BTSE/ExchangeBTSEAPI.cs
@@ -138,7 +138,7 @@ namespace ExchangeSharp
 			switch (s)
 			{
 				case "STATUS_ACTIVE":
-					return ExchangeAPIOrderResult.Pending;
+					return ExchangeAPIOrderResult.Open;
 				case "ORDER_CANCELLED":
 					return ExchangeAPIOrderResult.Canceled;
 				case "ORDER_FULLY_TRANSACTED":
@@ -202,24 +202,27 @@ namespace ExchangeSharp
 				var status = ExchangeAPIOrderResult.Unknown;
 				switch (token["status"].Value<int>())
 				{
-					case 2:
-						status = ExchangeAPIOrderResult.Pending;
+					case 2: // ORDER_INSERTED
+						status = ExchangeAPIOrderResult.Open;
 						break;
-					case 4:
+					case 4: // ORDER_FULLY_TRANSACTED
 						status = ExchangeAPIOrderResult.Filled;
 						break;
-					case 5:
+					case 5: // ORDER_PARTIALLY_TRANSACTED
 						status = ExchangeAPIOrderResult.FilledPartially;
 						break;
-					case 6:
+					case 6: // ORDER_CANCELLED
 						status = ExchangeAPIOrderResult.Canceled;
+						break;
+					case 8: // INSUFFICIENT_BALANCE
+						status = ExchangeAPIOrderResult.Rejected;
 						break;
 					case 9: //trigger inserted
 					case 10: //trigger activated
-						status = ExchangeAPIOrderResult.Pending;
+						status = ExchangeAPIOrderResult.Open;
 						break;
 					case 15: //rejected
-						status = ExchangeAPIOrderResult.Error;
+						status = ExchangeAPIOrderResult.Rejected;
 						break;
 					case 16: //not found
 						status = ExchangeAPIOrderResult.Unknown;

--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
@@ -886,7 +886,7 @@ namespace ExchangeSharp.BinanceGroup
 			switch (status)
 			{
 				case "NEW":
-					return ExchangeAPIOrderResult.Pending;
+					return ExchangeAPIOrderResult.Open;
 				case "PARTIALLY_FILLED":
 					return ExchangeAPIOrderResult.FilledPartially;
 				case "FILLED":
@@ -896,11 +896,11 @@ namespace ExchangeSharp.BinanceGroup
 				case "PENDING_CANCEL":
 					return ExchangeAPIOrderResult.PendingCancel;
 				case "EXPIRED":
-					return ExchangeAPIOrderResult.Error;
+					return ExchangeAPIOrderResult.Expired;
 				case "REJECTED":
-					return ExchangeAPIOrderResult.Canceled;
+					return ExchangeAPIOrderResult.Rejected;
 				default:
-					return ExchangeAPIOrderResult.Error;
+					throw new NotImplementedException($"Unexpected status type: {status}");
 			}
 		}
 

--- a/src/ExchangeSharp/API/Exchanges/BitBank/ExchangeBitBankAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BitBank/ExchangeBitBankAPI.cs
@@ -350,9 +350,13 @@ namespace ExchangeSharp
 			res.AmountFilled = token["executed_amount"].ConvertInvariant<decimal>();
 			res.OrderDate = token["ordered_at"].ConvertInvariant<double>().UnixTimeStampToDateTimeMilliseconds();
 			switch (token["status"].ToStringInvariant())
-			{
+			{ // status enum: INACTIVE, UNFILLED, PARTIALLY_FILLED, FULLY_FILLED, CANCELED_UNFILLED, CANCELED_PARTIALLY_FILLED
+				case "INACTIVE":
+					res.Result = ExchangeAPIOrderResult.PendingOpen;
+					break;
+
 				case "UNFILLED":
-					res.Result = ExchangeAPIOrderResult.Pending;
+					res.Result = ExchangeAPIOrderResult.Open;
 					break;
 
 				case "PARTIALLY_FILLED":
@@ -372,8 +376,7 @@ namespace ExchangeSharp
 					break;
 
 				default:
-					res.Result = ExchangeAPIOrderResult.Unknown;
-					break;
+					throw new NotImplementedException($"Unexpected status type: {token["status"].ToStringInvariant()}");
 			}
 			return res;
 		}

--- a/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BitMEX/ExchangeBitMEXAPI.cs
@@ -770,8 +770,11 @@ namespace ExchangeSharp
 			// http://www.onixs.biz/fix-dictionary/5.0.SP2/tagNum_39.html
 			switch (token["ordStatus"].ToStringInvariant())
 			{
+				case "Pending New":
+					result.Result = ExchangeAPIOrderResult.PendingOpen;
+					break;
 				case "New":
-					result.Result = ExchangeAPIOrderResult.Pending;
+					result.Result = ExchangeAPIOrderResult.Open;
 					break;
 				case "PartiallyFilled":
 					result.Result = ExchangeAPIOrderResult.FilledPartially;
@@ -782,9 +785,15 @@ namespace ExchangeSharp
 				case "Canceled":
 					result.Result = ExchangeAPIOrderResult.Canceled;
 					break;
+				case "Rejected":
+					result.Result = ExchangeAPIOrderResult.Rejected;
+					break;
+				case "Expired":
+					result.Result = ExchangeAPIOrderResult.Expired;
+					break;
 
 				default:
-					result.Result = ExchangeAPIOrderResult.Error;
+					result.Result = ExchangeAPIOrderResult.Rejected;
 					break;
 			}
 

--- a/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitfinex/ExchangeBitfinexAPI.cs
@@ -914,7 +914,7 @@ namespace ExchangeSharp
 				AveragePrice = order["avg_execution_price"].ConvertInvariant<decimal>(order["price"].ConvertInvariant<decimal>()),
 				Message = string.Empty,
 				OrderId = order["id"].ToStringInvariant(),
-				Result = (amountFilled == amount ? ExchangeAPIOrderResult.Filled : (amountFilled == 0 ? ExchangeAPIOrderResult.Pending : ExchangeAPIOrderResult.FilledPartially)),
+				Result = (amountFilled == amount ? ExchangeAPIOrderResult.Filled : (amountFilled == 0 ? ExchangeAPIOrderResult.Open : ExchangeAPIOrderResult.FilledPartially)),
 				OrderDate = CryptoUtility.UnixTimeStampToDateTimeSeconds(order["timestamp"].ConvertInvariant<double>()),
 				MarketSymbol = order["symbol"].ToStringInvariant(),
 				IsBuy = order["side"].ToStringInvariant() == "buy"
@@ -954,10 +954,10 @@ namespace ExchangeSharp
 				IsBuy = (amount > 0m),
 				OrderDate = order[8].ToDateTimeInvariant(),
 				OrderId = order[0].ToStringInvariant(),
-				Result = orderStatusString == "ACTIVE" ? ExchangeAPIOrderResult.Pending
+				Result = orderStatusString == "ACTIVE" ? ExchangeAPIOrderResult.Open
 					   : orderStatusString == "EXECUTED" ? ExchangeAPIOrderResult.Filled
 					   : orderStatusString == "PARTIALLY" ? ExchangeAPIOrderResult.FilledPartially
-					   : orderStatusString == "INSUFFICIENT" ? ExchangeAPIOrderResult.Canceled
+					   : orderStatusString == "INSUFFICIENT" ? ExchangeAPIOrderResult.Rejected
 					   : orderStatusString == "CANCELED" ? ExchangeAPIOrderResult.Canceled
 					   : ExchangeAPIOrderResult.Unknown,
 				MarketSymbol = order[1].ToStringInvariant(),

--- a/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -349,7 +349,7 @@ namespace ExchangeSharp
 				case "finished": return ExchangeAPIOrderResult.Filled;
 				case "open": return anyTransactions
 						? ExchangeAPIOrderResult.FilledPartially
-						: ExchangeAPIOrderResult.Pending;
+						: ExchangeAPIOrderResult.Open;
 				case "canceled": return ExchangeAPIOrderResult.Canceled;
 				default: return ExchangeAPIOrderResult.Unknown;
 			}

--- a/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -94,7 +94,7 @@ namespace ExchangeSharp
 			}
 			else if (amountFilled == 0m)
 			{
-				order.Result = ExchangeAPIOrderResult.Pending;
+				order.Result = ExchangeAPIOrderResult.Open;
 			}
 			else
 			{
@@ -406,7 +406,7 @@ namespace ExchangeSharp
 				IsBuy = order.IsBuy,
 				OrderDate = result["createdAt"].ToDateTimeInvariant(),
 				OrderId = result["id"].ToStringInvariant(),
-				Result = ExchangeAPIOrderResult.Pending,
+				Result = ExchangeAPIOrderResult.Open,
 				MarketSymbol = result["marketSymbol"].ToStringInvariant(),
 				Price = decimal.Parse(result["limit"].ToStringInvariant())
 			};

--- a/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bybit/ExchangeBybitAPI.cs
@@ -1026,10 +1026,15 @@ namespace ExchangeSharp
 				result.MarketSymbol = token["symbol"].ToStringInvariant();
 
 				switch (token["order_status"].ToStringInvariant())
-				{
+				{ // https://bybit-exchange.github.io/docs/inverse/#order-status-order_status
 					case "Created":
+						result.Result = ExchangeAPIOrderResult.PendingOpen;
+						break;
+					case "Rejected":
+						result.Result = ExchangeAPIOrderResult.Rejected;
+						break;
 					case "New":
-						result.Result = ExchangeAPIOrderResult.Pending;
+						result.Result = ExchangeAPIOrderResult.Open;
 						break;
 					case "PartiallyFilled":
 						result.Result = ExchangeAPIOrderResult.FilledPartially;
@@ -1040,10 +1045,12 @@ namespace ExchangeSharp
 					case "Cancelled":
 						result.Result = ExchangeAPIOrderResult.Canceled;
 						break;
+					case "PendingCancel":
+						result.Result = ExchangeAPIOrderResult.PendingCancel;
+						break;
 
 					default:
-						result.Result = ExchangeAPIOrderResult.Error;
-						break;
+						throw new NotImplementedException($"Unexpected status type: {token["order_status"].ToStringInvariant()}");
 				}
 			}
 			result.ResultCode = resultCode;

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -101,7 +101,7 @@ namespace ExchangeSharp
 			switch (result["status"].ToStringInvariant())
 			{
 				case "pending":
-					order.Result = ExchangeAPIOrderResult.Pending;
+					order.Result = ExchangeAPIOrderResult.PendingOpen;
 					break;
 				case "active":
 				case "open":
@@ -115,7 +115,7 @@ namespace ExchangeSharp
 					}
 					else
 					{
-						order.Result = ExchangeAPIOrderResult.Pending;
+						order.Result = ExchangeAPIOrderResult.Open;
 					}
 					break;
 				case "done":
@@ -134,13 +134,15 @@ namespace ExchangeSharp
 							break;
 					}
 					break;
+				case "rejected":
+					order.Result = ExchangeAPIOrderResult.Rejected;
+					break;
 				case "cancelled":
 				case "canceled":
 					order.Result = ExchangeAPIOrderResult.Canceled;
 					break;
 				default:
-					order.Result = ExchangeAPIOrderResult.Unknown;
-					break;
+					throw new NotImplementedException($"Unexpected status type: {result["status"].ToStringInvariant()}");
 			}
 			return order;
 		}

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/Models/Response/Messages.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/Models/Response/Messages.cs
@@ -41,7 +41,7 @@ namespace ExchangeSharp.Coinbase
 		{
 			OrderId = OrderId.ToString(),
 			ClientOrderId = null, // not provided here
-			Result = ExchangeAPIOrderResult.Pending, // order has just been activated (so it starts in PendingOpen)
+			Result = ExchangeAPIOrderResult.PendingOpen, // order has just been activated (so it starts in PendingOpen)
 			Message = null, // can use for something in the future if needed
 			Amount = Size,
 			AmountFilled = 0, // just activated, so none filled
@@ -205,7 +205,7 @@ namespace ExchangeSharp.Coinbase
 		{
 			OrderId = OrderId.ToString(),
 			ClientOrderId = null, // not provided here
-			Result = ExchangeAPIOrderResult.Pending, // order is now Open
+			Result = ExchangeAPIOrderResult.Open, // order is now Open
 			Message = null, // can use for something in the future if needed
 			Amount = 0, // ideally, this would be null, but ExchangeOrderResult.Amount is not nullable
 			AmountFilled = RemainingSize,
@@ -237,7 +237,7 @@ namespace ExchangeSharp.Coinbase
 		{
 			OrderId = OrderId.ToString(),
 			ClientOrderId = ClientOid.ToString(),
-			Result = ExchangeAPIOrderResult.Pending, // order is now Pending
+			Result = ExchangeAPIOrderResult.PendingOpen, // order is now Pending
 			Message = null, // can use for something in the future if needed
 			Amount = Size,
 			AmountFilled = 0, // order received but not yet open, so none filled

--- a/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
@@ -284,9 +284,9 @@ namespace ExchangeSharp
 		{
 			var x = (int)token;
 			switch (x)
-			{
+			{ // Order status, 0 for none executed, 1 for partially executed, 2 for fully executed, 3 for cancelled with none executed, 4 for cancelled with partially executed
 				case 0:
-					return ExchangeAPIOrderResult.Pending;
+					return ExchangeAPIOrderResult.Open;
 
 				case 1:
 					return ExchangeAPIOrderResult.FilledPartially;

--- a/src/ExchangeSharp/API/Exchanges/FTX/FTXExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/FTX/FTXExtensions.cs
@@ -3,19 +3,21 @@ namespace ExchangeSharp.API.Exchanges.FTX
 	/// <summary>
 	/// Extension helper methods.
 	/// </summary>
-	internal static class Extensions
+	internal static class FTXExtensions
 	{
 		/// <summary>
 		/// Cnvert FTX order status string to <see cref="ExchangeAPIOrderResult"/>.
 		/// </summary>
 		/// <param name="status">FTX order status string.</param>
 		/// <returns><see cref="ExchangeAPIOrderResult"/></returns>
-		internal static ExchangeAPIOrderResult ToExchangeAPIOrderResult(this string status)
+		internal static ExchangeAPIOrderResult ToExchangeAPIOrderResult(this string status, decimal remainingAmount)
 		{
-			return status switch
+			return (status, remainingAmount) switch
 			{
-				"open" => ExchangeAPIOrderResult.Pending,
-				"closed" => ExchangeAPIOrderResult.Filled,
+				("new", _) => ExchangeAPIOrderResult.PendingOpen,
+				("open", _) => ExchangeAPIOrderResult.Open,
+				("closed", 0) => ExchangeAPIOrderResult.Filled,
+				("closed", _) => ExchangeAPIOrderResult.Canceled,
 				_ => ExchangeAPIOrderResult.Unknown,
 			};
 		}

--- a/src/ExchangeSharp/API/Exchanges/GateIo/ExchangeGateIoAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/GateIo/ExchangeGateIoAPI.cs
@@ -368,13 +368,13 @@ namespace ExchangeSharp
 			switch (status)
 			{
 				case "open":
-					return ExchangeAPIOrderResult.Pending;
+					return ExchangeAPIOrderResult.Open;
 				case "closed":
 					return ExchangeAPIOrderResult.Filled;
 				case "cancelled":
 					return amountFilled > 0 ? ExchangeAPIOrderResult.FilledPartiallyAndCancelled : ExchangeAPIOrderResult.Canceled;
 				default:
-					return ExchangeAPIOrderResult.Error;
+					throw new NotImplementedException($"Unexpected status type: {status}");
 			}
 		}
 

--- a/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
@@ -66,7 +66,7 @@ namespace ExchangeSharp
 				AveragePrice = result["avg_execution_price"].ConvertInvariant<decimal>(),
 				Message = string.Empty,
 				OrderId = result["id"].ToStringInvariant(),
-				Result = (amountFilled == amount ? ExchangeAPIOrderResult.Filled : (amountFilled == 0 ? ExchangeAPIOrderResult.Pending : ExchangeAPIOrderResult.FilledPartially)),
+				Result = (amountFilled == amount ? ExchangeAPIOrderResult.Filled : (amountFilled == 0 ? ExchangeAPIOrderResult.Open : ExchangeAPIOrderResult.FilledPartially)),
 				OrderDate = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(result["timestampms"].ConvertInvariant<double>()),
 				MarketSymbol = result["symbol"].ToStringInvariant(),
 				IsBuy = result["side"].ToStringInvariant() == "buy"

--- a/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -345,7 +345,7 @@ namespace ExchangeSharp
             }
             else
             {
-                result.Result = ExchangeAPIOrderResult.Pending;
+                result.Result = ExchangeAPIOrderResult.Open;
             }
 
             ParseAveragePriceAndFeesFromFills(result, token["tradesReport"]);
@@ -660,13 +660,13 @@ namespace ExchangeSharp
             // new, suspended, partiallyFilled, filled, canceled, expired
             string status = token["status"].ToStringInvariant();
             switch (status)
-            {
-                case "filled": result.Result = ExchangeAPIOrderResult.Filled; break;
+			{ // Possible values: new, suspended, partiallyFilled, filled, canceled, expired
+				case "filled": result.Result = ExchangeAPIOrderResult.Filled; break;
                 case "partiallyFilled": result.Result = ExchangeAPIOrderResult.FilledPartially; break;
-                case "canceled":
-                case "expired": result.Result = ExchangeAPIOrderResult.Canceled; break;
-                case "new": result.Result = ExchangeAPIOrderResult.Pending; break;
-                default: result.Result = ExchangeAPIOrderResult.Error; break;
+                case "canceled": result.Result = ExchangeAPIOrderResult.Canceled; break;
+				case "expired": result.Result = ExchangeAPIOrderResult.Expired; break;
+                case "new": result.Result = ExchangeAPIOrderResult.Open; break;
+                default: result.Result = ExchangeAPIOrderResult.Rejected; break;
             }
             return result;
         }

--- a/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -853,7 +853,7 @@ namespace ExchangeSharp
                 MarketSymbol = order.MarketSymbol
             };
             result.AveragePrice = result.Price;
-            result.Result = ExchangeAPIOrderResult.Pending;
+            result.Result = ExchangeAPIOrderResult.Open;
 
             return result;
         }
@@ -862,21 +862,26 @@ namespace ExchangeSharp
         {
             switch (state)
             {
-                case "pre-submitted":
-                case "submitting":
-                case "submitted":
-                    return ExchangeAPIOrderResult.Pending;
+				case "created":
+				case "pre-submitted":
+				case "submitting":
+					return ExchangeAPIOrderResult.PendingOpen;
+				case "submitted":
+                    return ExchangeAPIOrderResult.Open;
                 case "partial-filled":
                     return ExchangeAPIOrderResult.FilledPartially;
                 case "filled":
                     return ExchangeAPIOrderResult.Filled;
                 case "partial-canceled":
-                case "canceled":
-                    return ExchangeAPIOrderResult.Canceled;
-                default:
-                    return ExchangeAPIOrderResult.Unknown;
-            }
-        }
+					return ExchangeAPIOrderResult.FilledPartiallyAndCancelled;
+				case "canceling":
+					return ExchangeAPIOrderResult.PendingCancel;
+				case "canceled":
+					return ExchangeAPIOrderResult.Canceled;
+				default:
+					throw new NotImplementedException($"Unexpected status type: {state}");
+			}
+		}
 
         private ExchangeOrderResult ParseOrder(JToken token)
         {

--- a/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
@@ -648,7 +648,7 @@ namespace ExchangeSharp
             order.Amount = token["size"].ConvertInvariant<decimal>() + order.AmountFilled.Value;
 
             if (order.Amount == order.AmountFilled) order.Result = ExchangeAPIOrderResult.Filled;
-            else if (order.AmountFilled == 0m) order.Result = ExchangeAPIOrderResult.Pending;
+            else if (order.AmountFilled == 0m) order.Result = ExchangeAPIOrderResult.Open;
             else order.Result = ExchangeAPIOrderResult.FilledPartially;
 
             return order;

--- a/src/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
@@ -327,7 +327,7 @@ namespace ExchangeSharp
 
 			CheckResponseToken(resp);
 
-			return ParseOrderList(resp, ExchangeAPIOrderResult.Pending);
+			return ParseOrderList(resp, ExchangeAPIOrderResult.Open);
 		}
 
 		//GetCompletedOrderDetails  11
@@ -465,7 +465,7 @@ namespace ExchangeSharp
 				IsBuy = payload["type"].ToString().Equals("buy"),
 				Price = payload["price"].ConvertInvariant<decimal>(),
 				OrderDate = CryptoUtility.UtcNow,
-				Result = ExchangeAPIOrderResult.Pending
+				Result = ExchangeAPIOrderResult.Open
 			};
 
 			return orderResult;
@@ -577,7 +577,7 @@ namespace ExchangeSharp
 					return ExchangeAPIOrderResult.Canceled;
 
 				case 0:
-					return ExchangeAPIOrderResult.Pending;
+					return ExchangeAPIOrderResult.Open;
 
 				case 1:
 					return ExchangeAPIOrderResult.FilledPartially;

--- a/src/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Livecoin/ExchangeLivecoinAPI.cs
@@ -283,7 +283,7 @@ namespace ExchangeSharp
 
             //{ "success": true, "added": true, "orderId": 4912
             JToken token = await MakeJsonRequestAsync<JToken>(orderType, null, payload, "POST");
-            return new ExchangeOrderResult() { OrderId = token["orderId"].ToStringInvariant(), Result = ExchangeAPIOrderResult.Pending };
+            return new ExchangeOrderResult() { OrderId = token["orderId"].ToStringInvariant(), Result = ExchangeAPIOrderResult.Open };
         }
 
         protected override async Task OnCancelOrderAsync(string orderId, string marketSymbol = null)

--- a/src/ExchangeSharp/API/Exchanges/NDAX/Models/Order.cs
+++ b/src/ExchangeSharp/API/Exchanges/NDAX/Models/Order.cs
@@ -101,11 +101,14 @@ namespace ExchangeSharp
 				ExchangeAPIOrderResult orderResult;
 				switch (OrderState.ToLowerInvariant())
 				{
+					case "unknown":
+						orderResult = ExchangeAPIOrderResult.Unknown;
+						break;
 					case "working":
-						orderResult = ExchangeAPIOrderResult.Pending;
+						orderResult = ExchangeAPIOrderResult.Open;
 						break;
 					case "rejected":
-						orderResult = ExchangeAPIOrderResult.Error;
+						orderResult = ExchangeAPIOrderResult.Rejected;
 						break;
 					case "canceled":
 						orderResult = ExchangeAPIOrderResult.Canceled;
@@ -117,8 +120,7 @@ namespace ExchangeSharp
 						orderResult = ExchangeAPIOrderResult.Filled;
 						break;
 					default:
-						orderResult = ExchangeAPIOrderResult.Unknown;
-						break;
+						throw new NotImplementedException($"Unexpected status type: {OrderState.ToLowerInvariant()}");
 				};
 				var symbol = symbolToIdMapping.Where(pair => pair.Value.Equals(Instrument));
 				return new ExchangeOrderResult()

--- a/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
@@ -595,32 +595,40 @@ namespace ExchangeSharp.OKGroup
                 MarketSymbol = order.MarketSymbol
             };
             result.AveragePrice = result.Price;
-            result.Result = ExchangeAPIOrderResult.Pending;
+            result.Result = ExchangeAPIOrderResult.Open;
 
             return result;
         }
 
         private ExchangeAPIOrderResult ParseOrderStatus(int status)
         {
-            // status: -1 = cancelled, 0 = unfilled, 1 = partially filled, 2 = fully filled, 3 = cancel request in process
-            switch (status)
+			// OKCoin: 	Order Status: -2 = Failed -1 = Canceled 0 = Open 1 = Partially Filled 2 = Fully Filled 3 = Submitting 4 = Canceling 6 = Incomplete (open + partially filled) 7 = Complete (canceled + fully filled)
+			// OKEx: 	Order Status: -2 = Failed -1 = Canceled 0 = Open 1 = Partially Filled 2 = Fully Filled 3 = Submitting 4 = Canceling
+			// (not sure where these old statuses came from) status: -1 = cancelled, 0 = unfilled, 1 = partially filled, 2 = fully filled, 3 = cancel request in process
+			switch (status)
             {
-                case -1:
-                    return ExchangeAPIOrderResult.Canceled;
-                case 0:
-                    return ExchangeAPIOrderResult.Pending;
+				case -2:
+					return ExchangeAPIOrderResult.Rejected;
+				case -1:
+					return ExchangeAPIOrderResult.Canceled;
+				case 0:
+                    return ExchangeAPIOrderResult.Open;
                 case 1:
                     return ExchangeAPIOrderResult.FilledPartially;
                 case 2:
                     return ExchangeAPIOrderResult.Filled;
-                case 3:
-                    return ExchangeAPIOrderResult.PendingCancel;
+				case 3:
+					return ExchangeAPIOrderResult.PendingOpen;
 				case 4:
-					return ExchangeAPIOrderResult.Error;
+					return ExchangeAPIOrderResult.PendingCancel;
+				case 6:
+					return ExchangeAPIOrderResult.FilledPartially;
+				case 7:
+					return ExchangeAPIOrderResult.Filled;
 				default:
-                    return ExchangeAPIOrderResult.Unknown;
-            }
-        }
+					throw new NotImplementedException($"Unexpected status type: {status}");
+			}
+		}
 
         private ExchangeOrderResult ParseOrder(JToken token)
         {

--- a/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Poloniex/ExchangePoloniexAPI.cs
@@ -101,7 +101,7 @@ namespace ExchangeSharp
 			}
 			else if (trades != null && trades.Count() == 0)
 			{
-				order.Result = ExchangeAPIOrderResult.Pending;
+				order.Result = ExchangeAPIOrderResult.Open;
 			}
 			else if (trades != null && trades.Children().Count() != 0)
 			{
@@ -126,7 +126,7 @@ namespace ExchangeSharp
                 OrderDate = result["date"].ToDateTimeInvariant(),
                 OrderId = result["orderNumber"].ToStringInvariant(),
                 Price = result["rate"].ConvertInvariant<decimal>(),
-                Result = ExchangeAPIOrderResult.Pending,
+                Result = ExchangeAPIOrderResult.Open,
                 MarketSymbol = (marketSymbol ?? result.Parent.Path)
             };
 

--- a/src/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Yobit/ExchangeYobitAPI.cs
@@ -270,7 +270,7 @@ namespace ExchangeSharp
 
             result.Amount = token["remains"].ConvertInvariant<decimal>() + result.AmountFilled.Value;
             if (result.Amount == result.AmountFilled) result.Result = ExchangeAPIOrderResult.Filled;
-            else if (result.AmountFilled == 0m) result.Result = ExchangeAPIOrderResult.Pending;
+            else if (result.AmountFilled == 0m) result.Result = ExchangeAPIOrderResult.Open;
             else result.Result = ExchangeAPIOrderResult.FilledPartially;
 
             return result;
@@ -358,7 +358,7 @@ namespace ExchangeSharp
             };
 
             if (result.Amount == result.AmountFilled) result.Result = ExchangeAPIOrderResult.Filled;
-            else if (result.AmountFilled == 0m) result.Result = ExchangeAPIOrderResult.Pending;
+            else if (result.AmountFilled == 0m) result.Result = ExchangeAPIOrderResult.Open;
             else result.Result = ExchangeAPIOrderResult.FilledPartially;
 
             return result;

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -332,7 +332,8 @@ namespace ExchangeSharp
 				{
 					case ExchangeAPIOrderResult.Filled:
 					case ExchangeAPIOrderResult.Canceled:
-					case ExchangeAPIOrderResult.Error:
+					case ExchangeAPIOrderResult.Rejected:
+					case ExchangeAPIOrderResult.Expired:
 						i = maxTries + 1;
 						break;
 				}

--- a/src/ExchangeSharp/Model/ExchangeAPIOrderResult.cs
+++ b/src/ExchangeSharp/Model/ExchangeAPIOrderResult.cs
@@ -26,11 +26,17 @@ namespace ExchangeSharp
         /// <summary>Order partially filled</summary>
         FilledPartially,
 
-        /// <summary>Order is pending or open but no amount has been filled yet</summary>
-        Pending,
+        /// <summary>Order is open but no amount has been filled yet</summary>
+        Open,
 
-        /// <summary>Error</summary>
-        Error,
+		/// <summary>Order is pending but not yet open</summary>
+		PendingOpen,
+
+        /// <summary>Order rejected by exchange, likely due to error in order</summary>
+        Rejected,
+
+		/// <summary> Order expired on exchange and no longer active </summary>
+		Expired,
 
         /// <summary>Order was cancelled</summary>
         Canceled,
@@ -45,7 +51,8 @@ namespace ExchangeSharp
 	public static class ExchangeAPIOrderResultExtensions
 	{
 		public static ExchangeAPIOrderResult[] Completed => new[] { ExchangeAPIOrderResult.Filled,
-			ExchangeAPIOrderResult.FilledPartially, ExchangeAPIOrderResult.Error,
+			// don't include FilledPartially, since this means order is still open
+			ExchangeAPIOrderResult.Rejected, ExchangeAPIOrderResult.Expired,
 			ExchangeAPIOrderResult.Canceled, ExchangeAPIOrderResult.FilledPartiallyAndCancelled,
 		};
 

--- a/src/ExchangeSharpConsole/Options/BuyOption.cs
+++ b/src/ExchangeSharpConsole/Options/BuyOption.cs
@@ -46,7 +46,7 @@ namespace ExchangeSharpConsole.Options
 
 		private async Task WaitForOrder(ExchangeOrderResult order, IExchangeAPI api)
 		{
-			while (order.Result == ExchangeAPIOrderResult.Pending)
+			while (order.Result == ExchangeAPIOrderResult.Open)
 			{
 				Console.Clear();
 				Console.WriteLine(order);

--- a/tests/ExchangeSharpTests/ExchangePoloniexAPITests.cs
+++ b/tests/ExchangeSharpTests/ExchangePoloniexAPITests.cs
@@ -194,7 +194,7 @@ namespace ExchangeSharpTests
             orders[0].OrderId.Should().Be("120466");
             orders[0].IsBuy.Should().BeFalse();
             orders[0].Price.Should().Be(0.025m);
-            orders[0].Result.Should().Be(ExchangeAPIOrderResult.Pending);
+            orders[0].Result.Should().Be(ExchangeAPIOrderResult.Open);
         }
 
         [TestMethod]
@@ -210,7 +210,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45, DateTimeKind.Utc));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
-            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
+            order.Result.Should().Be(ExchangeAPIOrderResult.Open);
         }
 
         [TestMethod]
@@ -227,7 +227,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45, DateTimeKind.Utc));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
-            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
+            order.Result.Should().Be(ExchangeAPIOrderResult.Open);
         }
 
         [TestMethod]
@@ -244,7 +244,7 @@ namespace ExchangeSharpTests
             order.OrderDate.Should().Be(new DateTime(2018, 4, 6, 1, 3, 45, DateTimeKind.Utc));
             order.Fees.Should().Be(0);
             order.FeesCurrency.Should().BeNullOrEmpty();
-            order.Result.Should().Be(ExchangeAPIOrderResult.Pending);
+            order.Result.Should().Be(ExchangeAPIOrderResult.Open);
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR contains the following breaking changes to the ExchangeAPIOrderResult enum:
- `PendingOpen` is an important state that many exchanges have, which is separate from `Open`
- Renamed `Pending` state to `Open`
- Renamed `Error` state to `Rejected`, since this is how most exchanges refer to it
- Added `Expired` state, which is separate from `Rejected`

also contains the following changes
- added stricter checks to FTX` OnGetOrderDetailsAsync()` and `OnPlaceOrderAsync` `isPostOnly`
- improved FTX `ToExchangeAPIOrderResult()`, renamed to `FTXExtensions` to reduce possibility of collision in the future