### PR TITLE
fix GetFullOrderBookWebSocketAsync data inconsistency

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/BinanceGroupCommon.cs
@@ -308,7 +308,7 @@ namespace ExchangeSharp.BinanceGroup
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
 		{
 			JToken obj = await MakeJsonRequestAsync<JToken>($"/depth?symbol={marketSymbol}&limit={maxCount}", BaseUrlApi);
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj, sequence: "lastUpdateId", maxCount: maxCount);
+			return obj.ParseOrderBookFromJTokenArrays(sequence: "lastUpdateId");
 		}
 
 		protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)

--- a/src/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bithumb/ExchangeBithumbAPI.cs
@@ -151,7 +151,7 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             var data = await MakeRequestBithumbAsync(marketSymbol, "/public/orderbook/$SYMBOL$");
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(data.Item1, amount: "quantity", sequence: "timestamp", maxCount: maxCount);
+            return data.Item1.ParseOrderBookFromJTokenDictionaries(amount: "quantity", sequence: "timestamp");
         }
 
         protected override async Task<IEnumerable<KeyValuePair<string, ExchangeOrderBook>>> OnGetOrderBooksAsync(int maxCount = 100)

--- a/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bitstamp/ExchangeBitstampAPI.cs
@@ -133,7 +133,7 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             JToken token = await MakeBitstampRequestAsync("/order_book/" + marketSymbol);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, maxCount: maxCount);
+            return token.ParseOrderBookFromJTokenArrays();
         }
 
         protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
@@ -254,7 +254,7 @@ namespace ExchangeSharp
 			// status can be 'Canceled', 'Open' or 'Finished'
 			var statusCode = result.Value<string>("status");
 			var status = GetOrderResultFromStatus(statusCode, anyTransaction);
-			
+
             // empty transaction array means that order is InQueue or Open and AmountFilled == 0
             // return empty order in this case. no any additional info available at this point
             if (!anyTransaction)

--- a/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Bittrex/ExchangeBittrexAPI.cs
@@ -271,7 +271,7 @@ namespace ExchangeSharp
 			}
 
 			JToken token = await MakeJsonRequestAsync<JToken>("/markets/" + marketSymbol + "/orderbook" + "?depth=" + maxCount);
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, "ask", "bid", "rate", "quantity", maxCount: maxCount);
+			return token.ParseOrderBookFromJTokenDictionaries("ask", "bid", "rate", "quantity");
 		}
 
 		/// <summary>Gets the deposit history for a symbol</summary>

--- a/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -586,7 +586,7 @@ namespace ExchangeSharp
 		{
 			string url = "/products/" + marketSymbol.ToUpperInvariant() + "/book?level=2";
 			JToken token = await MakeJsonRequestAsync<JToken>(url);
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, maxCount: maxCount);
+			return token.ParseOrderBookFromJTokenArrays();
 		}
 
 		protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
@@ -661,7 +661,7 @@ namespace ExchangeSharp
 			JObject token = await MakeJsonRequestAsync<JObject>("/fees", null, await GetNoncePayloadAsync(), "GET");
 			/*
 			 * We can chose between maker and taker fee, but currently ExchangeSharp only supports 1 fee rate per symbol.
-			 * Here, we choose taker fee, which are usually higher 
+			 * Here, we choose taker fee, which are usually higher
 			*/
 			decimal makerRate = token["taker_fee_rate"].Value<decimal>(); //percentage between 0 and 1
 

--- a/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Digifinex/ExchangeDigifinexAPI.cs
@@ -211,7 +211,7 @@ namespace ExchangeSharp
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
 		{
 			JToken obj = await MakeJsonRequestAsync<JToken>($"/order_book?symbol={marketSymbol}&limit={maxCount}");
-			var result = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj, sequence: "date", maxCount: maxCount);
+			var result = obj.ParseOrderBookFromJTokenArrays(sequence: "date");
 			result.LastUpdatedUtc = CryptoUtility.UnixTimeStampToDateTimeSeconds(obj["date"].ConvertInvariant<long>());
 			result.MarketSymbol = marketSymbol;
 			return result;

--- a/src/ExchangeSharp/API/Exchanges/FTX/ExchangeFTXAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/FTX/ExchangeFTXAPI.cs
@@ -270,10 +270,10 @@ namespace ExchangeSharp
 				{
 					continue;
 				}
-				
+
 				markets.Add(ParseOrder(token));
 			}
-			
+
 			return markets;
 		}
 
@@ -282,7 +282,7 @@ namespace ExchangeSharp
 		{
 			JToken response = await MakeJsonRequestAsync<JToken>($"/markets/{marketSymbol}/orderbook?depth={maxCount}");
 
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(response, maxCount: maxCount);
+			return response.ParseOrderBookFromJTokenArrays();
 		}
 
 		/// <inheritdoc />
