### PR TITLE
fix KuCoin trade stream ID parsing

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/KuCoin/Models/KuCoinTrade.cs
+++ b/src/ExchangeSharp/API/Exchanges/KuCoin/Models/KuCoinTrade.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 MIT LICENSE
 
 Copyright 2017 Digital Ruby, LLC - http://www.digitalruby.com
@@ -20,12 +20,12 @@ namespace ExchangeSharp.KuCoin
 {
 	public class KuCoinTrade : ExchangeTrade
 	{
-		public byte[] MakerOrderId { get; set; } // nullable
-		public byte[] TakerOrderId { get; set; } // nullable
+		public string MakerOrderId { get; set; } // nullable
+		public string TakerOrderId { get; set; } // nullable
 		public override string ToString()
 		{
 			return string.Format("{0},{1},{2}", base.ToString(),
-				BitConverter.ToString(MakerOrderId), BitConverter.ToString(TakerOrderId));
+				MakerOrderId, TakerOrderId);
 		}
 	}
 }

--- a/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
+++ b/src/ExchangeSharp/API/Exchanges/_Base/ExchangeAPIExtensions.cs
@@ -604,8 +604,8 @@ namespace ExchangeSharp
 		{
 			var trade = ParseTradeComponents<KuCoinTrade>(token, amountKey, priceKey, typeKey,
 				timestampKey, timestampType, idKey, typeKeyIsBuyValue);
-			trade.MakerOrderId = token["makerOrderId"].ToStringInvariant().StringToByteArray();
-			trade.TakerOrderId = token["takerOrderId"].ToStringInvariant().StringToByteArray();
+			trade.MakerOrderId = token["makerOrderId"].ToStringInvariant();
+			trade.TakerOrderId = token["takerOrderId"].ToStringInvariant();
 			return trade;
 		}
 

--- a/src/ExchangeSharp/Utility/CryptoUtility.cs
+++ b/src/ExchangeSharp/Utility/CryptoUtility.cs
@@ -271,33 +271,6 @@ namespace ExchangeSharp
         }
 
 		/// <summary>
-		/// Converts a hex string to a byte array
-		/// </summary>
-		/// <param name="hex">hex string</param>
-		/// <returns>byte array representation of the same string</returns>
-		public static byte[] StringToByteArray(this string hex)
-		{ // https://stackoverflow.com/questions/321370/how-can-i-convert-a-hex-string-to-a-byte-array
-			return Enumerable.Range(0, hex.Length / 2)
-				.Select(x => Convert
-				.ToByte(hex.Substring(x * 2, 2), 16))
-				.ToArray();
-		}
-
-		public static string ToHexString(this byte[] bytes)
-		{
-			var sb = new StringBuilder();
-
-			// Loop through each byte of the hashed data
-			// and format each one as a hexadecimal string.
-			for (int i = 0; i < bytes.Length; i++)
-			{
-				sb.Append(bytes[i].ToString("x2"));
-			}
-
-			return sb.ToString();
-		}
-
-		/// <summary>
 		/// Covnert a secure string to a non-secure string
 		/// </summary>
 		/// <param name="s">SecureString</param>


### PR DESCRIPTION
- Trade IDs in KuCoin are no longer hexadecimals - they are now strings which can incorporate any letter