### PR TITLE
Set MarketSymbolIsUppercase to true for all Binance based exchanges

### DIFF
--- a/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceAPI.cs
+++ b/src/ExchangeSharp/API/Exchanges/BinanceGroup/ExchangeBinanceAPI.cs
@@ -18,11 +18,6 @@ namespace ExchangeSharp
 	{
 		public override string BaseUrl { get; set; } = "https://api.binance.com";
 		public override string BaseUrlWebSocket { get; set; } = "wss://stream.binance.com:9443";
-
-		private ExchangeBinanceAPI()
-		{
-			MarketSymbolIsUppercase = true;
-		}
 	}
 
 	public partial class ExchangeName { public const string Binance = "Binance"; }


### PR DESCRIPTION
- extends #754 by @miguel1117
- also in this PR:
	- limit Trade stream to 400 symbols
	- use SerializerSettings