### PR TITLE
Use a single rate gate per type of api

### DIFF
--- a/examples/ExchangeSharpWinForms/ExchangeSharpWinForms.csproj
+++ b/examples/ExchangeSharpWinForms/ExchangeSharpWinForms.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{571623F9-1652-4669-8E17-A6FAD1426181}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>ExchangeSharpWinForms</AssemblyTitle>
     <Product>ExchangeSharpWinForms</Product>
@@ -21,9 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="MainForm.cs" />
     <Compile Update="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>

--- a/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
+++ b/src/ExchangeSharp.Forms/ExchangeSharp.Forms.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <DefineConstants>HAS_WINDOWS_FORMS</DefineConstants>
         <NeutralLanguage>en</NeutralLanguage>
         <LangVersion>8</LangVersion>
+		<UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,6 +18,10 @@
     <ItemGroup>
         <None Include="../../icon.png" Pack="true" PackagePath="\" />
         <None Include="../../LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Maikebing.System.Windows.Forms.DataVisualization" Version="5.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ExchangeSharp.Forms/Forms/PlotForm.Designer.cs
+++ b/src/ExchangeSharp.Forms/Forms/PlotForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿#if HAS_WINDOWS_FORMS
+#if HAS_WINDOWS_FORMS
 
 namespace ExchangeSharp
 {

--- a/src/ExchangeSharp.Forms/Forms/PlotForm.cs
+++ b/src/ExchangeSharp.Forms/Forms/PlotForm.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT LICENSE
 
 Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com

--- a/src/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/src/ExchangeSharp/API/Common/BaseAPI.cs
@@ -178,14 +178,15 @@ namespace ExchangeSharp
 		public System.Security.SecureString? Passphrase { get; set; }
 
 		private static readonly ConcurrentDictionary<Type, RateGate> rateLimiters = new ConcurrentDictionary<Type, RateGate>();
+		private RateGate rateGate;
 		/// <summary>
 		/// Rate limiter - set this to a new limit if you are seeing your ip get blocked by the API
 		/// One rate limiter is created per type of api
 		/// </summary>
 		public RateGate RateLimit
 		{
-			get => rateLimiters.GetOrAdd(GetType(), v => new RateGate(5, TimeSpan.FromSeconds(15.0d)));
-			set => rateLimiters[GetType()] = value;
+			get => rateGate ??= rateLimiters.GetOrAdd(GetType(), v => new RateGate(5, TimeSpan.FromSeconds(15.0d)));
+			set => rateLimiters[GetType()] = rateGate = value;
 		}
 
 		/// <summary>

--- a/src/ExchangeSharp/API/Common/BaseAPI.cs
+++ b/src/ExchangeSharp/API/Common/BaseAPI.cs
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 #nullable enable
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -176,10 +177,16 @@ namespace ExchangeSharp
 		/// </summary>
 		public System.Security.SecureString? Passphrase { get; set; }
 
+		private static readonly ConcurrentDictionary<Type, RateGate> rateLimiters = new ConcurrentDictionary<Type, RateGate>();
 		/// <summary>
 		/// Rate limiter - set this to a new limit if you are seeing your ip get blocked by the API
+		/// One rate limiter is created per type of api
 		/// </summary>
-		public RateGate RateLimit { get; set; } = new RateGate(5, TimeSpan.FromSeconds(15.0d));
+		public RateGate RateLimit
+		{
+			get => rateLimiters.GetOrAdd(GetType(), v => new RateGate(5, TimeSpan.FromSeconds(15.0d)));
+			set => rateLimiters[GetType()] = value;
+		}
 
 		/// <summary>
 		/// Default request method

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeName.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeName.cs
@@ -47,7 +47,7 @@ namespace ExchangeSharp
 			try
 			{
 				// make sure we have a valid type for the name
-				Type type = Type.GetType($"ExchangeSharp.Exchange{exchangeName}API");
+				Type type = Type.GetType($"ExchangeSharp.Exchange{exchangeName}API", true, true);
 
 				// we had better have a type sub-classing from ExchangeAPI
 				if (type is null || !type.IsSubclassOf(exchangeApiType))

--- a/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
+++ b/src/ExchangeSharpConsole/ExchangeSharpConsole.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>exchange-sharp</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <LangVersion>8</LangVersion>
     <AssemblyVersion>0.9.1</AssemblyVersion>


### PR DESCRIPTION
Some people need multiple exchanges with multiple credentials but need the rate limit to be shared, this solves that.