### PR TITLE
fix OKEx OnGetAmountsAsync

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
@@ -232,6 +232,7 @@ namespace ExchangeSharp
 			var token = await GetBalance();
 			return token[0]["details"]
 				.Select(x => new { Currency = x["ccy"].Value<string>(), TotalBalance = x["cashBal"].Value<decimal>() })
+				.Where(x => !string.IsNullOrEmpty(x.Currency))
 				.ToDictionary(k => k.Currency, v => v.TotalBalance);
 		}
 
@@ -241,6 +242,7 @@ namespace ExchangeSharp
 			return token[0]["details"]
 				.Select(x => new
 					{ Currency = x["ccy"].Value<string>(), AvailableBalance = x["availBal"].Value<decimal>() })
+				.Where(x => !string.IsNullOrEmpty(x.Currency))
 				.ToDictionary(k => k.Currency, v => v.AvailableBalance);
 		}
 
@@ -254,6 +256,7 @@ namespace ExchangeSharp
 					Currency = x["ccy"].Value<string>(),
 					AvailableEquity = x["availEq"].Value<string>() == string.Empty ? 0 : x["availEq"].Value<decimal>()
 				})
+				.Where(x => !string.IsNullOrEmpty(x.Currency))
 				.ToDictionary(k => k.Currency, v => v.AvailableEquity);
 
 			return includeZeroBalances


### PR DESCRIPTION
For some reason Okex returns some small available balances with missing currency names, so we remove those.

`{
        "availBal": "0.0278185",
        "availEq": "",
        "cashBal": "0.0278185",
        "ccy": "",
        "crossLiab": "",
        "disEq": "0",
        "eq": "0.0278185",
        "eqUsd": "0.0000000278568895",
        "frozenBal": "0",
        "interest": "",
        "isoEq": "",
        "isoLiab": "",
        "isoUpl": "",
        "liab": "",
        "maxLoan": "",
        "mgnRatio": "",
        "notionalLever": "",
        "ordFrozen": "0",
        "stgyEq": "0",
        "twap": "0",
        "uTime": "1622841834999",
        "upl": "",
        "uplLiab": ""
      }`