@@ -519,8 +519,8 @@ namespace ExchangeSharp
 				AmountFilled = token["filledSize"].ConvertInvariant<decimal>(),
 				ClientOrderId = token["clientId"].ToStringInvariant(),
 				Result = token["status"].ToStringInvariant().ToExchangeAPIOrderResult(token["size"].ConvertInvariant<decimal>() - token["filledSize"].ConvertInvariant<decimal>()),
-				ResultCode = token["status"].ToStringInvariant()			
-			};				
+				ResultCode = token["status"].ToStringInvariant()
+			};
 		}
 
 		#endregion

--- a/src/ExchangeSharp/API/Exchanges/GateIo/ExchangeGateIoAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/GateIo/ExchangeGateIoAPI.cs
@@ -206,7 +206,7 @@ namespace ExchangeSharp
 				}
 			*/
 
-			var orderBook = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(json, sequence: "current", maxCount: maxCount);
+			var orderBook = json.ParseOrderBookFromJTokenArrays(sequence: "current");
 			orderBook.LastUpdatedUtc = CryptoUtility.UnixTimeStampToDateTimeMilliseconds(json["current"].ConvertInvariant<long>());
 			return orderBook;
 		}

--- a/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Gemini/ExchangeGeminiAPI.cs
@@ -248,7 +248,7 @@ namespace ExchangeSharp
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
 		{
 			JToken obj = await MakeJsonRequestAsync<JToken>("/book/" + marketSymbol + "?limit_bids=" + maxCount + "&limit_asks=" + maxCount);
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(obj, maxCount: maxCount);
+			return obj.ParseOrderBookFromJTokenDictionaries();
 		}
 
 		protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)

--- a/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Hitbtc/ExchangeHitbtcAPI.cs
@@ -186,7 +186,7 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/public/orderbook/" + marketSymbol + "?limit=" + maxCount.ToStringInvariant());
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenDictionaries(token, asks: "ask", bids: "bid", amount: "size", maxCount: maxCount);
+            return token.ParseOrderBookFromJTokenDictionaries(asks: "ask", bids: "bid", amount: "size");
         }
 
         protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)
@@ -195,11 +195,11 @@ namespace ExchangeSharp
 			// TODO: Can't get Hitbtc to return other than the last 50 trades even though their API says it should (by orderid or timestamp). When passing either of these parms, it still returns the last 50
 			// So until there is an update, that's what we'll go with
 			// UPDATE: 2020/01/19 https://api.hitbtc.com/ GET /api/2/public/trades/{symbol} limit default: 100 max value:1000
-			// 
+			//
 			//var maxRequestLimit = 1000; //hard coded for now, should add limit as an argument
-			var maxRequestLimit = (limit == null || limit < 1 || limit > 1000) ? 1000 : (int)limit;  
+			var maxRequestLimit = (limit == null || limit < 1 || limit > 1000) ? 1000 : (int)limit;
             //note that sort must come after limit, else returns default 100 trades, sort default is DESC
-			JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol + "?limit=" + maxRequestLimit + "?sort=DESC"); 
+			JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol + "?limit=" + maxRequestLimit + "?sort=DESC");
 			//JToken obj = await MakeJsonRequestAsync<JToken>("/public/trades/" + marketSymbol);
 			if (obj.HasValues)
             {

--- a/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Huobi/ExchangeHuobiAPI.cs
@@ -346,7 +346,7 @@ namespace ExchangeSharp
                 var ch = token["ch"].ToStringInvariant();
                 var sArray = ch.Split('.');
                 var marketSymbol = sArray[1].ToStringInvariant();
-                ExchangeOrderBook book = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token["tick"], maxCount: maxCount);
+                ExchangeOrderBook book = token["tick"].ParseOrderBookFromJTokenArrays();
                 book.MarketSymbol = marketSymbol;
                 callback(book);
             }, async (_socket) =>
@@ -433,7 +433,7 @@ namespace ExchangeSharp
       [7995, 0.88],
              */
             JToken obj = await MakeJsonRequestAsync<JToken>("/market/depth?symbol=" + marketSymbol + "&type=step0", BaseUrl, null);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj["tick"], sequence: "ts", maxCount: maxCount);
+            return obj["tick"].ParseOrderBookFromJTokenArrays(sequence: "ts");
         }
 
         protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol, int periodSeconds, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)

--- a/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Kraken/ExchangeKrakenAPI.cs
@@ -408,7 +408,7 @@ namespace ExchangeSharp
 		}
 
 		protected internal override async Task<IEnumerable<ExchangeMarket>> OnGetMarketSymbolsMetadataAsync()
