### PR TITLE
Set MarketSymbolIsUppercase to true in ExchangeBinanceAPI

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceAPI.cs
@@ -18,6 +18,11 @@ namespace ExchangeSharp
 	{
 		public override string BaseUrl { get; set; } = "https://api.binance.com";
 		public override string BaseUrlWebSocket { get; set; } = "wss://stream.binance.com:9443";
+
+		private ExchangeBinanceAPI()
+		{
+			MarketSymbolIsUppercase = true;
+		}
 	}
 
 	public partial class ExchangeName { public const string Binance = "Binance"; }


### PR DESCRIPTION
Fixes #753.
I set the MarketSymbolIsUppercase in the ExchangeBinanceAPI constructor and not in the BinanceGroupCommon constructor because I haven't tested if this change also applies to other Binance's exchanges.