### PR TITLE
OKEx RateLimit

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
@@ -34,6 +34,11 @@ namespace ExchangeSharp
 		public string BaseUrlV5 { get; set; } = "https://www.okex.com/api/v5";
 		protected override bool IsFuturesAndSwapEnabled { get; } = true;
 
+		private ExchangeOKExAPI()
+		{
+			RateLimit = new RateGate(20, TimeSpan.FromSeconds(2));
+		}
+
 		public override string PeriodSecondsToString(int seconds)
 		{
 			return CryptoUtility.SecondsToPeriodString(seconds, true);


### PR DESCRIPTION
Increased the rate limit to 20req/2sec.
It's not the real limit, but somehow "averaged", because each endpoint has it's own limit.