-		{ 
+		{
 			var markets = new List<ExchangeMarket>();
 			JToken allPairs = await MakeJsonRequestAsync<JToken>("/0/public/AssetPairs");
 			var res = (from prop in allPairs.Children<JProperty>() select prop).ToArray();
@@ -546,7 +546,7 @@ namespace ExchangeSharp
 		protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
 		{
 			JToken obj = await MakeJsonRequestAsync<JToken>("/0/public/Depth?pair=" + marketSymbol + "&count=" + maxCount);
-			return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(obj[marketSymbol], maxCount: maxCount);
+			return obj[marketSymbol].ParseOrderBookFromJTokenArrays();
 		}
 
 		protected override async Task<IEnumerable<ExchangeTrade>> OnGetRecentTradesAsync(string marketSymbol, int? limit = null)

--- a/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/KuCoin/ExchangeKuCoinAPI.cs
@@ -159,7 +159,7 @@ namespace ExchangeSharp
         protected override async Task<ExchangeOrderBook> OnGetOrderBookAsync(string marketSymbol, int maxCount = 100)
         {
             JToken token = await MakeJsonRequestAsync<JToken>("/market/orderbook/level2_" + maxCount + "?symbol=" + marketSymbol);
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token, asks: "asks", bids: "bids", maxCount: maxCount);
+            return token.ParseOrderBookFromJTokenArrays(asks: "asks", bids: "bids");
         }
 
         protected override async Task<ExchangeTicker> OnGetTickerAsync(string marketSymbol)

--- a/src/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/LBank/ExchangeLBankAPI.cs
@@ -100,7 +100,7 @@ namespace ExchangeSharp
 			maxCount = Math.Min(maxCount, ORDER_BOOK_MAX_SIZE);
 			JToken resp = await this.MakeJsonRequestAsync<JToken>($"/depth.do?symbol={symbol}&size={maxCount}&merge=0");
 			CheckResponseToken(resp);
-			ExchangeOrderBook book = ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(resp, maxCount: maxCount);
+			ExchangeOrderBook book = resp.ParseOrderBookFromJTokenArrays();
 			book.SequenceId = resp["timestamp"].ConvertInvariant<long>();
 			return book;
 		}

--- a/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/ExchangeOKExAPI.cs
@@ -186,7 +186,7 @@ namespace ExchangeSharp
 		{
 			var token = await MakeJsonRequestAsync<JToken>($"/market/books?instId={marketSymbol}&sz={maxCount}",
 				BaseUrlV5);
-			return token[0].ParseOrderBookFromJTokenArrays(maxCount: maxCount);
+			return token[0].ParseOrderBookFromJTokenArrays();
 		}
 
 		protected override async Task<IEnumerable<MarketCandle>> OnGetCandlesAsync(string marketSymbol,
@@ -420,7 +420,7 @@ namespace ExchangeSharp
 					marketSymbols = await AddMarketSymbolsToChannel(_socket, "books-l2-tbt", marketSymbols);
 				}, (_socket, symbol, sArray, token) =>
 				{
-					ExchangeOrderBook book = token.ParseOrderBookFromJTokenArrays(maxCount: maxCount);
+					ExchangeOrderBook book = token.ParseOrderBookFromJTokenArrays();
 					book.MarketSymbol = symbol;
 					callback(book);
 					return Task.CompletedTask;

--- a/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
+++ b/src/ExchangeSharp/API/Exchanges/OKGroup/OKGroupCommon.cs
@@ -299,7 +299,7 @@ namespace ExchangeSharp.OKGroup
         {
             var token = await MakeRequestOkexAsync(marketSymbol, $"/spot/v3/instruments/{marketSymbol}/book", BaseUrlV3);
 
-            return ExchangeAPIExtensions.ParseOrderBookFromJTokenArrays(token.Item1, maxCount: maxCount);
+            return token.Item1.ParseOrderBookFromJTokenArrays();
         }
 
         protected override async Task OnGetHistoricalTradesAsync(Func<IEnumerable<ExchangeTrade>, bool> callback, string marketSymbol, DateTime? startDate = null, DateTime? endDate = null, int? limit = null)


### PR DESCRIPTION
Proposal for removing `maxCount` parameter from `ParseOrderBookFromJTokenArrays` and `ParseOrderBookFromJTokenDictionaries`.
Currently we are trimming the incoming order book data before processing it, which seems wrong and causes order book inconsistency as mentioned in #713 .
Instead I propose moving `maxCount` trimming logic to `GetFullOrderBookWebSocketAsync`, because that's the method responsible for order book data store as well.