### PR TITLE
change ExchangeMarket properties to nullable

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/Coinbase/ExchangeCoinbaseAPI.cs
@@ -210,7 +210,7 @@ namespace ExchangeSharp
 
 		protected override async Task<IEnumerable<string>> OnGetMarketSymbolsAsync()
 		{
-			return (await GetMarketSymbolsMetadataAsync()).Where(market => market.IsActive).Select(market => market.MarketSymbol);
+			return (await GetMarketSymbolsMetadataAsync()).Where(market => market.IsActive ?? true).Select(market => market.MarketSymbol);
 		}
 
 		protected override async Task<IReadOnlyDictionary<string, ExchangeCurrency>> OnGetCurrenciesAsync()

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPI.cs
@@ -245,7 +245,9 @@ namespace ExchangeSharp
 		protected async Task<decimal> ClampOrderPrice(string marketSymbol, decimal outputPrice)
 		{
 			ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
-			return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice, market.MaxPrice, market.PriceStepSize, outputPrice);
+			if (market.MinPrice == null || market.MaxPrice == null || market.PriceStepSize == null)
+				throw new NotImplementedException($"Exchange must return {nameof(market.MinPrice)} and {nameof(market.MaxPrice)} in order for {nameof(ClampOrderPrice)}() to work");
+			else return market == null ? outputPrice : CryptoUtility.ClampDecimal(market.MinPrice.Value, market.MaxPrice.Value, market.PriceStepSize, outputPrice);
 		}
 
 		/// <summary>
@@ -257,7 +259,9 @@ namespace ExchangeSharp
 		protected async Task<decimal> ClampOrderQuantity(string marketSymbol, decimal outputQuantity)
 		{
 			ExchangeMarket? market = await GetExchangeMarketFromCacheAsync(marketSymbol);
-			return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize, market.MaxTradeSize, market.QuantityStepSize, outputQuantity);
+			if (market.MinPrice == null || market.MaxPrice == null || market.PriceStepSize == null)
+				throw new NotImplementedException($"Exchange must return {nameof(market.MinPrice)} and {nameof(market.MaxPrice)} in order for {nameof(ClampOrderQuantity)}() to work");
+			else return market == null ? outputQuantity : CryptoUtility.ClampDecimal(market.MinTradeSize.Value, market.MaxTradeSize.Value, market.QuantityStepSize, outputQuantity);
 		}
 
 		/// <summary>

--- a/src/ExchangeSharp/Model/ExchangeMarket.cs
+++ b/src/ExchangeSharp/Model/ExchangeMarket.cs
@@ -28,7 +28,7 @@ namespace ExchangeSharp
 		public string AltMarketSymbol2 { get; set; }
 
 		/// <summary>A value indicating whether the market is active.</summary>
-		public bool IsActive { get; set; }
+		public bool? IsActive { get; set; }
 
         /// <summary>In a pair like ZRX/BTC, BTC is the quote currency.</summary>
         public string QuoteCurrency { get; set; }
@@ -38,10 +38,10 @@ namespace ExchangeSharp
 
         /// <summary>The minimum size of the trade in the unit of "BaseCurrency". For example, in
         /// DOGE/BTC the MinTradeSize is currently 423.72881356 DOGE</summary>
-        public decimal MinTradeSize { get; set; }
+        public decimal? MinTradeSize { get; set; }
 
         /// <summary>The maximum size of the trade in the unit of "BaseCurrency".</summary>
-        public decimal MaxTradeSize { get; set; } = decimal.MaxValue;
+        public decimal? MaxTradeSize { get; set; }
 
         /// <summary>The minimum size of the trade in the unit of "QuoteCurrency". To determine an order's
         /// trade size in terms of the Quote Currency, you need to calculate: price * quantity
@@ -54,10 +54,10 @@ namespace ExchangeSharp
         public decimal? MaxTradeSizeInQuoteCurrency { get; set; }
 
         /// <summary>The minimum price of the pair.</summary>
-        public decimal MinPrice { get; set; }
+        public decimal? MinPrice { get; set; }
 
         /// <summary>The maximum price of the pair.</summary>
-        public decimal MaxPrice { get; set; } = decimal.MaxValue;
+        public decimal? MaxPrice { get; set; }
 
         /// <summary>Defines the intervals that a price can be increased/decreased by. The following
         /// must be true for price: Price % PriceStepSize == 0 Null if unknown or not applicable.</summary>
@@ -71,7 +71,7 @@ namespace ExchangeSharp
         /// <summary>
         /// Margin trading enabled for this market
         /// </summary>
-        public bool MarginEnabled { get; set; }
+        public bool? MarginEnabled { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
- Not all exchanges provide every property. Instead of returning a value like decimal.MaxValue or 0, null should be returned instead. That way, the user cna decide how to handle it.